### PR TITLE
COMP: Switch test data ipfs gateway to ipfs.io

### DIFF
--- a/test/_data.py
+++ b/test/_data.py
@@ -32,7 +32,8 @@ def input_images():
         fname="data.tar.gz",
         path=test_dir,
         # url=f"https://itk.mypinata.cloud/ipfs/{test_data_ipfs_cid}/data.tar.gz",
-        url=f"https://{test_data_ipfs_cid}.ipfs.w3s.link/ipfs/{test_data_ipfs_cid}/data.tar.gz",
+        # url=f"https://{test_data_ipfs_cid}.ipfs.w3s.link/ipfs/{test_data_ipfs_cid}/data.tar.gz",
+        url=f"https://ipfs.io/ipfs/{test_data_ipfs_cid}/data.tar.gz",
         known_hash=f"sha256:{test_data_sha256}",
         processor=untar,
     )


### PR DESCRIPTION
For: urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='bafybeib2s7ls6yscm2uqxby5vbhbfsyxn3ev7soewi3hji4uiki7v6cbiy.ipfs.w3s.link', port=443): Read timed out.
