### PR TITLE
Add channel labels

### DIFF
--- a/ngff_zarr/from_ngff_zarr.py
+++ b/ngff_zarr/from_ngff_zarr.py
@@ -165,6 +165,7 @@ def from_ngff_zarr(
             channels=[
                 OmeroChannel(
                     color=channel["color"],
+                    label=channel.get("label", None),
                     window=OmeroWindow(
                         min=channel["window"]["min"],
                         max=channel["window"]["max"],

--- a/ngff_zarr/v04/zarr_metadata.py
+++ b/ngff_zarr/v04/zarr_metadata.py
@@ -178,6 +178,7 @@ class OmeroWindow:
 class OmeroChannel:
     color: str
     window: OmeroWindow
+    label: Optional[str] = None
 
     def validate_color(self):
         if not re.fullmatch(r"[0-9A-Fa-f]{6}", self.color):

--- a/test/test_omero.py
+++ b/test/test_omero.py
@@ -29,6 +29,7 @@ def test_read_omero(input_images):  # noqa: ARG001
     assert omero.channels[0].window.max == 65535.0
     assert omero.channels[0].window.start == 0.0
     assert omero.channels[0].window.end == 1200.0
+    assert omero.channels[0].label == "cy 1"
 
     # Channel 1
     assert omero.channels[1].color == "FFFFFF"
@@ -36,6 +37,7 @@ def test_read_omero(input_images):  # noqa: ARG001
     assert omero.channels[1].window.max == 65535.0
     assert omero.channels[1].window.start == 0.0
     assert omero.channels[1].window.end == 1200.0
+    assert omero.channels[1].label == "cy 2"
 
     # Channel 2
     assert omero.channels[2].color == "FFFFFF"
@@ -43,6 +45,7 @@ def test_read_omero(input_images):  # noqa: ARG001
     assert omero.channels[2].window.max == 65535.0
     assert omero.channels[2].window.start == 0.0
     assert omero.channels[2].window.end == 1200.0
+    assert omero.channels[2].label == "cy 3"
 
     # Channel 3
     assert omero.channels[3].color == "FFFFFF"
@@ -50,6 +53,7 @@ def test_read_omero(input_images):  # noqa: ARG001
     assert omero.channels[3].window.max == 65535.0
     assert omero.channels[3].window.start == 0.0
     assert omero.channels[3].window.end == 1200.0
+    assert omero.channels[3].label == "cy 4"
 
     # Channel 4
     assert omero.channels[4].color == "0000FF"
@@ -57,6 +61,7 @@ def test_read_omero(input_images):  # noqa: ARG001
     assert omero.channels[4].window.max == 65535.0
     assert omero.channels[4].window.start == 0.0
     assert omero.channels[4].window.end == 5000.0
+    assert omero.channels[4].label == "DAPI"
 
     # Channel 5
     assert omero.channels[5].color == "FF0000"
@@ -64,6 +69,7 @@ def test_read_omero(input_images):  # noqa: ARG001
     assert omero.channels[5].window.max == 65535.0
     assert omero.channels[5].window.start == 0.0
     assert omero.channels[5].window.end == 100.0
+    assert omero.channels[5].label == "Hyb probe"
 
 
 def test_write_omero():
@@ -76,10 +82,12 @@ def test_write_omero():
             OmeroChannel(
                 color="008000",
                 window=OmeroWindow(min=0.0, max=255.0, start=10.0, end=150.0),
+                label="Phalloidin",
             ),
             OmeroChannel(
                 color="0000FF",
                 window=OmeroWindow(min=0.0, max=255.0, start=30.0, end=200.0),
+                label="",
             ),
         ]
     )
@@ -97,9 +105,11 @@ def test_write_omero():
     assert read_omero.channels[0].color == "008000"
     assert read_omero.channels[0].window.start == 10.0
     assert read_omero.channels[0].window.end == 150.0
+    assert read_omero.channels[0].label == "Phalloidin"
     assert read_omero.channels[1].color == "0000FF"
     assert read_omero.channels[1].window.start == 30.0
     assert read_omero.channels[1].window.end == 200.0
+    assert read_omero.channels[1].label == ""
 
 
 def test_validate_color():


### PR DESCRIPTION
This pull request introduces a new optional `label` attribute to the `OmeroChannel` dataclass in line with the NGFF [0.4](https://ngff.openmicroscopy.org/0.4/index.html#omero-md) and [0.5](https://ngff.openmicroscopy.org/0.5/index.html#omero-md) specifications.

Updates related functions and tests to accommodate this change. The most important changes include modifications to the `OmeroChannel` class, the `from_ngff_zarr` function, and the `test_omero.py` test cases.

The OME-Zarr spec already supports the "label" string of a channel. This feature is useful because it makes it easy to include channel labels while writing `multiscales` data.