### PR TITLE
BUG: Use dimension_separator == / with OME-Zarr 0.4, zarr-python 3

### DIFF
--- a/ngff_zarr/to_ngff_zarr.py
+++ b/ngff_zarr/to_ngff_zarr.py
@@ -248,6 +248,9 @@ def to_ngff_zarr(
     metadata_dict["@type"] = "ngff:Image"
     zarr_format = 2 if version == "0.4" else 3
     format_kwargs = {"zarr_format": zarr_format} if zarr_version_major >= 3 else {}
+    _zarr_kwargs = zarr_kwargs.copy()
+    if zarr_format == 2 and zarr_version_major >= 3:
+        _zarr_kwargs["dimension_separator"] = "/"
     if version == "0.4":
         root = zarr.open_group(
             store,
@@ -354,7 +357,7 @@ def to_ngff_zarr(
                 path=path,
                 mode="a",
                 **sharding_kwargs,
-                **zarr_kwargs,
+                **_zarr_kwargs,
                 **dimension_names_kwargs,
                 **format_kwargs,
             )
@@ -515,7 +518,7 @@ def to_ngff_zarr(
                             compute=True,
                             return_stored=False,
                             **sharding_kwargs,
-                            **zarr_kwargs,
+                            **_zarr_kwargs,
                             **format_kwargs,
                             **dimension_names_kwargs,
                             **kwargs,
@@ -559,7 +562,7 @@ def to_ngff_zarr(
                     compute=True,
                     return_stored=False,
                     **sharding_kwargs,
-                    **zarr_kwargs,
+                    **_zarr_kwargs,
                     **format_kwargs,
                     **dimension_names_kwargs,
                     **kwargs,

--- a/test/_data.py
+++ b/test/_data.py
@@ -31,9 +31,8 @@ def input_images():
     pooch.retrieve(
         fname="data.tar.gz",
         path=test_dir,
-        # url=f"https://itk.mypinata.cloud/ipfs/{test_data_ipfs_cid}/data.tar.gz",
+        url=f"https://itk.mypinata.cloud/ipfs/{test_data_ipfs_cid}/data.tar.gz",
         # url=f"https://{test_data_ipfs_cid}.ipfs.w3s.link/ipfs/{test_data_ipfs_cid}/data.tar.gz",
-        url=f"https://ipfs.io/ipfs/{test_data_ipfs_cid}/data.tar.gz",
         known_hash=f"sha256:{test_data_sha256}",
         processor=untar,
     )


### PR DESCRIPTION
Zarr-Python 3 will use a dimension separator of / by default with
zarr_format = 3, which is used with OME-Zarr 0.5. However, we do need to
specify the dimension_separator explicity with Zarr-Python 3 and
OME-Zarr 0.4 when zarr_format 2 is used.
