### PR TITLE
BUG: Support reading and writing an OME-Zarr created by omero-zarr

### DIFF
--- a/test/_data.py
+++ b/test/_data.py
@@ -7,8 +7,8 @@ import pytest
 from ngff_zarr import itk_image_to_ngff_image, to_ngff_zarr
 from zarr.storage import DirectoryStore, MemoryStore
 
-test_data_ipfs_cid = "bafybeignqkbaz2stjnz2laplw5ah37punzjspv6pzqlwfcjp7ibm43o5fu"
-test_data_sha256 = "ae27aa76ca706c9c6ed69da8bc065f47ea118691eb7a6a329bdb68289fb38ba1"
+test_data_ipfs_cid = "bafybeidycdocaf7muhwt73m6vxfeaxfidbq7prvnhgn4tzrpxmpui5rila"
+test_data_sha256 = "675a2cb532cb6fbabfd2b1e19f26f05b059ac51f0b611eed1164d8dd1a22e4cb"
 
 test_dir = Path(__file__).resolve().parent
 extract_dir = "data"
@@ -18,12 +18,11 @@ test_data_dir = test_dir / extract_dir
 @pytest.fixture(scope="package")
 def input_images():
     untar = pooch.Untar(extract_dir=extract_dir)
-    test_data = pooch.retrieve(
+    pooch.retrieve(
         fname="data.tar.gz",
         path=test_dir,
         url=f"https://{test_data_ipfs_cid}.ipfs.w3s.link",
         known_hash=f"sha256:{test_data_sha256}",
-        # retry_if_failed=5,
         processor=untar,
     )
     result = {}

--- a/test/test_from_ngff_zarr.py
+++ b/test/test_from_ngff_zarr.py
@@ -1,13 +1,14 @@
 from dask_image import imread
 from ngff_zarr import (
     Methods,
+    from_ngff_zarr,
     to_multiscales,
     to_ngff_image,
     to_ngff_zarr,
 )
 from zarr.storage import MemoryStore
 
-from ._data import verify_against_baseline
+from ._data import test_data_dir, verify_against_baseline
 
 
 def test_gaussian_isotropic_scale_factors(input_images):
@@ -41,3 +42,11 @@ def test_from_ngff_zarr(input_images):
 
     # multiscales_back = from_ngff_zarr(test_store)
     # verify_against_baseline(dataset_name, baseline_name, multiscales_back)
+
+
+def test_omero_zarr_from_ngff_zarr_to_ngff_zarr(input_images):  # noqa: ARG001
+    dataset_name = "13457537"
+    store_path = test_data_dir / "input" / f"{dataset_name}.zarr"
+    multiscales = from_ngff_zarr(store_path)
+    test_store = MemoryStore(dimension_separator="/")
+    to_ngff_zarr(test_store, multiscales)


### PR DESCRIPTION
Paths are '0', '1', etc. -- not the minimum two component paths required to create a NetCDF compatible OME-Zarr. Detect and avoid.

We do not have scale_factors if we did not generate the multiscales -- do not run logic for generating multiscales when scale_factors is not present.