### PR TITLE
Fix usages of Sets

### DIFF
--- a/ngff_zarr/methods/_itk.py
+++ b/ngff_zarr/methods/_itk.py
@@ -223,7 +223,7 @@ def _downsample_itk_gaussian(
         previous_dim_factors = dim_factors
         previous_image = _align_chunks(previous_image, default_chunks, dim_factors)
 
-        shrink_factors = [dim_factors[sf] for sf in _spatial_dims if sf in dim_factors]
+        shrink_factors = [factor for dim, factor in dim_factors.items() if dim in _spatial_dims]
 
         # Compute metadata for region splitting
 

--- a/ngff_zarr/methods/_itkwasm.py
+++ b/ngff_zarr/methods/_itkwasm.py
@@ -165,7 +165,7 @@ def _downsample_itkwasm(
         previous_dim_factors = dim_factors
         previous_image = _align_chunks(previous_image, default_chunks, dim_factors)
 
-        shrink_factors = [dim_factors[sf] for sf in _spatial_dims if sf in dim_factors]
+        shrink_factors = [factor for dim, factor in dim_factors.items() if dim in _spatial_dims]
 
         # Compute metadata for region splitting
 

--- a/ngff_zarr/methods/_support.py
+++ b/ngff_zarr/methods/_support.py
@@ -11,7 +11,7 @@ def _dim_scale_factors(dims, scale_factor, previous_dim_factors):
     if isinstance(scale_factor, int):
         result_scale_factors = {
             dim: int(scale_factor / previous_dim_factors[dim])
-            for dim in _spatial_dims.intersection(dims)
+            for dim in dims if dim in _spatial_dims
         }
     else:
         result_scale_factors = {

--- a/test/test_ngff_image_scale_factors.py
+++ b/test/test_ngff_image_scale_factors.py
@@ -1,25 +1,39 @@
+import pytest
 import numpy as np
 from ngff_zarr.to_multiscales import _ngff_image_scale_factors
 from ngff_zarr.to_ngff_image import to_ngff_image
 
 rng = np.random.default_rng(12345)
 
-
-def test_scale_factors_520_520():
-    array = rng.random(size=(520, 520), dtype=np.float32) * 100.0
+@pytest.mark.parametrize("shape, expected_factors", [
+    ((30, 30), []),
+    ((520, 520), [{'x': 2, 'y': 2}, {'x': 4, 'y': 4}, {'x': 8, 'y': 8}]),
+    ((10, 530, 530), [{'x': 2, 'y': 2, 'z': 1}, {'x': 4, 'y': 4, 'z': 1}, {'x': 8, 'y': 8, 'z': 1}]),
+])
+def test_scale_factors(shape, expected_factors):
+    array = rng.random(size=shape, dtype=np.float32) * 100.0
     image = to_ngff_image(array)
-    image.data = image.data.rechunk(64)
-    scale_factors = _ngff_image_scale_factors(image, 64, {"x": 64, "y": 64})
-    assert len(scale_factors) == 3
-    assert scale_factors[2]["x"] == 8
-    assert scale_factors[2]["y"] == 8
+    chunk_length = 64
+    image.data = image.data.rechunk(chunk_length)
+    chunk_dims = {dim: chunk_length for dim in image.dims}
+    scale_factors = _ngff_image_scale_factors(image, chunk_length, chunk_dims)
+    assert scale_factors == expected_factors
 
-
-def test_scale_factors_520_530():
-    array = rng.random(size=(520, 530), dtype=np.float32) * 100.0
-    image = to_ngff_image(array)
-    image.data = image.data.rechunk(64)
-    scale_factors = _ngff_image_scale_factors(image, 64, {"x": 64, "y": 64})
-    assert len(scale_factors) == 3
-    assert scale_factors[2]["x"] == 8
-    assert scale_factors[2]["y"] == 8
+@pytest.mark.parametrize("shape, chunks, expected_factors", [
+    (
+        (1, 30, 1024, 1024),
+        (1, 30, 65, 65),
+        [{'x': 2, 'y': 2, 'z': 1}, {'x': 4, 'y': 4, 'z': 1}, {'x': 8, 'y': 8, 'z': 1}]
+    ),
+    (
+        (1, 125, 1024, 1024),
+        (1, 50, 51, 50),
+        [{'x': 2, 'y': 2, 'z': 1}, {'x': 4, 'y': 4, 'z': 1}, {'x': 8, 'y': 8, 'z': 1}, {'x': 16, 'y': 16, 'z': 2}]
+    ),
+])
+def test_scale_factors_with_chunk_shape(shape, chunks, expected_factors):
+    array = rng.random(size=shape, dtype=np.float32) * 100.0
+    image = to_ngff_image(array, dims=['t', 'z', 'y', 'x'])
+    out_chunks = {d: chunks[i] for i, d in enumerate(image.dims)}
+    scale_factors = _ngff_image_scale_factors(image, max(chunks), out_chunks)
+    assert scale_factors == expected_factors


### PR DESCRIPTION
I tried running `to_multiscales` with `scale_factors=113` and experienced my script hanging.

While debugging I pinpointed that the `while` in `_ngff_image_scale_factors` is infinite looping.

This was because `while (sizes_array > double_chunks).any()` was comparing `[30 113 113]` to `[226 60 226]`. Or in some runs, `[226 226 60]` or `[60 226 226]`. In other words, `double_chunks` was randomly ordered.

I traced this back to the set `_spatial_dims = {"x", "y", "z"}` being used in comprehension expressions in a way that pulls values out of the set. Sets in Python are [not ordered](https://stackoverflow.com/questions/26420945/what-is-the-order-of-elements-in-a-python-set), and it looks like in practice I really was getting the values out of the set in a random order.

This PR fixes all usages of `_spatial_dims` that would create randomly ordered lists, but really this helper variable just shouldn't be a set if the rest of the code wants to have a helper in xyz order.

I added an additional early exit condition to the loop; this shouldn't really be necessary anymore with the other fixes, but it is a sane exit condition in every case.

I decided to contribute the fix and found that the corresponding test's asserts weren't in sync what the function currently produces 😅  I don't know what's intended, but I set the expected values to what it currently produces since it doesn't necessarily look wrong, at least for the already existing test cases. I added another test where the chunks aren't just regular polyhedra.