### PR TITLE
Add line breaks to long signatures in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,8 @@ autodoc2_packages = [
 ]
 autodoc2_render_plugin = "myst"
 
+maximum_signature_line_length = 80
+
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "itkwasm": ("https://itkwasm.readthedocs.io/en/latest/", None),


### PR DESCRIPTION
I'm hoping that this configuration value ([see sphinx docs](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-maximum_signature_line_length)) will improve reability of long signatures like [`to_multiscales`](https://ngff-zarr.readthedocs.io/en/latest/apidocs/ngff_zarr/ngff_zarr.to_multiscales.html#ngff_zarr.to_multiscales.to_multiscales).