### PR TITLE
fix(rfc4): correct LPS RAS direction

### DIFF
--- a/docs/rfc4.md
+++ b/docs/rfc4.md
@@ -139,13 +139,18 @@ ngff_image = ngff_zarr.itk_image_to_ngff_image(
 
 ## ITK LPS Coordinate System
 
-ITK uses the LPS (Left-to-right, Posterior-to-anterior, Superior-to-inferior)
-coordinate system by default. When converting ITK images, the following mappings
-are applied:
+ITK uses the LPS (Left-Posterior-Superior) coordinate system by default. In LPS,
+the axis directions indicate the direction of increasing coordinate values:
 
-- **X axis**: `left-to-right`
-- **Y axis**: `posterior-to-anterior`
-- **Z axis**: `superior-to-inferior`
+- **L (Left)**: The X-axis increases from right-to-left
+- **P (Posterior)**: The Y-axis increases from anterior-to-posterior
+- **S (Superior)**: The Z-axis increases from inferior-to-superior
+
+When converting ITK images, the following mappings are applied:
+
+- **X axis**: `right-to-left` (L = Left direction)
+- **Y axis**: `anterior-to-posterior` (P = Posterior direction)
+- **Z axis**: `inferior-to-superior` (S = Superior direction)
 
 ## Convenience Coordinate Systems
 
@@ -154,7 +159,11 @@ For common use cases, we provide pre-defined orientation dictionaries:
 ### LPS Coordinate System
 
 The `LPS` constant provides orientations for the DICOM and ITK standard
-coordinate system:
+coordinate system. LPS stands for Left-Posterior-Superior, where:
+
+- **L (Left)**: X-axis increases from right-to-left
+- **P (Posterior)**: Y-axis increases from anterior-to-posterior
+- **S (Superior)**: Z-axis increases from inferior-to-superior
 
 ```python
 import ngff_zarr as nz
@@ -185,16 +194,20 @@ The `LPS` constant is equivalent to:
 
 ```python
 {
-    "x": AnatomicalOrientation(type="anatomical", value="left-to-right"),
-    "y": AnatomicalOrientation(type="anatomical", value="posterior-to-anterior"),
-    "z": AnatomicalOrientation(type="anatomical", value="superior-to-inferior")
+    "x": AnatomicalOrientation(type="anatomical", value="right-to-left"),
+    "y": AnatomicalOrientation(type="anatomical", value="anterior-to-posterior"),
+    "z": AnatomicalOrientation(type="anatomical", value="inferior-to-superior")
 }
 ```
 
 ### RAS Coordinate System
 
-The `RAS` constant provides orientations for the default Nifti neuroimaging
-coordinate system:
+The `RAS` constant provides orientations for the neuroimaging coordinate system
+used in NIfTI. RAS stands for Right-Anterior-Superior, where:
+
+- **R (Right)**: X-axis increases from left-to-right
+- **A (Anterior)**: Y-axis increases from posterior-to-anterior
+- **S (Superior)**: Z-axis increases from inferior-to-superior
 
 ```python
 import ngff_zarr as nz
@@ -225,9 +238,9 @@ The `RAS` constant is equivalent to:
 
 ```python
 {
-    "x": AnatomicalOrientation(type="anatomical", value="right-to-left"),
-    "y": AnatomicalOrientation(type="anatomical", value="anterior-to-posterior"),
-    "z": AnatomicalOrientation(type="anatomical", value="superior-to-inferior")
+    "x": AnatomicalOrientation(type="anatomical", value="left-to-right"),
+    "y": AnatomicalOrientation(type="anatomical", value="posterior-to-anterior"),
+    "z": AnatomicalOrientation(type="anatomical", value="inferior-to-superior")
 }
 ```
 
@@ -245,13 +258,13 @@ import dask.array as da
 
 # Create orientation objects
 x_orientation = AnatomicalOrientation(
-    value=AnatomicalOrientationValues.left_to_right
+    value=AnatomicalOrientationValues.right_to_left
 )
 y_orientation = AnatomicalOrientation(
     value=AnatomicalOrientationValues.anterior_to_posterior
 )
 z_orientation = AnatomicalOrientation(
-    value=AnatomicalOrientationValues.superior_to_inferior
+    value=AnatomicalOrientationValues.inferior_to_superior
 )
 
 # Create NGFF image with orientations
@@ -283,7 +296,7 @@ When RFC-4 is enabled, spatial axes in the OME-NGFF metadata include an
       "unit": "micrometer",
       "orientation": {
         "type": "anatomical",
-        "value": "superior-to-inferior"
+        "value": "inferior-to-superior"
       }
     },
     {
@@ -292,7 +305,7 @@ When RFC-4 is enabled, spatial axes in the OME-NGFF metadata include an
       "unit": "micrometer",
       "orientation": {
         "type": "anatomical",
-        "value": "posterior-to-anterior"
+        "value": "anterior-to-posterior"
       }
     },
     {
@@ -301,7 +314,7 @@ When RFC-4 is enabled, spatial axes in the OME-NGFF metadata include an
       "unit": "micrometer",
       "orientation": {
         "type": "anatomical",
-        "value": "left-to-right"
+        "value": "right-to-left"
       }
     }
   ]
