### PR TITLE
ENH: Add support for setting axis units from CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ dist/
 
 test/data/
 test/data.tar.gz
+
+*__pycache__*
+
+.vs/

--- a/ngff_zarr/__about__.py
+++ b/ngff_zarr/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2022-present Matt McCormick <matt.mccormick@kitware.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/ngff_zarr/to_multiscales.py
+++ b/ngff_zarr/to_multiscales.py
@@ -277,13 +277,15 @@ def to_multiscales(
     for dim in ngff_image.dims:
         unit = None
         if ngff_image.axes_units and dim in ngff_image.axes_units:
-            unit = axes_units[dim]
+            unit = ngff_image.axes_units[dim]
         if dim in {"x", "y", "z"}:
             axis = Axis(name=dim, type="space", unit=unit)
         elif dim == "c":
             axis = Axis(name=dim, type="channel", unit=unit)
         elif dim == "t":
             axis = Axis(name=dim, type="time", unit=unit)
+        else:
+            raise KeyError(f'Dimension identifier is not valid: {dim}')
         axes.append(axis)
 
     datasets = []

--- a/ngff_zarr/zarr_metadata.py
+++ b/ngff_zarr/zarr_metadata.py
@@ -63,6 +63,27 @@ TimeUnits = Union[
 ]
 Units = Union[SpaceUnits, TimeUnits]
 
+supported_dims = ['x','y','z','c','t']
+
+space_units = ['angstrom', 'attometer', 'centimeter', 'decimeter', 'exameter',
+                 'femtometer', 'foot', 'gigameter', 'hectometer', 'inch', 'kilometer',
+                 'megameter', 'meter', 'micrometer', 'mile', 'millimeter', 'nanometer',
+                 'parsec', 'petameter', 'picometer', 'terameter', 'yard', 'yoctometer',
+                 'yottameter', 'zeptometer', 'zettameter']
+
+time_units = ['attosecond', 'centisecond', 'day', 'decisecond', 'exasecond', 'femtosecond',
+              'gigasecond', 'hectosecond', 'hour', 'kilosecond', 'megasecond', 'microsecond',
+              'millisecond', 'minute', 'nanosecond', 'petasecond', 'picosecond', 'second',
+              'terasecond', 'yoctosecond', 'yottasecond', 'zeptosecond', 'zettasecond']
+
+def is_dimension_supported(dim:str) -> bool:
+    '''Helper for string validation'''
+    return dim in supported_dims
+
+def is_unit_supported(unit:str) -> bool:
+    '''Helper for string validation'''
+    return (unit in time_units) or (unit in space_units)
+
 
 @dataclass
 class Axis:


### PR DESCRIPTION
commit c6a655b3d656c02a9a1ded784f1605b56f350f7a (HEAD -> support-units-input, tbirdso/support-units-input)
Author: Tom Birdsong <tom.birdsong@kitware.com>
Date:   Mon May 1 11:17:10 2023 -0400

    BUG: Fix rich input validation printouts to console

    Resolves issue where CLI would crash silently and not print expected
    validation messages to console when bad input parameters were parsed.

commit 6d48c12706cd22c69a8ce723626b6d1a94075942
Author: Tom Birdsong <tom.birdsong@kitware.com>
Date:   Fri Apr 28 17:11:38 2023 -0400

    ENH: Add support for setting axis units from CLI

    Allows setting units in output OME-Zarr file. Includes validation to
    ensure that units match existing allowable type hints.

    Addresses issue where output with "null" units could not be loaded in
    viewer applications such as Neuroglancer.