### PR TITLE
ENH: Bump itkwasm-downsample to support more label image types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 ]
 dependencies = [
   "dask[array]",
-  "itkwasm >= 1.0b168",
-  "itkwasm-downsample >= 1.1.0",
+  "itkwasm >= 1.0b171",
+  "itkwasm-downsample >= 1.2.0",
   "numpy",
   "platformdirs",
   "psutil; sys_platform != \"emscripten\"",


### PR DESCRIPTION
Adds:

  https://github.com/InsightSoftwareConsortium/itk-wasm/pull/1117/commits/ffb6e2cf6c8b5c3f064c16d5d51636cd85a59eae