@@ -326,10 +339,14 @@ When RFC-4 is enabled, spatial axes in the OME-NGFF metadata include an
 
 ### Convenience Constants
 
-- `LPS`: Pre-defined orientations for ITK coordinate system (Left-to-right,
-  Posterior-to-anterior, Superior-to-inferior)
-- `RAS`: Pre-defined orientations for neuroimaging coordinate system
-  (Right-to-left, Anterior-to-posterior, Superior-to-inferior)
+- `LPS`: Pre-defined orientations for ITK coordinate system:
+  - L (Left): X-axis from right-to-left
+  - P (Posterior): Y-axis from anterior-to-posterior
+  - S (Superior): Z-axis from inferior-to-superior
+- `RAS`: Pre-defined orientations for neuroimaging coordinate system:
+  - R (Right): X-axis from left-to-right
+  - A (Anterior): Y-axis from posterior-to-anterior
+  - S (Superior): Z-axis from inferior-to-superior
 
 ## Compatibility
 

--- a/py/ngff_zarr/rfc4.py
+++ b/py/ngff_zarr/rfc4.py
@@ -67,17 +67,21 @@ class AnatomicalOrientation:
 # Convenience constants for common coordinate systems
 LPS: Dict[str, AnatomicalOrientation] = {
     "x": AnatomicalOrientation(
-        type="anatomical", value=AnatomicalOrientationValues.left_to_right
+        type="anatomical", value=AnatomicalOrientationValues.right_to_left
     ),
     "y": AnatomicalOrientation(
-        type="anatomical", value=AnatomicalOrientationValues.posterior_to_anterior
+        type="anatomical", value=AnatomicalOrientationValues.anterior_to_posterior
     ),
     "z": AnatomicalOrientation(
-        type="anatomical", value=AnatomicalOrientationValues.superior_to_inferior
+        type="anatomical", value=AnatomicalOrientationValues.inferior_to_superior
     ),
 }
 """
-LPS (Left-to-right, Posterior-to-anterior, Superior-to-inferior) coordinate system orientations.
+LPS (Left-Posterior-Superior) coordinate system orientations.
+In LPS, the axes increase from:
+- X: right-to-left (L = Left)
+- Y: anterior-to-posterior (P = Posterior)
+- Z: inferior-to-superior (S = Superior)
 This is the standard coordinate system used by ITK and many medical imaging applications.
 
 Example usage:
@@ -92,17 +96,21 @@ Example usage:
 
 RAS: Dict[str, AnatomicalOrientation] = {
     "x": AnatomicalOrientation(
-        type="anatomical", value=AnatomicalOrientationValues.right_to_left
+        type="anatomical", value=AnatomicalOrientationValues.left_to_right
     ),
     "y": AnatomicalOrientation(
-        type="anatomical", value=AnatomicalOrientationValues.anterior_to_posterior
+        type="anatomical", value=AnatomicalOrientationValues.posterior_to_anterior
     ),
     "z": AnatomicalOrientation(
-        type="anatomical", value=AnatomicalOrientationValues.superior_to_inferior
+        type="anatomical", value=AnatomicalOrientationValues.inferior_to_superior
     ),
 }
 """
-RAS (Right-to-left, Anterior-to-posterior, Superior-to-inferior) coordinate system orientations.
+RAS (Right-Anterior-Superior) coordinate system orientations.
+In RAS, the axes increase from:
+- X: left-to-right (R = Right)
+- Y: posterior-to-anterior (A = Anterior)
+- Z: inferior-to-superior (S = Superior)
 This coordinate system is commonly used in neuroimaging applications like FreeSurfer and FSL.
 
 Example usage:
