### PR TITLE
WIP: feat(mcp): push to the MCP registry

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,43 @@
+name: Publish to MCP Registry
+
+on:
+  push:
+    tags: ["mcp-v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        working-directory: ./mcp
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Set server.json version to tag
+        run: |
+          VERSION=${GITHUB_REF_NAME#mcp-v}
+          jq --arg v "$VERSION" '.version = $v | .packages = (.packages // []) | .packages |= (.[]? // {}) | .packages |= map(if .registry_type == "pypi" then .version = $v else . end)' server.json > server.tmp.json && mv server.tmp.json server.json
+
+      - name: Validate server.json against schema
+        run: |
+          pip install jsonschema
+          python -c "import json,urllib.request;schema=json.load(urllib.request.urlopen('https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json'));data=json.load(open('server.json'));from jsonschema import validate, Draft7Validator;Draft7Validator.check_schema(schema);validate(instance=data, schema=schema);print('server.json is valid')"
+
+      - name: Login to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -4,6 +4,8 @@
 with the ability to convert images to OME-Zarr format using the ngff-zarr
 library.
 
+<!-- mcp-name: io.github.thewtex/ngff-zarr -->
+
 [![asciicast](https://asciinema.org/a/726628.png)](https://asciinema.org/a/726628)
 
 ## Features

--- a/mcp/pixi.lock
+++ b/mcp/pixi.lock
@@ -4685,7 +4685,7 @@ packages:
   timestamp: 1738196177597
 - pypi: ../py
   name: ngff-zarr
-  version: 0.15.2
+  version: 0.16.1
   sha256: 2411f274c91e5efd78524d45aa9f1c5de5727b0ba35455ca58fa3b6cbf8880bd
   requires_dist:
   - dask[array]
@@ -4747,8 +4747,8 @@ packages:
   editable: true
 - pypi: ./
   name: ngff-zarr-mcp
-  version: 0.4.0
-  sha256: 0de3f56b4b53550b2f04c523044ceaa51b2304ff12fa84e3aa54ceb01ee6878a
+  version: 0.5.0
+  sha256: 5484ca1e9fd897b65b418f8a3c81b8de6fc42843b2dce76ea2bb55a66744a15c
   requires_dist:
   - aiofiles
   - aiohttp

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -171,6 +171,7 @@ pytest-asyncio = ">=1.0.0,<2"
 [tool.pixi.feature.dev.pypi-dependencies]
 ngff-zarr-mcp = { path = ".", editable = true, extras = ["dev"] }
 ngff-zarr = { path = "../py", editable = true, extras = ["cli", "tensorstore"] }
+jsonschema = "*"
 
 [tool.pixi.feature.dev.tasks]
 test = "pytest tests/"
@@ -181,6 +182,7 @@ format-check = "black --check --diff ."
 typecheck = "mypy ngff_zarr_mcp tests"
 build = "hatch build"
 all-checks = { depends-on = ["lint", "format-check", "typecheck"] }
+validate-server-json = "python -c \"import json,urllib.request; from jsonschema import validate, Draft7Validator; schema=json.load(urllib.request.urlopen('https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json')); data=json.load(open('server.json')); Draft7Validator.check_schema(schema); validate(instance=data, schema=schema); print('server.json is valid')\""
 
 [tool.pixi.feature.cloud.pypi-dependencies]
 ngff-zarr-mcp = { path = ".", editable = true, extras = ["cloud"] }

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.thewtex/ngff-zarr",
+  "description": "Model Context Protocol server for OME-Zarr image conversion and optimization using ngff-zarr.",
+  "version": "0.5.0",
+  "repository": {
+    "url": "https://github.com/thewtex/ngff-zarr",
+    "source": "github",
+    "subfolder": "mcp"
+  },
+  "packages": [
+    {
+      "registry_type": "pypi",
+      "identifier": "ngff-zarr-mcp",
+      "version": "0.5.0",
+      "transport": { "type": "stdio" },
+      "runtime_hint": "uvx",
+      "package_arguments": []
+    }
+  ]
+}


### PR DESCRIPTION
Re:

  https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/publish-server.md

Added server.json describing this MCP server for the registry:
Name: io.github.thewtex/ngff-zarr (GitHub namespace, so CI OIDC auth is supported)

How to publish

Push a tag matching the workflow pattern to trigger:

Example: git tag mcp-v0.5.1 && git push origin mcp-v0.5.1

The workflow will:

- Update server.json version to 0.5.1 and update the PyPI package version field accordingly
- Validate server.json
- Authenticate to MCP Registry via GitHub OIDC
- Publish to the registry

Note: For PyPI package verification, make sure the corresponding version of ngff-zarr-mcp is already published to PyPI (or is published as part of your broader release workflow). The README marker added ensures registry ownership validation succeeds on PyPI.
