### PR TITLE
absolute vs. relative scales bug fix in _dim_scale_factors

### DIFF
--- a/ngff_zarr/methods/_dask_image.py
+++ b/ngff_zarr/methods/_dask_image.py
@@ -111,10 +111,12 @@ def _downsample_dask_image(
     ]
     previous_image = ngff_image
     dims = ngff_image.dims
-    previous_dim_factors = {d: 1 for d in dims}
+    previous_absolute_dim_factors = {d: 1 for d in dims}
+    previous_scale_factor = 1
     for scale_factor in scale_factors:
-        dim_factors = _dim_scale_factors(dims, scale_factor, previous_dim_factors)
-        previous_dim_factors = dim_factors
+        dim_factors = _dim_scale_factors(dims, scale_factor, previous_absolute_dim_factors)
+        previous_absolute_dim_factors = {d:v*previous_scale_factor for d, v in dim_factors.items()}
+        previous_scale_factor = scale_factor
         previous_image = _align_chunks(previous_image, default_chunks, dim_factors)
 
         shrink_factors = []


### PR DESCRIPTION
This fixes #40.

Commit history implies you were aware of this issue before, so make sure I didn't misunderstand anything:
https://github.com/thewtex/ngff-zarr/commit/7796b71db9831763c0bb066d6e2b6b79ce34e84b

I renamed `previous_dim_factors` to `previous_absolute_dim_factors`, since we need these numbers to be relative to the full resolution data, not relative to the previous scale level as before. Name change is good since `previous_absolute_dim_factors` is no longer equal to the previous iteration `dim_factors`.

This fixes my test case:
<img width="685" alt="Screen Shot 2023-07-12 at 5 12 19 PM" src="https://github.com/thewtex/ngff-zarr/assets/8507206/58cfe421-b5a3-4cf6-8b12-429006b5ac5a">
