### PR TITLE
express existing functionality as rfc5 transforms

### DIFF
--- a/py/ngff_zarr/multiscales.py
+++ b/py/ngff_zarr/multiscales.py
@@ -5,12 +5,13 @@ from .methods import Methods
 from .ngff_image import NgffImage
 from .v04.zarr_metadata import Metadata as Metadata_v04
 from .v05.zarr_metadata import Metadata as Metadata_v05
+from .v06.zarr_metadata import Metadata as Metadata_v06
 
 
 @dataclass
 class Multiscales:
     images: List[NgffImage]
-    metadata: Union[Metadata_v04, Metadata_v05]
+    metadata: Union[Metadata_v04, Metadata_v05, Metadata_v06]
     scale_factors: Optional[Sequence[Union[Dict[str, int], int]]] = None
     method: Optional[Methods] = None
     chunks: Optional[

--- a/py/ngff_zarr/v06/zarr_metadata.py
+++ b/py/ngff_zarr/v06/zarr_metadata.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+from ..v04.zarr_metadata import Axis, Omero, MethodMetadata
+
+@dataclass
+class coordinateSystem:
+    name: str
+    axes: List[Axis]
+
+@dataclass
+class Scale:
+    scale: List[float]
+    type: str = "scale"
+    name: Optional[str] = None
+    input: Optional[Union[None, str, coordinateSystem]] = None
+    output: Optional[Union[None, str, coordinateSystem]] = None
+
+
+@dataclass
+class Translation:
+    translation: List[float]
+    type: str = "translation"
+    name: Optional[str] = None
+    input: Optional[Union[None, str, coordinateSystem]] = None
+    output: Optional[Union[None, str, coordinateSystem]] = None
+
+
+coordinateTransformations = Union[Scale, Translation]
+
+
+@dataclass
+class TransformSequence:
+    input: Optional[Union[str, coordinateSystem]]
+    output: Optional[Union[str, coordinateSystem]]
+    transformations: List[coordinateTransformations]
+    type: str = 'sequence'
+    name: Optional[str] = None
+
+
+@dataclass
+class Dataset:
+    path: str
+    coordinateTransformations: Optional[Union[coordinateTransformations, TransformSequence]]
+
+
+@dataclass
+class Metadata:
+    datasets: List[Dataset]
+    coordinateSystems: List[coordinateSystem]
+    omero: Optional[Omero] = None
+    name: str = "image"
+    type: Optional[str] = None
+    metadata: Optional[MethodMetadata] = None

--- a/py/test.ipynb
+++ b/py/test.ipynb
@@ -1,0 +1,116 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d40009f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import ngff_zarr as nz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "382ed958",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image = np.random.rand(512, 512)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "89d7960d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ngff_image = nz.to_ngff_image(\n",
+    "    data=image,\n",
+    "    dims=['y', 'x'],\n",
+    "    scale={'y': 0.5, 'x': 0.5},\n",
+    "    translation={'y': 10, 'x': 20},\n",
+    "    name='some_image',\n",
+    "    axes_units={'y': 'micrometer', 'x': 'micrometer'},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "58ee2255",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Multiscales(images=[NgffImage(data=dask.array<rechunk-merge, shape=(512, 512), dtype=float64, chunksize=(256, 256), chunktype=numpy.ndarray>, dims=['y', 'x'], scale={'y': 0.5, 'x': 0.5}, translation={'y': 10, 'x': 20}, name='some_image', axes_units={'y': 'micrometer', 'x': 'micrometer'}, axes_orientations=None, computed_callbacks=[]), NgffImage(data=dask.array<rechunk-merge, shape=(512, 512), dtype=float64, chunksize=(256, 256), chunktype=numpy.ndarray>, dims=['y', 'x'], scale={'y': 0.5, 'x': 0.5}, translation={'y': 10.0, 'x': 20.0}, name='image', axes_units=None, axes_orientations=None, computed_callbacks=[]), NgffImage(data=dask.array<affine_transform, shape=(256, 256), dtype=float64, chunksize=(256, 256), chunktype=numpy.ndarray>, dims=['y', 'x'], scale={'y': 1.0, 'x': 1.0}, translation={'y': 10.25, 'x': 20.25}, name='image', axes_units=None, axes_orientations=None, computed_callbacks=[]), NgffImage(data=dask.array<affine_transform, shape=(128, 128), dtype=float64, chunksize=(128, 128), chunktype=numpy.ndarray>, dims=['y', 'x'], scale={'y': 2.0, 'x': 2.0}, translation={'y': 10.75, 'x': 20.75}, name='image', axes_units=None, axes_orientations=None, computed_callbacks=[])], metadata=Metadata(datasets=[Dataset(path='scale0/some_image', coordinateTransformations=[TransformSequence(input='scale0/some_image', output='physical', transformations=[[Scale(scale=[0.5, 0.5], type='scale', name=None, input=None, output=None), Translation(translation=[10, 20], type='translation', name=None, input=None, output=None)]], type='sequence', name='scale_0_to_physical')]), Dataset(path='scale1/some_image', coordinateTransformations=[TransformSequence(input='scale1/some_image', output='physical', transformations=[[Scale(scale=[0.5, 0.5], type='scale', name=None, input=None, output=None), Translation(translation=[10.0, 20.0], type='translation', name=None, input=None, output=None)]], type='sequence', name='scale_1_to_physical')]), Dataset(path='scale2/some_image', coordinateTransformations=[TransformSequence(input='scale2/some_image', output='physical', transformations=[[Scale(scale=[1.0, 1.0], type='scale', name=None, input=None, output=None), Translation(translation=[10.25, 20.25], type='translation', name=None, input=None, output=None)]], type='sequence', name='scale_2_to_physical')]), Dataset(path='scale3/some_image', coordinateTransformations=[TransformSequence(input='scale3/some_image', output='physical', transformations=[[Scale(scale=[2.0, 2.0], type='scale', name=None, input=None, output=None), Translation(translation=[10.75, 20.75], type='translation', name=None, input=None, output=None)]], type='sequence', name='scale_3_to_physical')])], coordinateSystems=[coordinateSystem(name='physical', axes=[Axis(name='y', type='space', unit='micrometer', orientation=None), Axis(name='x', type='space', unit='micrometer', orientation=None)])], omero=None, name='some_image', type='dask_image_gaussian', metadata=MethodMetadata(description='Smoothed with a discrete gaussian filter to generate a scale space, ideal for intensity images. dask-image implementation based on scipy.', method='dask_image.ndfilters.gaussian_filter', version='2024.5.3')), scale_factors=[{'y': 1.0, 'x': 1.0}, {'y': 2.0, 'x': 2.0}, {'y': 4.0, 'x': 4.0}], method=<Methods.DASK_IMAGE_GAUSSIAN: 'dask_image_gaussian'>, chunks={'y': 256, 'x': 256})"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ngff_multiscales = nz.to_multiscales(\n",
+    "    ngff_image,\n",
+    "    scale_factors=[\n",
+    "        {'y': 1.0, 'x': 1.0},\n",
+    "        {'y': 2.0, 'x': 2.0},\n",
+    "        {'y': 4.0, 'x': 4.0},\n",
+    "    ],\n",
+    "    method=nz.Methods.DASK_IMAGE_GAUSSIAN\n",
+    ")\n",
+    "\n",
+    "ngff_multiscales"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b7868f40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nz.to_ngff_zarr(\n",
+    "    './test.ome.zarr',\n",
+    "    ngff_multiscales,\n",
+    "    version='0.6dev2'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e568811",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ngff-zarr",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Title. This expresses existing functionality to save ngff metadata in an rfc5-compliant way. All the changes happen under the hood of the `to_multiscales` and the `to_zarr` functions so the `NgffImage` class remains untouched.