### PR TITLE
More dimension_separator="/" added, so napari can open big data as well

### DIFF
--- a/ngff_zarr/methods/_dask_image.py
+++ b/ngff_zarr/methods/_dask_image.py
@@ -274,7 +274,7 @@ def _downsample_dask_image(
                             y_splits = _array_split(split, num_y_splits, y_index)
                             z_splits[split_index] = y_splits
                         z_offset = 0
-                        for z_split_index, z_split in enumerate(splits):
+                        for z_split_index, z_split in enumerate(z_splits):
                             y_offset = 0
                             for y_split_index, y_split in enumerate(z_split):
                                 region = [slice(shape[i]) for i in range(ndim)]

--- a/ngff_zarr/to_multiscales.py
+++ b/ngff_zarr/to_multiscales.py
@@ -116,6 +116,7 @@ def _large_image_serialization(image: NgffImage, progress: Optional[Union[NgffPr
             store=cache_store,
             path=path,
             mode='a',
+            dimension_separator="/",
         )
 
         n_slabs = int(np.ceil(data.shape[z_index] / slab_slices))
@@ -138,6 +139,7 @@ def _large_image_serialization(image: NgffImage, progress: Optional[Union[NgffPr
                 overwrite=False,
                 compute=True,
                 return_stored=False,
+                dimension_separator="/",
             )
         data = dask.array.from_zarr(cache_store, component=path)
         if optimized_chunks < data.shape[z_index] and slab_slices < optimized_chunks:
@@ -153,6 +155,7 @@ def _large_image_serialization(image: NgffImage, progress: Optional[Union[NgffPr
                 store=cache_store,
                 path=path,
                 mode='a',
+                dimension_separator="/",
             )
             n_slabs = int(np.ceil(data.shape[z_index] / optimized_chunks))
             for slab_index in range(n_slabs):
@@ -172,6 +175,7 @@ def _large_image_serialization(image: NgffImage, progress: Optional[Union[NgffPr
                     overwrite=False,
                     compute=True,
                     return_stored=False,
+                    dimension_separator="/",
                 )
             data = dask.array.from_zarr(cache_store, component=path)
         else:
@@ -189,6 +193,7 @@ def _large_image_serialization(image: NgffImage, progress: Optional[Union[NgffPr
             overwrite=False,
             compute=True,
             return_stored=False,
+            dimension_separator="/",
         )
         data = dask.array.from_zarr(cache_store, component=path)
 

--- a/ngff_zarr/to_ngff_zarr.py
+++ b/ngff_zarr/to_ngff_zarr.py
@@ -181,6 +181,7 @@ def to_ngff_zarr(
                         overwrite=False,
                         compute=True,
                         return_stored=False,
+                        dimension_separator="/",
                         **kwargs,
                     )
         else:
@@ -193,6 +194,7 @@ def to_ngff_zarr(
                 overwrite=False,
                 compute=True,
                 return_stored=False,
+                dimension_separator="/",
                 **kwargs,
             )
 

--- a/ngff_zarr/to_ngff_zarr.py
+++ b/ngff_zarr/to_ngff_zarr.py
@@ -97,6 +97,7 @@ def to_ngff_zarr(
                 store=store,
                 path=path,
                 mode='a',
+                dimension_separator="/",
             )
 
             shape = image.data.shape


### PR DESCRIPTION
This fixes the second comment in: https://github.com/thewtex/ngff-zarr/issues/45