### PR TITLE
BUG: Fix CI macos-14 matrix exclusion logic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,30 +9,41 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-22.04, windows-2022, macos-12, macos-14]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        if: ${{ matrix.os != 'macos-14' || matrix.package != '3.8' }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        if: ${{ matrix.os != 'macos-14' || matrix.package != '3.8' }}
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test,dask-image,itk,cli]"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test,dask-image,itk]"
+          python -m pip install itkwasm-image-io
+
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[test,dask-image,itk,cli]"
 
       - name: Test with pytest
-        if: ${{ matrix.os != 'macos-14' || matrix.package != '3.8' }}
+        if: ${{ matrix.os != 'ubuntu-22.04' && matrix.os != 'macos-14' }}
         run: |
           pytest --junitxml=junit/test-results.xml
 
       - name: Publish Test Report
-        if: ${{ matrix.os != 'macos-14' || matrix.package != '3.8' }}
+        if:
+          ${{ matrix.os != 'ubuntu-22.04' && (matrix.os != 'macos-14' ||
+          matrix.python-version != '3.8') }}
         uses: mikepenz/action-junit-report@v2
         with:
           report_paths: "junit/test-results*.xml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 5
+      matrix:
+        os: [ubuntu-22.04, windows-2022, macos-12, macos-14]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        if: ${{ matrix.os != 'macos-14' || matrix.package != '3.8' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        if: ${{ matrix.os != 'macos-14' || matrix.package != '3.8' }}
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test,dask-image,itk,cli]"
+
+      - name: Test with pytest
+        if: ${{ matrix.os != 'macos-14' || matrix.package != '3.8' }}
+        run: |
+          pytest --junitxml=junit/test-results.xml
+
+      - name: Publish Test Report
+        if: ${{ matrix.os != 'macos-14' || matrix.package != '3.8' }}
+        uses: mikepenz/action-junit-report@v2
+        with:
+          report_paths: "junit/test-results*.xml"

--- a/pixi.lock
+++ b/pixi.lock
@@ -3862,7 +3862,7 @@ packages:
   name: ngff-zarr
   version: 0.8.7
   path: .
-  sha256: c9184a12e04810ed96ff44a75e2435bd106170f274894c46ae13238be107c370
+  sha256: 890f55deabcd7138be81c735c9bc8bf8226fd8db8b75f1ce88a7318423e1fbca
   requires_dist:
   - dask[array]
   - itkwasm-downsample>=1.2.0
@@ -3896,7 +3896,7 @@ packages:
   - jsonschema ; extra == 'test'
   - pooch ; extra == 'test'
   - pytest>=6 ; extra == 'test'
-  requires_python: '>=3.8'
+  requires_python: '>=3.9'
   editable: true
 - kind: conda
   name: nodeenv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 name = "ngff-zarr"
 description = 'A lean and kind Open Microscopy Environment (OME) Next Generation File Format (NGFF) Zarr implementation.'
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "MIT"
 keywords = []
 authors = [{ name = "Matt McCormick", email = "matt.mccormick@kitware.com" }]
@@ -20,7 +20,6 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
macos-14 for matrix.os instead of mac-14. And we want to run always for
not macos-14 and for macos-15 when python is 3.9 or greater.
