### PR TITLE
BUG: Add ngff_zarr.zarr_metadata backwards compatibility module

### DIFF
--- a/ngff_zarr/zarr_metadata.py
+++ b/ngff_zarr/zarr_metadata.py
@@ -1,0 +1,2 @@
+# The version should match the default version in to_ngff_zarr
+from .v04.zarr_metadata import *  # noqa: F403


### PR DESCRIPTION
Re-provides the default OME-Zarr version zarr metadata at the same
module location for backwards compatibility, issue #122.
