### PR TITLE
feat(hcs): add helpers and docs for writing .ozx

### DIFF
--- a/py/ngff_zarr/__init__.py
+++ b/py/ngff_zarr/__init__.py
@@ -20,7 +20,7 @@ from .to_multiscales import to_multiscales
 from .to_ngff_image import to_ngff_image
 from .to_ngff_zarr import to_ngff_zarr
 from .validate import validate
-from .hcs import from_hcs_zarr, to_hcs_zarr, write_hcs_well_image, HCSPlate, HCSWell
+from .hcs import from_hcs_zarr, to_hcs_zarr, write_hcs_well_image, HCSPlate, HCSWell, HCSPlateWriter
 from .v04.zarr_metadata import (
     AxesType,
     SpatialDims,
@@ -115,6 +115,7 @@ __all__ = [
     "write_hcs_well_image",
     "HCSPlate",
     "HCSWell",
+    "HCSPlateWriter",
     # RFC 4 - Anatomical Orientation
     "AnatomicalOrientation",
     "AnatomicalOrientationValues",

--- a/py/ngff_zarr/from_ngff_zarr.py
+++ b/py/ngff_zarr/from_ngff_zarr.py
@@ -76,7 +76,7 @@ def from_ngff_zarr(
             version = read_ozx_version(store)
             if version is None:
                 version = "0.5"  # Default to 0.5 for .ozx files
-        
+
         # For zarr v3, create ZipStore directly with the path
         store = zarr.storage.ZipStore(str(store), mode='r')
 

--- a/py/ngff_zarr/rfc9_zip.py
+++ b/py/ngff_zarr/rfc9_zip.py
@@ -34,7 +34,7 @@ def is_ozx_path(path: Union[str, Path]) -> bool:
 
 
 def write_store_to_zip(
-    source_store: zarr.storage.StoreLike,
+    source_store: Union[zarr.storage.StoreLike, str, Path],
     zip_path: Union[str, Path],
     version: str = "0.5",
     compression: int = zipfile.ZIP_STORED
@@ -49,16 +49,28 @@ def write_store_to_zip(
     - ZIP64 format should be used
     - A comment with OME-Zarr version should be added
 
+    This function can be used to convert any existing zarr store (including HCS plates)
+    to .ozx format after it has been written.
+
     Parameters
     ----------
-    source_store : zarr.storage.StoreLike
-        Source zarr store to write from
+    source_store : zarr.storage.StoreLike, str, or Path
+        Source zarr store to write from. Can be a store object (LocalStore, DirectoryStore)
+        or a path string to a directory containing zarr data.
     zip_path : str or Path
         Path to output .ozx file
     version : str, optional
         OME-Zarr version string (e.g., "0.5")
     compression : int, optional
         ZIP compression method (default: ZIP_STORED for no compression)
+
+    Examples
+    --------
+    Convert an existing HCS plate to .ozx:
+
+    >>> from ngff_zarr.rfc9_zip import write_store_to_zip
+    >>> # After writing plate with to_hcs_zarr or HCSPlateWriter
+    >>> write_store_to_zip("my_plate.ome.zarr", "my_plate.ozx", version="0.5")
     """
     import asyncio
     from zarr.core.buffer import default_buffer_prototype
@@ -68,14 +80,44 @@ def write_store_to_zip(
     # Get the buffer prototype for zarr v3 stores
     proto = default_buffer_prototype()
 
-    # Collect all files from source store using async list()
-    async def get_all_files():
-        items = []
-        async for item in source_store.list():
-            items.append(item)
-        return items
+    # Handle string/Path inputs by converting to appropriate store or using filesystem directly
+    if isinstance(source_store, (str, Path)):
+        # For path strings, enumerate files directly from filesystem
+        root_dir = Path(source_store)
+        all_files = []
+        for file_path in root_dir.rglob('*'):
+            if file_path.is_file():
+                # Get relative path from root
+                rel_path = file_path.relative_to(root_dir)
+                # Convert to forward slashes for ZIP
+                all_files.append(str(rel_path).replace('\\', '/'))
+    elif hasattr(zarr.storage, "LocalStore") and isinstance(source_store, zarr.storage.LocalStore):
+        # Get the root directory from LocalStore
+        root_dir = Path(source_store.root)
+        all_files = []
+        for file_path in root_dir.rglob('*'):
+            if file_path.is_file():
+                # Get relative path from root
+                rel_path = file_path.relative_to(root_dir)
+                # Convert to forward slashes for ZIP
+                all_files.append(str(rel_path).replace('\\', '/'))
+    elif hasattr(zarr.storage, "DirectoryStore") and isinstance(source_store, zarr.storage.DirectoryStore):
+        # For DirectoryStore (zarr v2), use dir_path()
+        root_dir = Path(source_store.dir_path())
+        all_files = []
+        for file_path in root_dir.rglob('*'):
+            if file_path.is_file():
+                rel_path = file_path.relative_to(root_dir)
+                all_files.append(str(rel_path).replace('\\', '/'))
+    else:
+        # For other store types, use async list()
+        async def get_all_files():
+            items = []
+            async for item in source_store.list():
+                items.append(item)
+            return items
 
-    all_files = asyncio.run(get_all_files())
+        all_files = asyncio.run(get_all_files())
 
     if not all_files:
         raise ValueError(f"No files found in source store of type {type(source_store)}")
@@ -92,24 +134,57 @@ def write_store_to_zip(
     # Order: zarr.json files first, then everything else sorted
     ordered_files = zarr_jsons + sorted(other_files)
 
-    # Helper async function to get file data
-    async def get_file_data(file_path: str):
-        """Get data from store using zarr v3 async API"""
-        try:
-            result = await source_store.get(file_path, proto)
-            if result:
-                return result.to_bytes()
-            return None
-        except (KeyError, FileNotFoundError):
-            # File not found in store - this is an error condition
-            return None
+    # Read file data based on store type
+    if isinstance(source_store, (str, Path)):
+        # Read files directly from filesystem for path strings
+        root_dir = Path(source_store)
+        file_data = {}
+        for file_path in ordered_files:
+            full_path = root_dir / file_path
+            if full_path.exists():
+                file_data[file_path] = full_path.read_bytes()
+            else:
+                raise ValueError(f"Could not read data for {file_path} from {root_dir}")
+    elif hasattr(zarr.storage, "LocalStore") and isinstance(source_store, zarr.storage.LocalStore):
+        # Read files directly from filesystem
+        root_dir = Path(source_store.root)
+        file_data = {}
+        for file_path in ordered_files:
+            full_path = root_dir / file_path
+            if full_path.exists():
+                file_data[file_path] = full_path.read_bytes()
+            else:
+                raise ValueError(f"Could not read data for {file_path} from {root_dir}")
+    elif hasattr(zarr.storage, "DirectoryStore") and isinstance(source_store, zarr.storage.DirectoryStore):
+        # Read files directly from filesystem
+        root_dir = Path(source_store.dir_path())
+        file_data = {}
+        for file_path in ordered_files:
+            full_path = root_dir / file_path
+            if full_path.exists():
+                file_data[file_path] = full_path.read_bytes()
+            else:
+                raise ValueError(f"Could not read data for {file_path} from {root_dir}")
+    else:
+        # For other store types, use async get()
+        # Helper async function to get file data
+        async def get_file_data(file_path: str):
+            """Get data from store using zarr v3 async API"""
+            try:
+                result = await source_store.get(file_path, proto)
+                if result:
+                    return result.to_bytes()
+                return None
+            except (KeyError, FileNotFoundError):
+                # File not found in store - this is an error condition
+                return None
 
-    # Gather all file data in a single event loop (more efficient than creating one per file)
-    async def get_all_file_data(file_paths):
-        results = await asyncio.gather(*(get_file_data(fp) for fp in file_paths))
-        return dict(zip(file_paths, results))
+        # Gather all file data in a single event loop (more efficient than creating one per file)
+        async def get_all_file_data(file_paths):
+            results = await asyncio.gather(*(get_file_data(fp) for fp in file_paths))
+            return dict(zip(file_paths, results))
 
-    file_data = asyncio.run(get_all_file_data(ordered_files))
+        file_data = asyncio.run(get_all_file_data(ordered_files))
 
     # Create ZIP archive with ZIP64 support
     with zipfile.ZipFile(

--- a/py/test/test_hcs_ozx.py
+++ b/py/test/test_hcs_ozx.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Tests for HCS support with RFC-9: Zipped OME-Zarr (.ozx) format"""
+
+import json
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import packaging.version
+import pytest
+import zarr
+
+from ngff_zarr import to_multiscales, to_ngff_image
+from ngff_zarr.hcs import HCSPlateWriter, from_hcs_zarr
+from ngff_zarr.rfc9_zip import read_ozx_version
+from ngff_zarr.v04.zarr_metadata import (
+    Plate,
+    PlateColumn,
+    PlateRow,
+    PlateWell,
+)
+
+zarr_version = packaging.version.parse(zarr.__version__)
+zarr_version_major = zarr_version.major
+
+# RFC-9 requires zarr v3 (OME-Zarr 0.5)
+pytestmark = pytest.mark.skipif(
+    zarr_version_major < 3, reason="RFC-9 requires zarr-python >= 3.0.0"
+)
+
+# Output directory for test files
+OUTPUT_DIR = Path(__file__).parent / "output"
+
+
+def test_write_hcs_well_image_to_ozx():
+    """Test writing HCS well images to .ozx format using HCSPlateWriter"""
+    # Create plate metadata
+    columns = [PlateColumn(name="1"), PlateColumn(name="2")]
+    rows = [PlateRow(name="A"), PlateRow(name="B")]
+    wells = [
+        PlateWell(path="A/1", rowIndex=0, columnIndex=0),
+        PlateWell(path="A/2", rowIndex=0, columnIndex=1),
+    ]
+    plate_metadata = Plate(
+        columns=columns,
+        rows=rows,
+        wells=wells,
+        name="Test Plate OZX",
+        field_count=2,
+        version="0.5",
+    )
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    ozx_path = OUTPUT_DIR / "test_hcs_plate.ozx"
+
+    # Remove old file if exists
+    if ozx_path.exists():
+        ozx_path.unlink()
+
+    # Create test images for wells
+    data1 = np.random.randint(0, 255, (3, 64, 64), dtype=np.uint8)
+    image1 = to_ngff_image(
+        data=data1,
+        dims=["c", "y", "x"],
+        scale={"y": 0.65, "x": 0.65},
+        translation={"c": 0.0, "y": 0.0, "x": 0.0},
+        name="Field 0",
+    )
+    multiscales1 = to_multiscales(image1, [2])
+
+    data2 = np.random.randint(0, 255, (3, 64, 64), dtype=np.uint8)
+    image2 = to_ngff_image(
+        data=data2,
+        dims=["c", "y", "x"],
+        scale={"y": 0.65, "x": 0.65},
+        translation={"c": 0.0, "y": 0.0, "x": 0.0},
+        name="Field 1",
+    )
+    multiscales2 = to_multiscales(image2, [2])
+
+    # Write individual well images using HCSPlateWriter
+    with HCSPlateWriter(str(ozx_path), plate_metadata) as writer:
+        writer.write_well_image(
+            multiscales=multiscales1,
+            row_name="A",
+            column_name="1",
+            field_index=0,
+            acquisition_id=0,
+        )
+
+        writer.write_well_image(
+            multiscales=multiscales2,
+            row_name="A",
+            column_name="1",
+            field_index=1,
+            acquisition_id=0,
+        )
+
+    # Verify file was created and is a valid ZIP
+    assert ozx_path.exists()
+    assert zipfile.is_zipfile(ozx_path)
+
+    # Verify ZIP structure
+    with zipfile.ZipFile(ozx_path, 'r') as zf:
+        files = zf.namelist()
+
+        # Root zarr.json should be first
+        assert files[0] == "zarr.json"
+
+        # Should contain well metadata
+        well_zarr_json = "A/1/zarr.json"
+        assert well_zarr_json in files
+
+        # Check for OME-Zarr version comment
+        version_from_zip = read_ozx_version(ozx_path)
+        assert version_from_zip == "0.5"
+
+    # Read back and verify
+    plate_read = from_hcs_zarr(str(ozx_path))
+
+    assert plate_read.name == "Test Plate OZX"
+    assert len(plate_read.wells) == 2
+    assert plate_read.field_count == 2
+
+    # Get well and verify images
+    well = plate_read.get_well("A", "1")
+    assert well is not None
+    assert len(well.images) == 2
+
+    # Verify field images can be loaded
+    field0 = well.get_image(0)
+    assert field0 is not None
+    assert len(field0.images) > 0  # Has scale levels
+
+    field1 = well.get_image(1)
+    assert field1 is not None
+    assert len(field1.images) > 0
+
+
+def test_write_hcs_ozx_requires_version_05():
+    """Test that HCS .ozx files require OME-Zarr version 0.5"""
+    columns = [PlateColumn(name="1")]
+    rows = [PlateRow(name="A")]
+    wells = [PlateWell(path="A/1", rowIndex=0, columnIndex=0)]
+    plate_metadata = Plate(
+        columns=columns,
+        rows=rows,
+        wells=wells,
+        name="Test Plate",
+        version="0.4",
+    )
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    ozx_path = OUTPUT_DIR / "test_hcs_version_check.ozx"
+
+    # Should raise error for version 0.4 with .ozx
+    with pytest.raises(ValueError, match="RFC-9.*requires.*0.5"):
+        with HCSPlateWriter(str(ozx_path), plate_metadata, version="0.4"):
+            pass
+
+
+def test_hcs_ozx_multiple_wells():
+    """Test writing multiple wells to .ozx HCS plate"""
+    # Create 2x2 plate
+    columns = [PlateColumn(name="1"), PlateColumn(name="2")]
+    rows = [PlateRow(name="A"), PlateRow(name="B")]
+    wells = [
+        PlateWell(path="A/1", rowIndex=0, columnIndex=0),
+        PlateWell(path="A/2", rowIndex=0, columnIndex=1),
+        PlateWell(path="B/1", rowIndex=1, columnIndex=0),
+        PlateWell(path="B/2", rowIndex=1, columnIndex=1),
+    ]
+    plate_metadata = Plate(
+        columns=columns,
+        rows=rows,
+        wells=wells,
+        name="Multi-Well Plate",
+        field_count=1,
+        version="0.5",
+    )
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    ozx_path = OUTPUT_DIR / "test_hcs_multi_well.ozx"
+
+    # Remove old file if exists
+    if ozx_path.exists():
+        ozx_path.unlink()
+
+    # Write one image to each well using HCSPlateWriter
+    with HCSPlateWriter(str(ozx_path), plate_metadata) as writer:
+        for well in wells:
+            row_name, col_name = well.path.split("/")
+            data = np.random.randint(0, 255, (2, 32, 32), dtype=np.uint8)
+            image = to_ngff_image(
+                data=data,
+                dims=["c", "y", "x"],
+                name=f"Well {well.path}",
+            )
+            multiscales = to_multiscales(image)
+
+            writer.write_well_image(
+                multiscales=multiscales,
+                row_name=row_name,
+                column_name=col_name,
+                field_index=0,
+            )
+
+    # Verify all wells can be read
+    plate_read = from_hcs_zarr(str(ozx_path))
+
+    assert len(plate_read.wells) == 4
+
+    for well_meta in plate_read.wells:
+        row_name = plate_read.rows[well_meta.rowIndex].name
+        col_name = plate_read.columns[well_meta.columnIndex].name
+        well = plate_read.get_well(row_name, col_name)
+
+        assert well is not None
+        assert len(well.images) == 1
+
+        # Verify image can be loaded
+        image = well.get_image(0)
+        assert image is not None
+
+
+def test_hcs_ozx_zip_comment():
+    """Test that HCS .ozx files have proper ZIP comment"""
+    columns = [PlateColumn(name="1")]
+    rows = [PlateRow(name="A")]
+    wells = [PlateWell(path="A/1", rowIndex=0, columnIndex=0)]
+    plate_metadata = Plate(
+        columns=columns,
+        rows=rows,
+        wells=wells,
+        version="0.5",
+    )
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    ozx_path = OUTPUT_DIR / "test_hcs_comment.ozx"
+
+    if ozx_path.exists():
+        ozx_path.unlink()
+
+    # Create and write test image using HCSPlateWriter
+    data = np.random.randint(0, 255, (2, 32, 32), dtype=np.uint8)
+    image = to_ngff_image(data=data, dims=["c", "y", "x"])
+    multiscales = to_multiscales(image)
+
+    with HCSPlateWriter(str(ozx_path), plate_metadata) as writer:
+        writer.write_well_image(
+            multiscales=multiscales,
+            row_name="A",
+            column_name="1",
+            field_index=0,
+        )
+
+    # Check ZIP comment
+    with zipfile.ZipFile(ozx_path, 'r') as zf:
+        comment = zf.comment.decode('utf-8').rstrip('\0')
+        comment_dict = json.loads(comment)
+
+        assert "ome" in comment_dict
+        assert "version" in comment_dict["ome"]
+        assert comment_dict["ome"]["version"] == "0.5"

--- a/py/test/test_hcs_plate_writer.py
+++ b/py/test/test_hcs_plate_writer.py
@@ -1,0 +1,398 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Tests for HCSPlateWriter context manager with .ozx support"""
+
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import packaging.version
+import pytest
+import zarr
+
+from ngff_zarr import to_multiscales, to_ngff_image
+from ngff_zarr.hcs import HCSPlateWriter, from_hcs_zarr
+from ngff_zarr.rfc9_zip import read_ozx_version
+from ngff_zarr.v04.zarr_metadata import (
+    Plate,
+    PlateColumn,
+    PlateRow,
+    PlateWell,
+)
+
+zarr_version = packaging.version.parse(zarr.__version__)
+zarr_version_major = zarr_version.major
+
+# RFC-9 requires zarr v3 (OME-Zarr 0.5)
+pytestmark = pytest.mark.skipif(
+    zarr_version_major < 3, reason="HCSPlateWriter with .ozx requires zarr-python >= 3.0.0"
+)
+
+# Output directory for test files
+OUTPUT_DIR = Path(__file__).parent / "output"
+
+
+def test_hcs_plate_writer_ozx_basic():
+    """Test basic HCSPlateWriter with .ozx format"""
+    # Create plate metadata
+    columns = [PlateColumn(name="1"), PlateColumn(name="2")]
+    rows = [PlateRow(name="A"), PlateRow(name="B")]
+    wells = [
+        PlateWell(path="A/1", rowIndex=0, columnIndex=0),
+        PlateWell(path="A/2", rowIndex=0, columnIndex=1),
+    ]
+    plate_metadata = Plate(
+        columns=columns,
+        rows=rows,
+        wells=wells,
+        name="Test Plate Writer",
+        field_count=2,
+        version="0.5",
+    )
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    ozx_path = OUTPUT_DIR / "test_plate_writer.ozx"
+
+    # Remove old file if exists
+    if ozx_path.exists():
+        ozx_path.unlink()
+
+    # Create test images
+    data1 = np.random.randint(0, 255, (2, 32, 32), dtype=np.uint8)
+    image1 = to_ngff_image(
+        data=data1,
+        dims=["c", "y", "x"],
+        scale={"y": 0.65, "x": 0.65},
+    )
+    multiscales1 = to_multiscales(image1, [2])
+
+    data2 = np.random.randint(0, 255, (2, 32, 32), dtype=np.uint8)
+    image2 = to_ngff_image(
+        data=data2,
+        dims=["c", "y", "x"],
+        scale={"y": 0.65, "x": 0.65},
+    )
+    multiscales2 = to_multiscales(image2, [2])
+
+    # Use context manager to write wells
+    with HCSPlateWriter(str(ozx_path), plate_metadata) as writer:
+        writer.write_well_image(
+            multiscales=multiscales1,
+            row_name="A",
+            column_name="1",
+            field_index=0,
+        )
+        writer.write_well_image(
+            multiscales=multiscales2,
+            row_name="A",
+            column_name="2",
+            field_index=0,
+        )
+
+    # Verify file was created and is a valid ZIP
+    assert ozx_path.exists()
+    assert zipfile.is_zipfile(ozx_path)
+
+    # Verify ZIP structure
+    with zipfile.ZipFile(ozx_path, 'r') as zf:
+        files = zf.namelist()
+        assert files[0] == "zarr.json"
+        
+        # Check for version
+        version_from_zip = read_ozx_version(ozx_path)
+        assert version_from_zip == "0.5"
+
+    # Read back and verify
+    plate_read = from_hcs_zarr(str(ozx_path))
+    assert plate_read.name == "Test Plate Writer"
+    assert len(plate_read.wells) == 2
+
+    # Verify wells
+    well1 = plate_read.get_well("A", "1")
+    assert well1 is not None
+    assert len(well1.images) == 1
+
+    well2 = plate_read.get_well("A", "2")
+    assert well2 is not None
+    assert len(well2.images) == 1
+
+
+def test_hcs_plate_writer_regular_zarr():
+    """Test HCSPlateWriter with regular .ome.zarr directory"""
+    columns = [PlateColumn(name="1")]
+    rows = [PlateRow(name="A")]
+    wells = [PlateWell(path="A/1", rowIndex=0, columnIndex=0)]
+    plate_metadata = Plate(
+        columns=columns,
+        rows=rows,
+        wells=wells,
+        version="0.5",
+    )
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    zarr_path = OUTPUT_DIR / "test_plate_writer_regular.ome.zarr"
+
+    # Remove old directory if exists
+    if zarr_path.exists():
+        import shutil
+        shutil.rmtree(zarr_path)
+
+    # Create test image
+    data = np.random.randint(0, 255, (2, 32, 32), dtype=np.uint8)
+    image = to_ngff_image(data=data, dims=["c", "y", "x"])
+    multiscales = to_multiscales(image)
+
+    # Use context manager
+    with HCSPlateWriter(str(zarr_path), plate_metadata) as writer:
+        writer.write_well_image(
+            multiscales=multiscales,
+            row_name="A",
+            column_name="1",
+            field_index=0,
+        )
+
+    # Verify directory was created
+    assert zarr_path.exists()
+    assert zarr_path.is_dir()
+
+    # Read back
+    plate_read = from_hcs_zarr(str(zarr_path))
+    well = plate_read.get_well("A", "1")
+    assert well is not None
+
+
+def test_hcs_plate_writer_multiple_fields():
+    """Test writing multiple fields to same well"""
+    columns = [PlateColumn(name="1")]
+    rows = [PlateRow(name="A")]
+    wells = [PlateWell(path="A/1", rowIndex=0, columnIndex=0)]
+    plate_metadata = Plate(
+        columns=columns,
+        rows=rows,
+        wells=wells,
+        field_count=3,
+        version="0.5",
+    )
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    ozx_path = OUTPUT_DIR / "test_multiple_fields.ozx"
+
+    if ozx_path.exists():
+        ozx_path.unlink()
+
+    # Create context manager and write multiple fields
+    with HCSPlateWriter(str(ozx_path), plate_metadata) as writer:
+        for field_idx in range(3):
+            data = np.random.randint(0, 255, (2, 32, 32), dtype=np.uint8)
+            image = to_ngff_image(data=data, dims=["c", "y", "x"])
+            multiscales = to_multiscales(image)
+            
+            writer.write_well_image(
+                multiscales=multiscales,
+                row_name="A",
+                column_name="1",
+                field_index=field_idx,
+            )
+
+    # Verify
+    plate_read = from_hcs_zarr(str(ozx_path))
+    well = plate_read.get_well("A", "1")
+    assert well is not None
+    assert len(well.images) == 3
+
+
+def test_hcs_plate_writer_parallel_writes():
+    """Test parallel writing using ThreadPoolExecutor"""
+    from concurrent.futures import ThreadPoolExecutor
+
+    # Create 2x2 plate
+    columns = [PlateColumn(name="1"), PlateColumn(name="2")]
+    rows = [PlateRow(name="A"), PlateRow(name="B")]
+    wells = [
+        PlateWell(path="A/1", rowIndex=0, columnIndex=0),
+        PlateWell(path="A/2", rowIndex=0, columnIndex=1),
+        PlateWell(path="B/1", rowIndex=1, columnIndex=0),
+        PlateWell(path="B/2", rowIndex=1, columnIndex=1),
+    ]
+    plate_metadata = Plate(
+        columns=columns,
+        rows=rows,
+        wells=wells,
+        version="0.5",
+    )
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    ozx_path = OUTPUT_DIR / "test_parallel.ozx"
+
+    if ozx_path.exists():
+        ozx_path.unlink()
+
+    # Prepare well data
+    well_data = []
+    for well in wells:
+        row_name, col_name = well.path.split("/")
+        data = np.random.randint(0, 255, (2, 32, 32), dtype=np.uint8)
+        image = to_ngff_image(data=data, dims=["c", "y", "x"])
+        multiscales = to_multiscales(image)
+        well_data.append((multiscales, row_name, col_name))
+
+    # Write in parallel
+    def write_well(args):
+        writer, multiscales, row, col = args
+        writer.write_well_image(
+            multiscales=multiscales,
+            row_name=row,
+            column_name=col,
+            field_index=0,
+        )
+
+    with HCSPlateWriter(str(ozx_path), plate_metadata) as writer:
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            executor.map(write_well, [(writer, *wd) for wd in well_data])
+
+    # Verify all wells were written
+    plate_read = from_hcs_zarr(str(ozx_path))
+    assert len(plate_read.wells) == 4
+
+    for well_meta in plate_read.wells:
+        row_name = plate_read.rows[well_meta.rowIndex].name
+        col_name = plate_read.columns[well_meta.columnIndex].name
+        well = plate_read.get_well(row_name, col_name)
+        assert well is not None
+        assert len(well.images) == 1
+
+
+def test_hcs_plate_writer_version_validation():
+    """Test that .ozx requires version 0.5"""
+    plate_metadata = Plate(
+        columns=[PlateColumn(name="1")],
+        rows=[PlateRow(name="A")],
+        wells=[PlateWell(path="A/1", rowIndex=0, columnIndex=0)],
+        version="0.4",
+    )
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    ozx_path = OUTPUT_DIR / "test_version_error.ozx"
+
+    # Should raise error for version 0.4 with .ozx
+    with pytest.raises(ValueError, match="RFC-9.*requires.*0.5"):
+        with HCSPlateWriter(str(ozx_path), plate_metadata, version="0.4"):
+            pass
+
+
+def test_hcs_plate_writer_exception_handling():
+    """Test that .ozx is not created if exception occurs"""
+    plate_metadata = Plate(
+        columns=[PlateColumn(name="1")],
+        rows=[PlateRow(name="A")],
+        wells=[PlateWell(path="A/1", rowIndex=0, columnIndex=0)],
+        version="0.5",
+    )
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    ozx_path = OUTPUT_DIR / "test_exception.ozx"
+
+    if ozx_path.exists():
+        ozx_path.unlink()
+
+    # Trigger exception inside context
+    try:
+        with HCSPlateWriter(str(ozx_path), plate_metadata) as _writer:
+            raise RuntimeError("Test exception")
+    except RuntimeError:
+        pass
+
+    # .ozx file should not be created due to exception
+    assert not ozx_path.exists()
+
+
+def test_hcs_plate_writer_default_version():
+    """Test that default version is 0.5"""
+    plate_metadata = Plate(
+        columns=[PlateColumn(name="1")],
+        rows=[PlateRow(name="A")],
+        wells=[PlateWell(path="A/1", rowIndex=0, columnIndex=0)],
+        version="0.5",
+    )
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    ozx_path = OUTPUT_DIR / "test_default_version.ozx"
+
+    if ozx_path.exists():
+        ozx_path.unlink()
+
+    # Don't specify version - should default to 0.5
+    with HCSPlateWriter(str(ozx_path), plate_metadata) as writer:
+        data = np.random.randint(0, 255, (2, 32, 32), dtype=np.uint8)
+        image = to_ngff_image(data=data, dims=["c", "y", "x"])
+        multiscales = to_multiscales(image)
+        
+        writer.write_well_image(
+            multiscales=multiscales,
+            row_name="A",
+            column_name="1",
+            field_index=0,
+        )
+
+    # Verify version is 0.5
+    version = read_ozx_version(ozx_path)
+    assert version == "0.5"
+
+
+def test_hcs_plate_writer_large_plate():
+    """Test writing a larger plate with multiple wells and fields"""
+    # Create 3x3 plate
+    columns = [PlateColumn(name=str(i)) for i in range(1, 4)]
+    rows = [PlateRow(name=chr(65 + i)) for i in range(3)]  # A, B, C
+    wells = []
+    for row_idx, row in enumerate(rows):
+        for col_idx, col in enumerate(columns):
+            wells.append(PlateWell(
+                path=f"{row.name}/{col.name}",
+                rowIndex=row_idx,
+                columnIndex=col_idx
+            ))
+
+    plate_metadata = Plate(
+        columns=columns,
+        rows=rows,
+        wells=wells,
+        name="Large Test Plate",
+        field_count=2,
+        version="0.5",
+    )
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    ozx_path = OUTPUT_DIR / "test_large_plate.ozx"
+
+    if ozx_path.exists():
+        ozx_path.unlink()
+
+    # Write all wells with 2 fields each
+    with HCSPlateWriter(str(ozx_path), plate_metadata) as writer:
+        for well in wells:
+            row_name, col_name = well.path.split("/")
+            for field_idx in range(2):
+                data = np.random.randint(0, 255, (2, 32, 32), dtype=np.uint8)
+                image = to_ngff_image(data=data, dims=["c", "y", "x"])
+                multiscales = to_multiscales(image)
+                
+                writer.write_well_image(
+                    multiscales=multiscales,
+                    row_name=row_name,
+                    column_name=col_name,
+                    field_index=field_idx,
+                )
+
+    # Verify all wells and fields
+    plate_read = from_hcs_zarr(str(ozx_path))
+    assert plate_read.name == "Large Test Plate"
+    assert len(plate_read.wells) == 9  # 3x3
+
+    # Check each well has 2 fields
+    for well_meta in plate_read.wells:
+        row_name = plate_read.rows[well_meta.rowIndex].name
+        col_name = plate_read.columns[well_meta.columnIndex].name
+        well = plate_read.get_well(row_name, col_name)
+        assert well is not None
+        assert len(well.images) == 2

--- a/py/test/test_write_store_to_zip.py
+++ b/py/test/test_write_store_to_zip.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Tests for write_store_to_zip public API"""
+
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import packaging.version
+import pytest
+import zarr
+
+from ngff_zarr import to_multiscales, to_ngff_image, to_ngff_zarr, write_store_to_zip
+from ngff_zarr.hcs import to_hcs_zarr, HCSPlate, from_hcs_zarr
+from ngff_zarr.rfc9_zip import read_ozx_version
+from ngff_zarr.v04.zarr_metadata import (
+    Plate,
+    PlateColumn,
+    PlateRow,
+    PlateWell,
+)
+
+zarr_version = packaging.version.parse(zarr.__version__)
+zarr_version_major = zarr_version.major
+
+# RFC-9 requires zarr v3 (OME-Zarr 0.5)
+pytestmark = pytest.mark.skipif(
+    zarr_version_major < 3, reason="RFC-9 requires zarr-python >= 3.0.0"
+)
+
+# Output directory for test files
+OUTPUT_DIR = Path(__file__).parent / "output"
+
+
+def test_write_store_to_zip_with_path_string():
+    """Test that users can call write_store_to_zip directly with a path string"""
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    
+    # Create a simple image and write it to a regular zarr store
+    data = np.random.randint(0, 255, (2, 64, 64), dtype=np.uint8)
+    image = to_ngff_image(
+        data=data,
+        dims=["c", "y", "x"],
+        scale={"y": 0.5, "x": 0.5},
+    )
+    multiscales = to_multiscales(image)
+    
+    zarr_path = OUTPUT_DIR / "test_image.ome.zarr"
+    ozx_path = OUTPUT_DIR / "test_image_converted.ozx"
+    
+    # Write to regular zarr store
+    to_ngff_zarr(str(zarr_path), multiscales, version="0.5")
+    
+    # Now convert to .ozx using write_store_to_zip with path string
+    write_store_to_zip(str(zarr_path), str(ozx_path), version="0.5")
+    
+    # Verify the .ozx file was created and is valid
+    assert ozx_path.exists()
+    assert zipfile.is_zipfile(ozx_path)
+    
+    # Check ZIP structure
+    with zipfile.ZipFile(ozx_path, 'r') as zf:
+        files = zf.namelist()
+        assert 'zarr.json' in files
+        assert files[0] == 'zarr.json'  # Root zarr.json must be first
+        
+    # Verify version in ZIP comment
+    version_from_zip = read_ozx_version(ozx_path)
+    assert version_from_zip == "0.5"
+
+
+def test_write_store_to_zip_hcs_plate():
+    """Test converting an HCS plate to .ozx after writing"""
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    
+    # Create plate metadata
+    columns = [PlateColumn(name="1"), PlateColumn(name="2")]
+    rows = [PlateRow(name="A")]
+    wells = [
+        PlateWell(path="A/1", rowIndex=0, columnIndex=0),
+        PlateWell(path="A/2", rowIndex=0, columnIndex=1),
+    ]
+    plate_metadata = Plate(
+        columns=columns,
+        rows=rows,
+        wells=wells,
+        name="Test Plate",
+        field_count=1,
+        version="0.5",
+    )
+    
+    # Create and write plate to regular zarr
+    plate_path = OUTPUT_DIR / "test_plate.ome.zarr"
+    plate = HCSPlate(store=str(plate_path), plate_metadata=plate_metadata)
+    to_hcs_zarr(plate, str(plate_path))
+    
+    # Add a well image
+    from ngff_zarr.hcs import write_hcs_well_image
+    
+    data = np.random.randint(0, 255, (2, 32, 32), dtype=np.uint8)
+    image = to_ngff_image(data=data, dims=["c", "y", "x"])
+    multiscales = to_multiscales(image)
+    
+    write_hcs_well_image(
+        store=str(plate_path),
+        multiscales=multiscales,
+        plate_metadata=plate_metadata,
+        row_name="A",
+        column_name="1",
+        field_index=0,
+        version="0.5",
+    )
+    
+    # Convert to .ozx
+    ozx_path = OUTPUT_DIR / "test_plate_converted.ozx"
+    write_store_to_zip(str(plate_path), str(ozx_path), version="0.5")
+    
+    # Verify the .ozx file
+    assert ozx_path.exists()
+    assert zipfile.is_zipfile(ozx_path)
+    
+    # Read it back
+    plate_read = from_hcs_zarr(str(ozx_path))
+    assert plate_read.name == "Test Plate"
+    assert len(plate_read.wells) == 2
+    
+    # Verify we can access well data
+    well = plate_read.get_well("A", "1")
+    assert well is not None
+    assert len(well.images) == 1
+
+
+def test_write_store_to_zip_with_path_object():
+    """Test that write_store_to_zip works with Path objects too"""
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    
+    # Create a simple image
+    data = np.random.randint(0, 255, (2, 32, 32), dtype=np.uint8)
+    image = to_ngff_image(data=data, dims=["c", "y", "x"])
+    multiscales = to_multiscales(image)
+    
+    zarr_path = OUTPUT_DIR / "test_path_obj.ome.zarr"
+    ozx_path = OUTPUT_DIR / "test_path_obj.ozx"
+    
+    # Write to regular zarr store
+    to_ngff_zarr(zarr_path, multiscales, version="0.5")
+    
+    # Convert using Path objects (not strings)
+    write_store_to_zip(zarr_path, ozx_path, version="0.5")
+    
+    # Verify
+    assert ozx_path.exists()
+    assert zipfile.is_zipfile(ozx_path)


### PR DESCRIPTION
Documentation on how to generate a .ozx RFC-9 Zip OME-Zarr from a
plate, support for writing a small number of individual wells,
a new helper class, HCSPlateWriter, for writing with a context
manager in parallel, and better documentation and ergonomics
on converting a directory OME-Zarr store to a .ozx.
