### PR TITLE
fix(mcp): remove memory_target option

### DIFF
--- a/mcp/ngff_zarr_mcp/models.py
+++ b/mcp/ngff_zarr_mcp/models.py
@@ -61,7 +61,6 @@ class ConversionOptions(BaseModel):
     use_tensorstore: bool = Field(False, description="Use TensorStore for I/O")
 
     # Performance options
-    memory_target: Optional[str] = Field(None, description="Memory limit (e.g., 4GB)")
     use_local_cluster: bool = Field(
         False, description="Use Dask LocalCluster for large datasets"
     )

--- a/mcp/ngff_zarr_mcp/server.py
+++ b/mcp/ngff_zarr_mcp/server.py
@@ -45,7 +45,6 @@ async def convert_images_to_ome_zarr(
     compression_codec: Optional[str] = None,
     compression_level: Optional[int] = None,
     use_tensorstore: bool = False,
-    memory_target: Optional[str] = None,
     use_local_cluster: bool = False,
     cache_dir: Optional[str] = None,
     # New RFC 4 and storage options
@@ -73,7 +72,6 @@ async def convert_images_to_ome_zarr(
         compression_codec: Compression codec
         compression_level: Compression level
         use_tensorstore: Use TensorStore for I/O
-        memory_target: Memory limit (e.g., "4GB")
         use_local_cluster: Use Dask LocalCluster for large datasets
         cache_dir: Directory for caching
         anatomical_orientation: Anatomical orientation preset (LPS, RAS)
@@ -112,7 +110,6 @@ async def convert_images_to_ome_zarr(
         compression_codec=compression_codec,
         compression_level=compression_level,
         use_tensorstore=use_tensorstore,
-        memory_target=memory_target,
         use_local_cluster=use_local_cluster,
         cache_dir=cache_dir,
         anatomical_orientation=anatomical_orientation,

--- a/mcp/ngff_zarr_mcp/tools.py
+++ b/mcp/ngff_zarr_mcp/tools.py
@@ -12,7 +12,6 @@ from ngff_zarr import (  # type: ignore[import-untyped]
     to_ngff_zarr,
     from_ngff_zarr,
     Methods,
-    config,
 )
 
 # Import validation function if available
@@ -60,7 +59,6 @@ async def convert_to_ome_zarr(
 
         # Setup Dask if needed
         client = setup_dask_config(
-            memory_target=options.memory_target,
             use_local_cluster=options.use_local_cluster,
             cache_dir=options.cache_dir,
         )
@@ -158,7 +156,7 @@ async def convert_to_ome_zarr(
                     raise ValueError("No valid input image found")
 
                 # Setup caching for large datasets
-                cache = ngff_image.data.nbytes > config.memory_target
+                cache = False  # Let the system handle caching automatically
 
                 # Always use to_multiscales to create proper Multiscales object
                 # If scale_factors is None, create single-scale multiscales

--- a/mcp/ngff_zarr_mcp/utils.py
+++ b/mcp/ngff_zarr_mcp/utils.py
@@ -163,6 +163,7 @@ def analyze_zarr_store(store_path: str) -> StoreInfo:
         version = "0.4"  # Default
         try:
             import zarr as zarr_module  # Use a different name to avoid conflicts
+
             root = zarr_module.open(store, mode="r")
 
             # Check for v0.5 format first (ome.version)
@@ -203,8 +204,8 @@ def analyze_zarr_store(store_path: str) -> StoreInfo:
             translation_info=(
                 dict(first_image.translation) if first_image.translation else {}
             ),
-            method_type=getattr(multiscales, 'method', None),
-            method_metadata=getattr(multiscales, 'method_metadata', None),
+            method_type=getattr(multiscales, "method", None),
+            method_metadata=getattr(multiscales, "method_metadata", None),
             anatomical_orientation=None,  # Will be populated if available
             rfc_support=None,  # Will be populated if available
         )
@@ -390,15 +391,10 @@ def get_available_compression_codecs() -> List[str]:
 
 
 def setup_dask_config(
-    memory_target: Optional[str] = None,
     use_local_cluster: bool = False,
     cache_dir: Optional[str] = None,
 ) -> Optional[Any]:
     """Setup Dask configuration and return client if using LocalCluster."""
-    import dask
-
-    if memory_target:
-        config.memory_target = dask.utils.parse_bytes(memory_target)  # type: ignore[attr-defined]
 
     if cache_dir:
         cache_path = Path(cache_dir).resolve()
@@ -416,19 +412,16 @@ def setup_dask_config(
             import psutil
 
             n_workers = 4
-            worker_memory_target = config.memory_target // n_workers
 
             try:
                 cpu_count = psutil.cpu_count(False)
                 if cpu_count is not None:
                     n_workers = cpu_count // 2
-                    worker_memory_target = config.memory_target // n_workers
             except Exception:
                 pass
 
             cluster = LocalCluster(
                 n_workers=n_workers,
-                memory_limit=worker_memory_target,
                 processes=True,
                 threads_per_worker=2,
             )

--- a/mcp/pixi.lock
+++ b/mcp/pixi.lock
@@ -4747,7 +4747,7 @@ packages:
   editable: true
 - pypi: ./
   name: ngff-zarr-mcp
-  version: 0.3.0
+  version: 0.4.0
   sha256: 0de3f56b4b53550b2f04c523044ceaa51b2304ff12fa84e3aa54ceb01ee6878a
   requires_dist:
   - aiofiles

--- a/mcp/tests/test_tensorstore_compression.py
+++ b/mcp/tests/test_tensorstore_compression.py
@@ -19,11 +19,14 @@ def temp_output_dir():
     yield temp_dir
     # Cleanup after test
     import shutil
+
     shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 @pytest.mark.asyncio
-async def test_convert_to_ome_zarr_tensorstore_with_compression(test_input_file, temp_output_dir):
+async def test_convert_to_ome_zarr_tensorstore_with_compression(
+    test_input_file, temp_output_dir
+):
     """Test conversion with TensorStore and compression (reproduces the original bug)."""
     # Verify input file exists
     assert test_input_file.exists(), f"Test input file not found: {test_input_file}"
@@ -56,7 +59,9 @@ async def test_convert_to_ome_zarr_tensorstore_with_compression(test_input_file,
 
 
 @pytest.mark.asyncio
-async def test_convert_to_ome_zarr_tensorstore_with_gzip_compression(test_input_file, temp_output_dir):
+async def test_convert_to_ome_zarr_tensorstore_with_gzip_compression(
+    test_input_file, temp_output_dir
+):
     """Test conversion with TensorStore and gzip compression."""
     # Verify input file exists
     assert test_input_file.exists(), f"Test input file not found: {test_input_file}"
@@ -90,13 +95,17 @@ async def test_convert_to_ome_zarr_tensorstore_with_gzip_compression(test_input_
 
 
 @pytest.mark.asyncio
-async def test_convert_to_ome_zarr_zarr_v3_tensorstore_with_compression(test_input_file, temp_output_dir):
+async def test_convert_to_ome_zarr_zarr_v3_tensorstore_with_compression(
+    test_input_file, temp_output_dir
+):
     """Test conversion with TensorStore, Zarr v3, and compression."""
     # Verify input file exists
     assert test_input_file.exists(), f"Test input file not found: {test_input_file}"
 
     # Setup output path
-    output_path = Path(temp_output_dir) / "mr_head_zarr_v3_tensorstore_compression.ome.zarr"
+    output_path = (
+        Path(temp_output_dir) / "mr_head_zarr_v3_tensorstore_compression.ome.zarr"
+    )
 
     # Configure conversion options with TensorStore, Zarr v3, and compression
     options = ConversionOptions(


### PR DESCRIPTION
Agents try to set this too conservatively, and this can interfere with
the processing of large datasets.

Just use the default behavior, which inspects the memory available on
the system and adjusts accordingly.