@@ -122,8 +130,11 @@ def itk_lps_to_anatomical_orientation(
     """
     Convert ITK LPS coordinate system to anatomical orientation.
 
-    ITK uses the LPS (Left-to-right, Posterior-to-anterior, Superior-to-inferior)
-    coordinate system by default.
+    ITK uses the LPS (Left-Posterior-Superior) coordinate system by default.
+    In LPS, the axes increase from:
+    - X: right-to-left (L = Left)
+    - Y: anterior-to-posterior (P = Posterior)
+    - Z: inferior-to-superior (S = Superior)
 
     Parameters
     ----------

--- a/py/test/test_rfc4.py
+++ b/py/test/test_rfc4.py
@@ -19,23 +19,23 @@ def test_anatomical_orientation_creation():
 
 def test_itk_lps_to_anatomical_orientation():
     """Test ITK LPS coordinate mapping."""
-    # Test X axis (left to right in LPS)
+    # Test X axis (right to left in LPS)
     x_orientation = itk_lps_to_anatomical_orientation("x")
     assert x_orientation is not None
     assert x_orientation.type == "anatomical"
-    assert x_orientation.value == AnatomicalOrientationValues.left_to_right
+    assert x_orientation.value == AnatomicalOrientationValues.right_to_left
 
-    # Test Y axis (posterior to anterior in LPS)
+    # Test Y axis (anterior to posterior in LPS)
     y_orientation = itk_lps_to_anatomical_orientation("y")
     assert y_orientation is not None
     assert y_orientation.type == "anatomical"
-    assert y_orientation.value == AnatomicalOrientationValues.posterior_to_anterior
+    assert y_orientation.value == AnatomicalOrientationValues.anterior_to_posterior
 
-    # Test Z axis (superior to inferior in LPS)
+    # Test Z axis (inferior to superior in LPS)
     z_orientation = itk_lps_to_anatomical_orientation("z")
     assert z_orientation is not None
     assert z_orientation.type == "anatomical"
-    assert z_orientation.value == AnatomicalOrientationValues.superior_to_inferior
+    assert z_orientation.value == AnatomicalOrientationValues.inferior_to_superior
 
     # Test non-spatial axis
     c_orientation = itk_lps_to_anatomical_orientation("c")

--- a/py/test/test_rfc4_validation.py
+++ b/py/test/test_rfc4_validation.py
@@ -27,19 +27,19 @@ def test_has_rfc4_orientation_metadata():
             "name": "x",
             "type": "space",
             "unit": "micrometer",
-            "orientation": {"type": "anatomical", "value": "left-to-right"},
+            "orientation": {"type": "anatomical", "value": "right-to-left"},
         },
         {
             "name": "y",
             "type": "space",
             "unit": "micrometer",
-            "orientation": {"type": "anatomical", "value": "posterior-to-anterior"},
+            "orientation": {"type": "anatomical", "value": "anterior-to-posterior"},
         },
         {
             "name": "z",
             "type": "space",
             "unit": "micrometer",
-            "orientation": {"type": "anatomical", "value": "superior-to-inferior"},
+            "orientation": {"type": "anatomical", "value": "inferior-to-superior"},
         },
     ]
     assert has_rfc4_orientation_metadata(axes_with_orientation)
@@ -83,19 +83,19 @@ def test_validate_rfc4_orientation_mixed_types():
             "name": "x",
             "type": "space",
             "unit": "micrometer",
-            "orientation": {"type": "anatomical", "value": "left-to-right"},
+            "orientation": {"type": "anatomical", "value": "right-to-left"},
         },
         {
             "name": "y",
             "type": "space",
             "unit": "micrometer",
-            "orientation": {"type": "anatomical", "value": "posterior-to-anterior"},
+            "orientation": {"type": "anatomical", "value": "anterior-to-posterior"},
         },
         {
             "name": "z",
             "type": "space",
             "unit": "micrometer",
-            "orientation": {"type": "anatomical", "value": "superior-to-inferior"},
+            "orientation": {"type": "anatomical", "value": "inferior-to-superior"},
         },
     ]
 
@@ -111,13 +111,13 @@ def test_validate_rfc4_orientation_incomplete():
             "name": "x",
             "type": "space",
             "unit": "micrometer",
-            "orientation": {"type": "anatomical", "value": "left-to-right"},
+            "orientation": {"type": "anatomical", "value": "right-to-left"},
         },
         {
             "name": "y",
             "type": "space",
             "unit": "micrometer",
-            "orientation": {"type": "anatomical", "value": "posterior-to-anterior"},
+            "orientation": {"type": "anatomical", "value": "anterior-to-posterior"},
         },
         {
             "name": "z",
@@ -141,19 +141,19 @@ def test_validate_rfc4_orientation_inconsistent_types():
             "name": "x",
             "type": "space",
             "unit": "micrometer",
-            "orientation": {"type": "anatomical", "value": "left-to-right"},
+            "orientation": {"type": "anatomical", "value": "right-to-left"},
         },
         {
             "name": "y",
             "type": "space",
             "unit": "micrometer",
-            "orientation": {"type": "different_type", "value": "posterior-to-anterior"},
+            "orientation": {"type": "different_type", "value": "anterior-to-posterior"},
         },
         {
             "name": "z",
             "type": "space",
             "unit": "micrometer",
-            "orientation": {"type": "anatomical", "value": "superior-to-inferior"},
+            "orientation": {"type": "anatomical", "value": "inferior-to-superior"},
         },
     ]
 
@@ -179,13 +179,13 @@ def test_validate_rfc4_orientation_invalid_value():
             "name": "y",
             "type": "space",
             "unit": "micrometer",
-            "orientation": {"type": "anatomical", "value": "posterior-to-anterior"},
+            "orientation": {"type": "anatomical", "value": "anterior-to-posterior"},
         },
         {
             "name": "z",
             "type": "space",
             "unit": "micrometer",
-            "orientation": {"type": "anatomical", "value": "superior-to-inferior"},
+            "orientation": {"type": "anatomical", "value": "inferior-to-superior"},
         },
     ]
 
@@ -213,19 +213,19 @@ def test_from_ngff_zarr_with_rfc4_validation():
                 "name": "x",
                 "type": "space",
                 "unit": "micrometer",
-                "orientation": {"type": "anatomical", "value": "left-to-right"},
+                "orientation": {"type": "anatomical", "value": "right-to-left"},
             },
             {
                 "name": "y",
                 "type": "space",
                 "unit": "micrometer",
-                "orientation": {"type": "anatomical", "value": "posterior-to-anterior"},
+                "orientation": {"type": "anatomical", "value": "anterior-to-posterior"},
             },
             {
                 "name": "z",
                 "type": "space",
                 "unit": "micrometer",
-                "orientation": {"type": "anatomical", "value": "superior-to-inferior"},
+                "orientation": {"type": "anatomical", "value": "inferior-to-superior"},
             },
         ],
         "datasets": [
@@ -265,13 +265,13 @@ def test_from_ngff_zarr_with_rfc4_validation_invalid():
                 "name": "x",
                 "type": "space",
                 "unit": "micrometer",
-                "orientation": {"type": "anatomical", "value": "left-to-right"},
+                "orientation": {"type": "anatomical", "value": "right-to-left"},
             },
             {
                 "name": "y",
                 "type": "space",
                 "unit": "micrometer",
-                "orientation": {"type": "anatomical", "value": "posterior-to-anterior"},
+                "orientation": {"type": "anatomical", "value": "anterior-to-posterior"},
             },
             {
                 "name": "z",
@@ -317,13 +317,13 @@ def test_from_ngff_zarr_without_rfc4_validation():
                 "name": "x",
                 "type": "space",
                 "unit": "micrometer",
-                "orientation": {"type": "anatomical", "value": "left-to-right"},
+                "orientation": {"type": "anatomical", "value": "right-to-left"},
             },
             {
                 "name": "y",
                 "type": "space",
                 "unit": "micrometer",
-                "orientation": {"type": "anatomical", "value": "posterior-to-anterior"},
+                "orientation": {"type": "anatomical", "value": "anterior-to-posterior"},
             },
             {
                 "name": "z",


### PR DESCRIPTION
The one-letter acronyn denotes the positive direction.

LPS: x: right-to-left, y: anterior-to-posterior, z: inferior-to-superior
RAS: x: left-to-right, y: posterior-to-anterior, z: inferior-to-superior
