### PR TITLE
nested separator in to_ngff_zarr, fixed napari display problem

### DIFF
--- a/ngff_zarr/to_ngff_zarr.py
+++ b/ngff_zarr/to_ngff_zarr.py
@@ -181,6 +181,7 @@ def to_ngff_zarr(
                         overwrite=False,
                         compute=True,
                         return_stored=False,
+                        dimension_separator="/",
                         **kwargs,
                     )
         else:
@@ -193,6 +194,7 @@ def to_ngff_zarr(
                 overwrite=False,
                 compute=True,
                 return_stored=False,
+                dimension_separator="/",
                 **kwargs,
             )
 


### PR DESCRIPTION
This fixes https://github.com/thewtex/ngff-zarr/issues/45

I noticed calls to `to_zarr` in the `to_multiscales` function as well, but I think they're just cache for large files and not meant as ome-ngff-zarr outputs so I did not add a dimension separator for them.

You can also specify the dimension separator when you create the array (i.e. `zarr.creation.open_array`) but since you don't always do this explicitly I let the `dask.array.to_zarr` function do it.

Not sure if you want the dimension separator to be a user settable thing instead of hardcoded like this? If it's going to be standard practice for ome-ngff-zarr to use '/' and if some programs won't even support '.' then maybe compulsory like this is better, but your choice.