### PR TITLE
ENH: Add imagecodecs as a cli dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ cli = [
     "itk-io>=5.3.0",
     "imageio",
     "tifffile",
+    "imagecodecs",
 ]
 test = [
     "pytest",


### PR DESCRIPTION
This provides most common codecs for the tifffile package.

Suggested by: Davis Vann Bennett <davis.v.bennett@gmail.com>

Addresses #38

@d-v-b please take a look