### PR TITLE
Implement compression for OME-Zarr 0.5

### DIFF
--- a/ngff_zarr/to_ngff_zarr.py
+++ b/ngff_zarr/to_ngff_zarr.py
@@ -384,34 +384,36 @@ def _write_array_direct(
     arr = _prep_for_to_zarr(store, arr)
 
     if region is not None and zarr_array is not None:
-        dask.array.to_zarr(
-            arr,
-            zarr_array,
-            region=region,
-            component=path,
-            overwrite=False,
-            compute=True,
-            return_stored=False,
-            **sharding_kwargs,
-            **zarr_kwargs,
-            **format_kwargs,
-            **dimension_names_kwargs,
-            **kwargs,
-        )
+        # array = zarr.create_array(
+        #     store=zarr_array.store,
+        #     name=path,
+        #     shape=arr.shape,
+        #     dtype=arr.dtype,
+        #     **sharding_kwargs,
+        #     **zarr_kwargs,
+        #     **format_kwargs,
+        #     **dimension_names_kwargs,
+        #     **kwargs,
+        # )
+        # array[region] = arr.compute()
+        pass
     else:
-        dask.array.to_zarr(
-            arr,
-            store,
-            component=path,
-            overwrite=False,
-            compute=True,
-            return_stored=False,
-            **sharding_kwargs,
+
+        print(sharding_kwargs)
+
+        array = zarr.create_array(
+            store=store,
+            name=path,
+            shape=arr.shape,
+            dtype=arr.dtype,
+            # **sharding_kwargs,
             **zarr_kwargs,
             **format_kwargs,
             **dimension_names_kwargs,
             **kwargs,
         )
+        
+        array[:] = arr.compute()
 
 
 def _handle_large_array_writing(

--- a/test/test_to_ngff_zarr_compression.py
+++ b/test/test_to_ngff_zarr_compression.py
@@ -1,0 +1,79 @@
+import json
+from packaging import version
+import tempfile
+
+import pytest
+
+import zarr.storage
+from zarr.storage import MemoryStore
+import zarr
+
+from dask_image import imread
+
+from ngff_zarr import Methods, to_multiscales, to_ngff_zarr, config, to_ngff_image
+
+# from ._data import verify_against_baseline
+
+zarr_version = version.parse(zarr.__version__)
+
+# Skip tests if zarr version is less than 3.0.0b1
+pytestmark = pytest.mark.skipif(
+    zarr_version < version.parse("3.0.0b1"), reason="zarr version < 3.0.0b1"
+)
+
+
+def test_zarr_v3_compression(input_images):
+    dataset_name = "cthead1"
+    image = input_images[dataset_name]
+    baseline_name = "2_4/RFC3_GAUSSIAN.zarr"
+    chunks = (64, 64)
+    multiscales = to_multiscales(
+        image, [2, 4], chunks=chunks, method=Methods.ITKWASM_GAUSSIAN
+    )
+    store = zarr.storage.MemoryStore()
+
+
+    compressors = zarr.codecs.BloscCodec(cname="zlib", clevel=5, shuffle=zarr.codecs.BloscShuffle.shuffle)
+
+    # chunks_per_shard = 2
+    # Test this with sharding also
+
+    version = "0.5"
+    with tempfile.TemporaryDirectory() as tmpdir:
+
+        to_ngff_zarr(
+            tmpdir, multiscales, version=version, compressors=compressors
+        )
+
+        with open(tmpdir + "/zarr.json") as f:
+            zarr_json = json.load(f)
+        assert zarr_json["zarr_format"] == 3
+        metadata = zarr_json["consolidated_metadata"]["metadata"]
+
+        scale0 = metadata["scale0/image"]
+
+        assert scale0['codecs'][1]['name'] == 'blosc'
+        assert scale0['codecs'][1]['configuration']['cname'] == 'zlib'
+        assert scale0['codecs'][1]['configuration']['clevel'] == 5
+        assert scale0['codecs'][1]['configuration']['shuffle'] == 'shuffle'
+
+        scale1 = metadata["scale1/image"]
+
+        assert scale1['codecs'][1]['name'] == 'blosc'
+        assert scale1['codecs'][1]['configuration']['cname'] == 'zlib'
+        assert scale1['codecs'][1]['configuration']['clevel'] == 5
+        assert scale1['codecs'][1]['configuration']['shuffle'] == 'shuffle'
+
+        scale2 = metadata["scale2/image"]
+
+        assert scale2['codecs'][1]['name'] == 'blosc'
+        assert scale2['codecs'][1]['configuration']['cname'] == 'zlib'
+        assert scale2['codecs'][1]['configuration']['clevel'] == 5
+        assert scale2['codecs'][1]['configuration']['shuffle'] == 'shuffle'
+
+
+    # Save to a persistent location
+    persistent_path = "/mnt/c/scratch/ngff-zarr-test/test.zarr"
+    to_ngff_zarr(
+        persistent_path, multiscales, version=version, compressors=compressors
+    )

--- a/test/test_to_ngff_zarr_compression.py
+++ b/test/test_to_ngff_zarr_compression.py
@@ -70,10 +70,3 @@ def test_zarr_v3_compression(input_images):
         assert scale2['codecs'][1]['configuration']['cname'] == 'zlib'
         assert scale2['codecs'][1]['configuration']['clevel'] == 5
         assert scale2['codecs'][1]['configuration']['shuffle'] == 'shuffle'
-
-
-    # Save to a persistent location
-    persistent_path = "/mnt/c/scratch/ngff-zarr-test/test.zarr"
-    to_ngff_zarr(
-        persistent_path, multiscales, version=version, compressors=compressors
-    )


### PR DESCRIPTION
This PR closes #159 

This will patch the behavior of `nz.to_ngff_zarr()` to make it possible to do:
```
compressors = zarr.codecs.BloscCodec(cname="zstd", clevel=5, shuffle='shuffle')

nz.to_ngff_zarr(
    store="test-compression-05.zarr",
    multiscales=ms,
    version="0.5",
    compressors=compressors,
)
```