### PR TITLE
feat(ts): add RFC-9 (.ozx) zipped OME-Zarr support

### DIFF
--- a/ts/deno.json
+++ b/ts/deno.json
@@ -41,6 +41,7 @@
     "p-queue": "npm:p-queue@^8.1.0",
     "zod": "npm:zod@^4.0.2",
     "zarrita": "jsr:@zarrita/zarrita@^0.5.2",
+    "fflate": "npm:fflate@^0.8.2",
     "playwright/test": "npm:@playwright/test@^1.54.1"
   },
   "lint": {

--- a/ts/deno.lock
+++ b/ts/deno.lock
@@ -51,6 +51,7 @@
     "npm:@itk-wasm/image-io@^1.6.0": "1.6.0",
     "npm:@playwright/test@^1.54.1": "1.54.1",
     "npm:@types/node@*": "22.15.15",
+    "npm:fflate@~0.8.2": "0.8.2",
     "npm:itk-wasm@^1.0.0-b.196": "1.0.0-b.196",
     "npm:microdiff@^1.4.0": "1.5.0",
     "npm:numcodecs@~0.3.2": "0.3.2",
@@ -295,7 +296,7 @@
     "@itk-wasm/compare-images@5.4.1": {
       "integrity": "sha512-ocCaBMVLAavnB0NHFfDgjmeVvJdqGvZnCrVsxH8aeYsLE6KE+2tizN3qPDpGIdQ7xZGqL20fxpBEl7DLSN74xA==",
       "dependencies": [
-        "itk-wasm@1.0.0-b.196"
+        "itk-wasm"
       ]
     },
     "@itk-wasm/dam@1.1.1": {
@@ -313,14 +314,14 @@
     "@itk-wasm/downsample@1.8.1": {
       "integrity": "sha512-8j29GkeIECmMgS70DyLHnLMT81Ua5HZ28xSifhshEK2nERq6x4V8nm+CjJDpnKpNE3ZFe3cIY/MES5lr4iF/FQ==",
       "dependencies": [
-        "itk-wasm@1.0.0-b.196"
+        "itk-wasm"
       ]
     },
     "@itk-wasm/image-io@1.6.0": {
       "integrity": "sha512-cx+lHpTc3tmkfKMOMpuwGfQyhsYmac09NoOjeo5bOW45pp040boQiPow8Q/GQmjHUfI9c+H7SqeJCfKVS5SPRw==",
       "dependencies": [
         "axios",
-        "itk-wasm@1.0.0-b.195",
+        "itk-wasm",
         "mime-types"
       ]
     },
@@ -924,25 +925,6 @@
     "it-stream-types@2.0.2": {
       "integrity": "sha512-Rz/DEZ6Byn/r9+/SBCuJhpPATDF9D+dz5pbgSUyBsCDtza6wtNATrz/jz1gDyNanC3XdLboriHnOC925bZRBww=="
     },
-    "itk-wasm@1.0.0-b.195": {
-      "integrity": "sha512-UteObV3LlwRKBe4SfVseCzN371qXYZLC7raDKBEfP/SQ6CYgLPEYhCRYhu/vDsVxFs1pmg2UBUuW8l0LgSxLjg==",
-      "dependencies": [
-        "@emnapi/wasi-threads",
-        "@itk-wasm/dam",
-        "@thewtex/zstddec",
-        "@types/emscripten",
-        "axios",
-        "chalk",
-        "comlink",
-        "commander@11.1.0",
-        "fs-extra",
-        "glob",
-        "markdown-table",
-        "mime-types",
-        "wasm-feature-detect"
-      ],
-      "bin": true
-    },
     "itk-wasm@1.0.0-b.196": {
       "integrity": "sha512-LJoGEFQLgE2lKERTEOq9XFtMTnPUwR0TBWxTA/hI1QPqvXfVNHQGv+vzHTrRCq2GAM+vtWZuVt/XecTBBkN6Hg==",
       "dependencies": [
@@ -1221,7 +1203,8 @@
         "minizlib",
         "mkdirp",
         "yallist"
-      ]
+      ],
+      "deprecated": true
     },
     "through@2.3.8": {
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
@@ -1375,6 +1358,7 @@
       "npm:@itk-wasm/downsample@^1.8.1",
       "npm:@itk-wasm/image-io@^1.6.0",
       "npm:@playwright/test@^1.54.1",
+      "npm:fflate@~0.8.2",
       "npm:itk-wasm@^1.0.0-b.196",
       "npm:microdiff@^1.4.0",
       "npm:p-queue@^8.1.0",

--- a/ts/src/browser-mod.ts
+++ b/ts/src/browser-mod.ts
@@ -41,9 +41,22 @@ export {
   type MemoryStore,
 } from "./io/from_ngff_zarr-browser.ts";
 export {
+  isOzxPath,
   toNgffZarr,
   type ToNgffZarrOptions,
+  toNgffZarrOzx,
+  type ToNgffZarrOzxOptions,
 } from "./io/to_ngff_zarr-browser.ts";
+
+// RFC-9 exports
+export {
+  getZipFileCompressionMethod,
+  getZipFileList,
+  memoryStoreToZip,
+  orderFilesForRfc9,
+  readOzxVersion,
+} from "./io/rfc9_zip.ts";
+export type { MemoryStoreToZipOptions } from "./io/rfc9_zip.ts";
 
 // Browser-compatible processing modules
 export * from "./process/to_multiscales-browser.ts";

--- a/ts/src/io/rfc9_zip.ts
+++ b/ts/src/io/rfc9_zip.ts
@@ -1,0 +1,429 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+/**
+ * RFC-9: Zipped OME-Zarr (.ozx) support
+ *
+ * This module provides utilities for writing OME-Zarr hierarchies
+ * to ZIP archives according to RFC-9 specification.
+ *
+ * @see https://ngff.openmicroscopy.org/rfc/9/index.html
+ */
+
+import { zipSync } from "fflate";
+
+/** MemoryStore type for zarr data */
+export type MemoryStore = Map<string, Uint8Array>;
+
+/**
+ * Check if a path refers to a .ozx file.
+ *
+ * @param path - Path to check
+ * @returns True if path ends with .ozx extension
+ */
+export function isOzxPath(path: string): boolean {
+  return path.endsWith(".ozx");
+}
+
+/**
+ * Order files for RFC-9 compliance.
+ *
+ * According to RFC-9:
+ * - Root-level zarr.json must be the first entry
+ * - Other zarr.json files should follow in breadth-first order
+ * - Data files come after all zarr.json files
+ *
+ * @param keys - Array of file paths from the store
+ * @returns Ordered array of file paths
+ */
+export function orderFilesForRfc9(keys: string[]): string[] {
+  const zarrJsons = keys.filter((k) => k.endsWith("zarr.json"));
+  const others = keys.filter((k) => !k.endsWith("zarr.json"));
+
+  // Root zarr.json first
+  const rootIdx = zarrJsons.indexOf("zarr.json");
+  if (rootIdx > 0) {
+    zarrJsons.splice(rootIdx, 1);
+    zarrJsons.unshift("zarr.json");
+  }
+
+  // Sort by depth for breadth-first order
+  zarrJsons.sort((a, b) => {
+    if (a === "zarr.json") return -1;
+    if (b === "zarr.json") return 1;
+    return a.split("/").length - b.split("/").length;
+  });
+
+  return [...zarrJsons, ...others.sort()];
+}
+
+/**
+ * Add a ZIP comment to existing ZIP data.
+ *
+ * fflate doesn't support ZIP comments natively, so we manually
+ * modify the End of Central Directory (EOCD) record to add one.
+ *
+ * @param zipData - Original ZIP data
+ * @param comment - Comment string to add (UTF-8)
+ * @returns New ZIP data with comment
+ */
+function addZipComment(zipData: Uint8Array, comment: string): Uint8Array {
+  const commentBytes = new TextEncoder().encode(comment);
+
+  if (commentBytes.length > 65535) {
+    throw new Error("ZIP comment too long (max 65535 bytes)");
+  }
+
+  // Find EOCD signature (0x06054b50) searching from end
+  // EOCD is at least 22 bytes, so start searching from length - 22
+  let eocdOffset = -1;
+  for (let i = zipData.length - 22; i >= 0; i--) {
+    if (
+      zipData[i] === 0x50 &&
+      zipData[i + 1] === 0x4b &&
+      zipData[i + 2] === 0x05 &&
+      zipData[i + 3] === 0x06
+    ) {
+      eocdOffset = i;
+      break;
+    }
+  }
+
+  if (eocdOffset === -1) {
+    throw new Error("Invalid ZIP: End of Central Directory not found");
+  }
+
+  // Note: We could read current comment length at EOCD + 20, but we
+  // always replace any existing comment, so we just need the EOCD position.
+
+  // Calculate the size of ZIP without the current comment
+  const zipWithoutComment = eocdOffset + 22;
+
+  // Create new array: ZIP without old comment + new comment
+  const result = new Uint8Array(zipWithoutComment + commentBytes.length);
+
+  // Copy ZIP data up to and including EOCD (excluding old comment)
+  result.set(zipData.subarray(0, zipWithoutComment));
+
+  // Update comment length field (little-endian at EOCD + 20)
+  result[eocdOffset + 20] = commentBytes.length & 0xff;
+  result[eocdOffset + 21] = (commentBytes.length >> 8) & 0xff;
+
+  // Append new comment
+  result.set(commentBytes, zipWithoutComment);
+
+  return result;
+}
+
+/**
+ * Read the OME-Zarr version from ZIP comment.
+ *
+ * @param zipData - ZIP file data
+ * @returns OME-Zarr version string if found, null otherwise
+ */
+export function readOzxVersion(zipData: Uint8Array): string | null {
+  // Find EOCD signature searching from end
+  let eocdOffset = -1;
+  for (let i = zipData.length - 22; i >= 0; i--) {
+    if (
+      zipData[i] === 0x50 &&
+      zipData[i + 1] === 0x4b &&
+      zipData[i + 2] === 0x05 &&
+      zipData[i + 3] === 0x06
+    ) {
+      eocdOffset = i;
+      break;
+    }
+  }
+
+  if (eocdOffset === -1) {
+    return null;
+  }
+
+  // Get comment length (little-endian uint16 at EOCD + 20)
+  const commentLength = zipData[eocdOffset + 20] |
+    (zipData[eocdOffset + 21] << 8);
+
+  if (commentLength === 0) {
+    return null;
+  }
+
+  // Extract comment bytes
+  const commentStart = eocdOffset + 22;
+  const commentBytes = zipData.subarray(
+    commentStart,
+    commentStart + commentLength,
+  );
+
+  try {
+    const commentStr = new TextDecoder("utf-8").decode(commentBytes);
+    const commentObj = JSON.parse(commentStr);
+
+    if (commentObj?.ome?.version) {
+      return commentObj.ome.version;
+    }
+  } catch {
+    // Invalid JSON or encoding
+  }
+
+  return null;
+}
+
+/**
+ * Read the jsonFirst flag from ZIP comment.
+ *
+ * The jsonFirst flag indicates that zarr.json files are ordered
+ * breadth-first in the central directory and precede other content.
+ *
+ * @param zipData - ZIP file data
+ * @returns true if jsonFirst is set to true in the ZIP comment, false otherwise
+ */
+export function readOzxJsonFirst(zipData: Uint8Array): boolean {
+  // Find EOCD signature searching from end
+  let eocdOffset = -1;
+  for (let i = zipData.length - 22; i >= 0; i--) {
+    if (
+      zipData[i] === 0x50 &&
+      zipData[i + 1] === 0x4b &&
+      zipData[i + 2] === 0x05 &&
+      zipData[i + 3] === 0x06
+    ) {
+      eocdOffset = i;
+      break;
+    }
+  }
+
+  if (eocdOffset === -1) {
+    return false;
+  }
+
+  // Get comment length (little-endian uint16 at EOCD + 20)
+  const commentLength = zipData[eocdOffset + 20] |
+    (zipData[eocdOffset + 21] << 8);
+
+  if (commentLength === 0) {
+    return false;
+  }
+
+  // Extract comment bytes
+  const commentStart = eocdOffset + 22;
+  const commentBytes = zipData.subarray(
+    commentStart,
+    commentStart + commentLength,
+  );
+
+  try {
+    const commentStr = new TextDecoder("utf-8").decode(commentBytes);
+    const commentObj = JSON.parse(commentStr);
+
+    if (commentObj?.ome?.zipFile?.centralDirectory?.jsonFirst === true) {
+      return true;
+    }
+  } catch {
+    // Invalid JSON or encoding
+  }
+
+  return false;
+}
+
+/**
+ * Check if a file in the ZIP uses compression.
+ *
+ * @param zipData - ZIP file data
+ * @param filename - Name of the file to check
+ * @returns Compression method (0 = stored, 8 = deflate, etc.)
+ */
+export function getZipFileCompressionMethod(
+  zipData: Uint8Array,
+  filename: string,
+): number | null {
+  // Search for local file header with matching filename
+  const filenameBytes = new TextEncoder().encode(filename);
+  let offset = 0;
+
+  while (offset < zipData.length - 30) {
+    // Check for local file header signature (0x04034b50)
+    if (
+      zipData[offset] === 0x50 &&
+      zipData[offset + 1] === 0x4b &&
+      zipData[offset + 2] === 0x03 &&
+      zipData[offset + 3] === 0x04
+    ) {
+      // Get filename length (little-endian at offset + 26)
+      const nameLength = zipData[offset + 26] | (zipData[offset + 27] << 8);
+
+      // Get extra field length (little-endian at offset + 28)
+      const extraLength = zipData[offset + 28] | (zipData[offset + 29] << 8);
+
+      // Extract filename
+      const nameStart = offset + 30;
+      const nameEnd = nameStart + nameLength;
+
+      if (nameEnd <= zipData.length) {
+        const nameBytes = zipData.subarray(nameStart, nameEnd);
+
+        // Compare filenames
+        if (
+          nameBytes.length === filenameBytes.length &&
+          nameBytes.every((b, i) => b === filenameBytes[i])
+        ) {
+          // Found the file, return compression method (at offset + 8)
+          return zipData[offset + 8] | (zipData[offset + 9] << 8);
+        }
+      }
+
+      // Get compressed size to skip to next header
+      const compressedSize = zipData[offset + 18] |
+        (zipData[offset + 19] << 8) |
+        (zipData[offset + 20] << 16) |
+        (zipData[offset + 21] << 24);
+
+      offset = nameEnd + extraLength + compressedSize;
+    } else {
+      offset++;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Get the list of files in a ZIP archive in order.
+ *
+ * @param zipData - ZIP file data
+ * @returns Array of filenames in the order they appear in the central directory
+ */
+export function getZipFileList(zipData: Uint8Array): string[] {
+  const files: string[] = [];
+
+  // Find EOCD to get central directory location
+  let eocdOffset = -1;
+  for (let i = zipData.length - 22; i >= 0; i--) {
+    if (
+      zipData[i] === 0x50 &&
+      zipData[i + 1] === 0x4b &&
+      zipData[i + 2] === 0x05 &&
+      zipData[i + 3] === 0x06
+    ) {
+      eocdOffset = i;
+      break;
+    }
+  }
+
+  if (eocdOffset === -1) {
+    return files;
+  }
+
+  // Get central directory offset (little-endian uint32 at EOCD + 16)
+  let cdOffset = zipData[eocdOffset + 16] |
+    (zipData[eocdOffset + 17] << 8) |
+    (zipData[eocdOffset + 18] << 16) |
+    (zipData[eocdOffset + 19] << 24);
+
+  // Get number of entries (little-endian uint16 at EOCD + 10)
+  const numEntries = zipData[eocdOffset + 10] | (zipData[eocdOffset + 11] << 8);
+
+  // Parse central directory entries
+  for (let i = 0; i < numEntries && cdOffset < eocdOffset; i++) {
+    // Check for central directory file header signature (0x02014b50)
+    if (
+      zipData[cdOffset] !== 0x50 ||
+      zipData[cdOffset + 1] !== 0x4b ||
+      zipData[cdOffset + 2] !== 0x01 ||
+      zipData[cdOffset + 3] !== 0x02
+    ) {
+      break;
+    }
+
+    // Get filename length (little-endian at offset + 28)
+    const nameLength = zipData[cdOffset + 28] | (zipData[cdOffset + 29] << 8);
+
+    // Get extra field length (little-endian at offset + 30)
+    const extraLength = zipData[cdOffset + 30] | (zipData[cdOffset + 31] << 8);
+
+    // Get comment length (little-endian at offset + 32)
+    const commentLength = zipData[cdOffset + 32] |
+      (zipData[cdOffset + 33] << 8);
+
+    // Extract filename
+    const nameStart = cdOffset + 46;
+    const nameEnd = nameStart + nameLength;
+
+    if (nameEnd <= zipData.length) {
+      const filename = new TextDecoder("utf-8").decode(
+        zipData.subarray(nameStart, nameEnd),
+      );
+      files.push(filename);
+    }
+
+    // Move to next entry
+    cdOffset = nameEnd + extraLength + commentLength;
+  }
+
+  return files;
+}
+
+export interface MemoryStoreToZipOptions {
+  /** OME-Zarr version string (default: "0.5") */
+  version?: string;
+}
+
+/**
+ * Normalize a store key by removing leading slashes.
+ * zarrita uses leading slashes (e.g., "/zarr.json") but ZIP files
+ * should use relative paths (e.g., "zarr.json").
+ */
+function normalizeKey(key: string): string {
+  return key.startsWith("/") ? key.slice(1) : key;
+}
+
+/**
+ * Convert a MemoryStore to ZIP data following RFC-9 specification.
+ *
+ * According to RFC-9:
+ * - Root-level zarr.json must be the first entry
+ * - Other zarr.json files should follow in breadth-first order
+ * - ZIP-level compression should be disabled (ZIP_STORED)
+ * - A comment with OME-Zarr version should be added
+ *
+ * @param store - MemoryStore containing zarr data
+ * @param options - Options for ZIP creation
+ * @returns ZIP file data as Uint8Array
+ */
+export function memoryStoreToZip(
+  store: MemoryStore,
+  options: MemoryStoreToZipOptions = {},
+): Uint8Array {
+  const version = options.version ?? "0.5";
+
+  // Get all keys, normalize them (remove leading slashes from zarrita),
+  // and order them for RFC-9 compliance
+  const keys = Array.from(store.keys()).map(normalizeKey);
+  const orderedKeys = orderFilesForRfc9(keys);
+
+  // Build files object in the correct order
+  // Note: JavaScript objects maintain insertion order for string keys
+  const files: Record<string, Uint8Array> = {};
+  for (const key of orderedKeys) {
+    // Try both normalized and original key (with leading slash) for lookup
+    const data = store.get(key) ?? store.get("/" + key);
+    if (data) {
+      files[key] = data;
+    }
+  }
+
+  // Create ZIP with no compression (level: 0 = ZIP_STORED equivalent)
+  const zipData = zipSync(files, { level: 0 });
+
+  // Add OME-Zarr version comment as per RFC-9
+  // Include jsonFirst flag to indicate zarr.json files are ordered
+  // breadth-first and precede other content
+  const comment = JSON.stringify({
+    ome: {
+      version,
+      zipFile: { centralDirectory: { jsonFirst: true } },
+    },
+  });
+  const zipWithComment = addZipComment(zipData, comment);
+
+  return zipWithComment;
+}

--- a/ts/src/io/to_ngff_zarr-browser.ts
+++ b/ts/src/io/to_ngff_zarr-browser.ts
@@ -7,11 +7,23 @@ import type { Multiscales } from "../types/multiscales.ts";
 import type { NgffImage } from "../types/ngff_image.ts";
 import type { MemoryStore } from "./from_ngff_zarr-browser.ts";
 import { createQueue } from "../utils/create_queue.ts";
+import { memoryStoreToZip } from "./rfc9_zip.ts";
+import { writeMultiscalesToMemoryStore } from "./to_ngff_zarr_ozx_common.ts";
+export { isOzxPath } from "./rfc9_zip.ts";
 
 export interface ToNgffZarrOptions {
   overwrite?: boolean;
   version?: "0.4" | "0.5";
   chunksPerShard?: number | number[] | Record<string, number>;
+}
+
+/**
+ * Options for writing to .ozx (RFC-9) format.
+ * Note: chunksPerShard is NOT supported for .ozx files and will throw an error.
+ */
+export interface ToNgffZarrOzxOptions {
+  /** List of RFC numbers to enable (e.g., [4] for RFC 4 anatomical orientation) */
+  enabledRfcs?: number[] | undefined;
 }
 
 /**
@@ -226,7 +238,7 @@ function getChunksFromImage(image: NgffImage): number[] {
     return image.data.chunks;
   }
 
-  return image.data.shape.map((dim) => Math.min(dim, 1024));
+  return image.data.shape.map((dim: number) => Math.min(dim, 1024));
 }
 
 async function _writeArrayData(
@@ -451,4 +463,43 @@ function calculateChunkStride(chunkShape: number[]): number[] {
   }
 
   return stride;
+}
+
+/**
+ * Create OME-Zarr .ozx ZIP data (RFC-9) - Browser version.
+ *
+ * This function creates an OME-Zarr hierarchy in memory and returns
+ * the ZIP data as a Uint8Array. This is the browser-compatible version
+ * that returns the raw ZIP data for download or further processing.
+ *
+ * Note: Sharding is NOT supported because zarrita does not currently
+ * support writing shards. If you need sharding, use the Python implementation.
+ *
+ * @param multiscales - Multiscales data to write
+ * @param options - Options for writing
+ * @returns ZIP file data as Uint8Array
+ *
+ * @see https://ngff.openmicroscopy.org/rfc/9/index.html
+ */
+export async function toNgffZarrOzx(
+  multiscales: Multiscales,
+  _options: ToNgffZarrOzxOptions = {},
+): Promise<Uint8Array> {
+  const enabledRfcs = _options.enabledRfcs;
+
+  // Create a memory store to hold the zarr data
+  const memoryStore: MemoryStore = new Map<string, Uint8Array>();
+
+  // Use the shared write function
+  await writeMultiscalesToMemoryStore(
+    memoryStore,
+    multiscales,
+    enabledRfcs,
+    _writeImage,
+  );
+
+  // Convert the memory store to ZIP data
+  const zipData = memoryStoreToZip(memoryStore, { version: "0.5" });
+
+  return zipData;
 }

--- a/ts/src/io/to_ngff_zarr.ts
+++ b/ts/src/io/to_ngff_zarr.ts
@@ -5,17 +5,60 @@ import type { Multiscales } from "../types/multiscales.ts";
 import type { NgffImage } from "../types/ngff_image.ts";
 import type { MemoryStore } from "./from_ngff_zarr.ts";
 import { createQueue } from "../utils/create_queue.ts";
-import type { Axis } from "../types/zarr_metadata.ts";
-import { isRfc4Enabled } from "../types/rfc4.ts";
+import { isOzxPath, memoryStoreToZip } from "./rfc9_zip.ts";
+import {
+  processAxesForRfcs,
+  writeMultiscalesToMemoryStore,
+} from "./to_ngff_zarr_ozx_common.ts";
 
 export interface ToNgffZarrOptions {
   overwrite?: boolean;
+  /**
+   * OME-Zarr version to write. Defaults to "0.4" for regular Zarr files.
+   * For .ozx files (RFC-9), this must be version 0.5. If omitted for .ozx files,
+   * it defaults to 0.5. If explicitly set to any other value for .ozx files,
+   * an error will be thrown.
+   */
   version?: "0.4" | "0.5";
   chunksPerShard?: number | number[] | Record<string, number>;
   /** List of RFC numbers to enable (e.g., [4] for RFC 4 anatomical orientation) */
   enabledRfcs?: number[];
 }
 
+/**
+ * Options for writing to .ozx (RFC-9) format.
+ * Note: chunksPerShard is NOT supported for .ozx files and will throw an error.
+ */
+export interface ToNgffZarrOzxOptions {
+  /** List of RFC numbers to enable (e.g., [4] for RFC 4 anatomical orientation) */
+  enabledRfcs?: number[] | undefined;
+}
+
+/**
+ * Write multiscales data to an OME-Zarr store.
+ *
+ * This function automatically detects .ozx paths (RFC-9 zipped OME-Zarr format)
+ * and handles them appropriately. For .ozx files:
+ * - Version 0.5 is always used when the version option is omitted (undefined)
+ * - Sharding (chunksPerShard) is not supported
+ * - An error is thrown if you explicitly specify a version other than "0.5"
+ *
+ * @param store - File path, MemoryStore, or FetchStore to write to
+ * @param multiscales - Multiscales data to write
+ * @param options - Writing options
+ *
+ * @example
+ * ```typescript
+ * // Writing to .ozx file - version 0.5 is used automatically
+ * await toNgffZarr("output.ozx", multiscales);
+ *
+ * // Writing to regular zarr with version 0.4 (default)
+ * await toNgffZarr("output.zarr", multiscales);
+ *
+ * // Writing to regular zarr with version 0.5
+ * await toNgffZarr("output.zarr", multiscales, { version: "0.5" });
+ * ```
+ */
 export async function toNgffZarr(
   store: string | MemoryStore | zarr.FetchStore,
   multiscales: Multiscales,
@@ -24,6 +67,32 @@ export async function toNgffZarr(
   const _overwrite = options.overwrite ?? true;
   const _version = options.version ?? "0.4";
   const enabledRfcs = options.enabledRfcs;
+
+  // Handle .ozx paths (RFC-9)
+  if (typeof store === "string" && isOzxPath(store)) {
+    // Validate version - RFC-9 requires version 0.5
+    // If no version is specified (undefined), we silently default to 0.5
+    // If a version is explicitly specified and it's not 0.5, throw an error
+    if (options.version !== undefined && options.version !== "0.5") {
+      throw new Error(
+        "RFC-9 (.ozx) requires OME-Zarr version 0.5. " +
+          `Got version "${options.version}". ` +
+          "For .ozx files, either omit the version option or explicitly set it to '0.5'.",
+      );
+    }
+
+    // Throw error if chunksPerShard is specified
+    if (options.chunksPerShard !== undefined) {
+      throw new Error(
+        "RFC-9 (.ozx) does not support sharding (chunksPerShard). " +
+          "zarrita does not currently support writing shards.",
+      );
+    }
+
+    // Delegate to toNgffZarrOzx (which always uses version 0.5)
+    await toNgffZarrOzx(store, multiscales, { enabledRfcs });
+    return;
+  }
 
   try {
     // Determine the appropriate store type based on the path
@@ -244,7 +313,7 @@ function getChunksFromImage(image: NgffImage): number[] {
     return image.data.chunks;
   }
 
-  return image.data.shape.map((dim) => Math.min(dim, 1024));
+  return image.data.shape.map((dim: number) => Math.min(dim, 1024));
 }
 
 async function _writeArrayData(
@@ -472,35 +541,102 @@ function calculateChunkStride(chunkShape: number[]): number[] {
 }
 
 /**
- * Process axes for RFC enablement.
- * If RFC 4 is enabled, include orientation metadata.
- * If RFC 4 is not enabled, strip orientation from axes.
+ * Write OME-Zarr to .ozx ZIP file (RFC-9).
+ *
+ * This function creates an OME-Zarr hierarchy in memory and then writes it
+ * to a ZIP file following RFC-9 specification:
+ * - Root-level zarr.json is the first entry
+ * - Other zarr.json files follow in breadth-first order
+ * - ZIP-level compression is disabled (ZIP_STORED)
+ * - A comment with OME-Zarr version is added
+ *
+ * Note: Sharding is NOT supported because zarrita does not currently
+ * support writing shards. If you need sharding, use the Python implementation.
+ *
+ * @param path - Output .ozx file path
+ * @param multiscales - Multiscales data to write
+ * @param options - Options for writing
+ * @throws Error if called in a browser environment (use toNgffZarrOzxData instead)
+ *
+ * @see https://ngff.openmicroscopy.org/rfc/9/index.html
  */
-function processAxesForRfcs(
-  axes: Axis[],
+export async function toNgffZarrOzx(
+  path: string,
+  multiscales: Multiscales,
+  options: ToNgffZarrOzxOptions = {},
+): Promise<void> {
+  // Check for browser environment
+  if (typeof window !== "undefined") {
+    throw new Error(
+      "toNgffZarrOzx cannot write files in browser environments. " +
+        "Use toNgffZarrOzxData to get the ZIP data as Uint8Array.",
+    );
+  }
+
+  // Get the ZIP data
+  const zipData = await toNgffZarrOzxData(multiscales, options);
+
+  // Write to file using fs module (works in both Node.js and Deno)
+  try {
+    // Use dynamic import for Node.js fs module
+    // Deno also supports node:fs/promises via its Node compatibility layer
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(path, zipData);
+  } catch (error) {
+    throw new Error(
+      `Failed to write .ozx file: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+/**
+ * Create OME-Zarr .ozx ZIP data (RFC-9).
+ *
+ * This function creates an OME-Zarr hierarchy in memory and returns
+ * the ZIP data as a Uint8Array. Useful for browser environments or
+ * when you need the raw ZIP data.
+ *
+ * @param multiscales - Multiscales data to write
+ * @param options - Options for writing
+ * @returns ZIP file data as Uint8Array
+ *
+ * @see https://ngff.openmicroscopy.org/rfc/9/index.html
+ */
+export async function toNgffZarrOzxData(
+  multiscales: Multiscales,
+  options: ToNgffZarrOzxOptions = {},
+): Promise<Uint8Array> {
+  const enabledRfcs = options.enabledRfcs;
+
+  // Create a memory store to hold the zarr data
+  const memoryStore: MemoryStore = new Map<string, Uint8Array>();
+
+  // Write to the memory store using existing toNgffZarr logic
+  // but we need to inline the core logic since toNgffZarr would
+  // try to detect .ozx again
+  await _writeToMemoryStore(memoryStore, multiscales, enabledRfcs);
+
+  // Convert the memory store to ZIP data
+  const zipData = memoryStoreToZip(memoryStore, { version: "0.5" });
+
+  return zipData;
+}
+
+/**
+ * Internal function to write multiscales to a memory store.
+ * Used by toNgffZarrOzxData to avoid recursion with toNgffZarr.
+ */
+async function _writeToMemoryStore(
+  store: MemoryStore,
+  multiscales: Multiscales,
   enabledRfcs?: number[],
-): Record<string, unknown>[] {
-  const rfc4Enabled = isRfc4Enabled(enabledRfcs);
-
-  return axes.map((axis) => {
-    const result: Record<string, unknown> = {
-      name: axis.name,
-      type: axis.type,
-    };
-
-    // Include unit if present
-    if (axis.unit !== undefined) {
-      result.unit = axis.unit;
-    }
-
-    // Include orientation only if RFC 4 is enabled and orientation exists
-    if (rfc4Enabled && axis.orientation) {
-      result.orientation = {
-        type: axis.orientation.type,
-        value: axis.orientation.value,
-      };
-    }
-
-    return result;
-  });
+): Promise<void> {
+  await writeMultiscalesToMemoryStore(
+    store,
+    multiscales,
+    enabledRfcs,
+    _writeImage,
+  );
 }

--- a/ts/src/io/to_ngff_zarr_ozx_common.ts
+++ b/ts/src/io/to_ngff_zarr_ozx_common.ts
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+/**
+ * Shared internal utilities for RFC-9 (.ozx) writing
+ * Used by both Node and browser implementations to avoid code duplication
+ */
+
+import * as zarr from "zarrita";
+import type { Multiscales } from "../types/multiscales.ts";
+import type { NgffImage } from "../types/ngff_image.ts";
+import type { Axis } from "../types/zarr_metadata.ts";
+import type { MemoryStore } from "./rfc9_zip.ts";
+import { isRfc4Enabled } from "../types/rfc4.ts";
+
+/**
+ * Process axes for RFC enablement.
+ * If RFC 4 is enabled, include orientation metadata.
+ * If RFC 4 is not enabled, strip orientation from axes.
+ */
+export function processAxesForRfcs(
+  axes: Axis[],
+  enabledRfcs?: number[],
+): Record<string, unknown>[] {
+  const rfc4Enabled = isRfc4Enabled(enabledRfcs);
+
+  return axes.map((axis) => {
+    const result: Record<string, unknown> = {
+      name: axis.name,
+      type: axis.type,
+    };
+
+    // Include unit if present
+    if (axis.unit !== undefined) {
+      result.unit = axis.unit;
+    }
+
+    // Include orientation only if RFC 4 is enabled and orientation exists
+    if (rfc4Enabled && axis.orientation) {
+      result.orientation = {
+        type: axis.orientation.type,
+        value: axis.orientation.value,
+      };
+    }
+
+    return result;
+  });
+}
+
+/**
+ * Validate that the Multiscales metadata version is compatible with RFC-9.
+ * RFC-9 always uses version 0.5.
+ *
+ * @param multiscales - Multiscales object to validate
+ * @throws Error if metadata.version is defined and not "0.5"
+ */
+export function validateRfc9Version(multiscales: Multiscales): void {
+  const providedVersion = multiscales.metadata.version;
+  if (providedVersion !== undefined && providedVersion !== "0.5") {
+    throw new Error(
+      `Inconsistent NGFF version in Multiscales metadata: expected "0.5" for RFC-9 OZX export, but got "${providedVersion}".`,
+    );
+  }
+}
+
+/**
+ * Prepare multiscales metadata for RFC-9 export.
+ * This includes processing axes for RFC enablement and setting version to 0.5.
+ *
+ * @param multiscales - Source multiscales data
+ * @param enabledRfcs - Optional list of RFC numbers to enable
+ * @returns Prepared metadata object
+ */
+export function prepareRfc9Metadata(
+  multiscales: Multiscales,
+  enabledRfcs?: number[],
+): Record<string, unknown> {
+  const _version = "0.5";
+
+  // Process axes - filter orientation based on enabledRfcs
+  const processedAxes = processAxesForRfcs(
+    multiscales.metadata.axes,
+    enabledRfcs,
+  );
+
+  return {
+    version: _version,
+    name: multiscales.metadata.name,
+    axes: processedAxes,
+    datasets: multiscales.metadata.datasets,
+    ...(multiscales.metadata.coordinateTransformations && {
+      coordinateTransformations: multiscales.metadata.coordinateTransformations,
+    }),
+    ...(multiscales.metadata.type && {
+      type: multiscales.metadata.type,
+    }),
+    ...(multiscales.metadata.metadata && {
+      metadata: multiscales.metadata.metadata,
+    }),
+  };
+}
+
+/**
+ * Create root group attributes for RFC-9 export.
+ *
+ * @param multiscalesMetadata - Prepared multiscales metadata
+ * @param multiscales - Original multiscales (for OMERO metadata)
+ * @returns Attributes object for root group
+ */
+export function createRfc9RootAttributes(
+  multiscalesMetadata: Record<string, unknown>,
+  multiscales: Multiscales,
+): Record<string, unknown> {
+  const _version = "0.5";
+
+  const attributes: Record<string, unknown> = {
+    ome: {
+      version: _version,
+      multiscales: [multiscalesMetadata],
+    },
+  };
+
+  // Add OMERO metadata at root level if present
+  if (multiscales.metadata.omero) {
+    attributes.omero = multiscales.metadata.omero;
+  }
+
+  return attributes;
+}
+
+/**
+ * Write multiscales data to a memory store for RFC-9 export.
+ * This is the shared implementation used by both Node and browser versions.
+ *
+ * @param store - Memory store to write to
+ * @param multiscales - Multiscales data to write
+ * @param enabledRfcs - Optional list of RFC numbers to enable
+ * @param writeImage - Function to write individual images
+ */
+export async function writeMultiscalesToMemoryStore(
+  store: MemoryStore,
+  multiscales: Multiscales,
+  enabledRfcs: number[] | undefined,
+  writeImage: (
+    group: zarr.Group<MemoryStore>,
+    image: NgffImage,
+    path: string,
+  ) => Promise<void>,
+): Promise<void> {
+  // Validate version
+  validateRfc9Version(multiscales);
+
+  // Create root location and group with zarrita API
+  const root = zarr.root(store);
+
+  // Prepare metadata
+  const multiscalesMetadata = prepareRfc9Metadata(multiscales, enabledRfcs);
+
+  // Create root attributes
+  const attributes = createRfc9RootAttributes(multiscalesMetadata, multiscales);
+
+  const rootGroup = await zarr.create(root, { attributes });
+
+  // Write each image in the multiscales
+  for (let i = 0; i < multiscales.images.length; i++) {
+    const image = multiscales.images[i];
+    const dataset = multiscales.metadata.datasets[i];
+
+    if (!dataset) {
+      throw new Error(`No dataset configuration found for image ${i}`);
+    }
+
+    await writeImage(rootGroup as zarr.Group<MemoryStore>, image, dataset.path);
+  }
+}

--- a/ts/src/mod.ts
+++ b/ts/src/mod.ts
@@ -43,3 +43,15 @@ export type { MemoryStore } from "./io/from_ngff_zarr.ts";
 export * from "./io/itk_image_to_ngff_image.ts";
 export * from "./io/ngff_image_to_itk_image.ts";
 export * from "./io/hcs.ts";
+
+// RFC-9 exports
+export {
+  getZipFileCompressionMethod,
+  getZipFileList,
+  isOzxPath,
+  memoryStoreToZip,
+  orderFilesForRfc9,
+  readOzxJsonFirst,
+  readOzxVersion,
+} from "./io/rfc9_zip.ts";
+export type { MemoryStoreToZipOptions } from "./io/rfc9_zip.ts";

--- a/ts/test/browser-npm/ngff-zarr.test.js
+++ b/ts/test/browser-npm/ngff-zarr.test.js
@@ -327,6 +327,167 @@ test.describe("fromNgffZarr Browser Tests", () => {
   });
 });
 
+test.describe("RFC-9 Browser Tests", () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to the bundle test page (which has access to the bundle)
+    await page.goto("/bundle-test");
+
+    // Wait for the page to fully load
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("should have RFC-9 functions available in browser bundle", async ({ page }) => {
+    const loadResult = await page.evaluate(async () => {
+      try {
+        const ngffZarr = await import("./ngff-zarr.bundle.js");
+        return {
+          success: true,
+          hasIsOzxPath: "isOzxPath" in ngffZarr,
+          hasToNgffZarrOzx: "toNgffZarrOzx" in ngffZarr,
+          hasMemoryStoreToZip: "memoryStoreToZip" in ngffZarr,
+          hasOrderFilesForRfc9: "orderFilesForRfc9" in ngffZarr,
+          hasReadOzxVersion: "readOzxVersion" in ngffZarr,
+          typeOfIsOzxPath: typeof ngffZarr.isOzxPath,
+          typeOfToNgffZarrOzx: typeof ngffZarr.toNgffZarrOzx,
+          typeOfMemoryStoreToZip: typeof ngffZarr.memoryStoreToZip,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error.message,
+        };
+      }
+    });
+
+    expect(loadResult.success).toBeTruthy();
+    expect(loadResult.hasIsOzxPath).toBeTruthy();
+    expect(loadResult.hasToNgffZarrOzx).toBeTruthy();
+    expect(loadResult.hasMemoryStoreToZip).toBeTruthy();
+    expect(loadResult.hasOrderFilesForRfc9).toBeTruthy();
+    expect(loadResult.hasReadOzxVersion).toBeTruthy();
+    expect(loadResult.typeOfIsOzxPath).toBe("function");
+    expect(loadResult.typeOfToNgffZarrOzx).toBe("function");
+    expect(loadResult.typeOfMemoryStoreToZip).toBe("function");
+  });
+
+  test("isOzxPath should correctly detect .ozx paths", async ({ page }) => {
+    const pathResult = await page.evaluate(async () => {
+      try {
+        const { isOzxPath } = await import("./ngff-zarr.bundle.js");
+        return {
+          success: true,
+          ozxPath: isOzxPath("test.ozx"),
+          ozxPathWithDir: isOzxPath("/path/to/file.ozx"),
+          zarrPath: isOzxPath("test.zarr"),
+          zipPath: isOzxPath("test.zip"),
+          noExtension: isOzxPath("ozx"),
+          upperCase: isOzxPath("test.OZX"),
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error.message,
+        };
+      }
+    });
+
+    expect(pathResult.success).toBeTruthy();
+    expect(pathResult.ozxPath).toBe(true);
+    expect(pathResult.ozxPathWithDir).toBe(true);
+    expect(pathResult.zarrPath).toBe(false);
+    expect(pathResult.zipPath).toBe(false);
+    expect(pathResult.noExtension).toBe(false);
+    expect(pathResult.upperCase).toBe(false); // Case sensitive
+  });
+
+  test("memoryStoreToZip should create valid ZIP data", async ({ page }) => {
+    const zipResult = await page.evaluate(async () => {
+      try {
+        const { memoryStoreToZip, readOzxVersion } = await import(
+          "./ngff-zarr.bundle.js"
+        );
+
+        // Create a simple memory store
+        const store = new Map();
+        store.set("zarr.json", new TextEncoder().encode('{"zarr_format": 3}'));
+        store.set(
+          "scale0/zarr.json",
+          new TextEncoder().encode('{"zarr_format": 3}'),
+        );
+
+        // Convert to ZIP
+        const zipData = memoryStoreToZip(store, { version: "0.5" });
+
+        // Verify it's a Uint8Array
+        const isUint8Array = zipData instanceof Uint8Array;
+
+        // Verify ZIP magic number (PK\x03\x04)
+        const hasZipMagic = zipData[0] === 0x50 && zipData[1] === 0x4b &&
+          zipData[2] === 0x03 && zipData[3] === 0x04;
+
+        // Read back the version from the ZIP comment
+        const version = readOzxVersion(zipData);
+
+        return {
+          success: true,
+          isUint8Array,
+          hasZipMagic,
+          zipSize: zipData.length,
+          version,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error.message,
+        };
+      }
+    });
+
+    expect(zipResult.success).toBeTruthy();
+    expect(zipResult.isUint8Array).toBe(true);
+    expect(zipResult.hasZipMagic).toBe(true);
+    expect(zipResult.zipSize).toBeGreaterThan(0);
+    expect(zipResult.version).toBe("0.5");
+  });
+
+  test("orderFilesForRfc9 should order files correctly", async ({ page }) => {
+    const orderResult = await page.evaluate(async () => {
+      try {
+        const { orderFilesForRfc9 } = await import("./ngff-zarr.bundle.js");
+
+        // Test with files in wrong order
+        const files = [
+          "c/0/0",
+          "scale0/zarr.json",
+          "zarr.json",
+          "scale1/zarr.json",
+        ];
+        const ordered = orderFilesForRfc9(files);
+
+        return {
+          success: true,
+          ordered,
+          firstIsRootZarrJson: ordered[0] === "zarr.json",
+          zarrJsonsBeforeData: ordered.indexOf("c/0/0") >
+            ordered.indexOf("scale1/zarr.json"),
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error.message,
+        };
+      }
+    });
+
+    expect(orderResult.success).toBeTruthy();
+    expect(orderResult.firstIsRootZarrJson).toBe(true);
+    expect(orderResult.zarrJsonsBeforeData).toBe(true);
+  });
+
+  // Note: Version validation test is covered in Deno tests (rfc9_test.ts)
+  // Browser tests cannot easily create zarr arrays without zarrita import
+});
+
 test.describe("toNgffZarr Browser Tests", () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to the bundle test page (which has access to the bundle)

--- a/ts/test/rfc9_test.ts
+++ b/ts/test/rfc9_test.ts
@@ -1,0 +1,769 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+/**
+ * Tests for RFC-9: Zipped OME-Zarr (.ozx) support
+ *
+ * @see https://ngff.openmicroscopy.org/rfc/9/index.html
+ */
+
+import { assertEquals, assertExists, assertRejects } from "@std/assert";
+import { join } from "@std/path";
+import { readImageNode } from "@itk-wasm/image-io";
+
+import {
+  getZipFileCompressionMethod,
+  getZipFileList,
+  isOzxPath,
+  memoryStoreToZip,
+  orderFilesForRfc9,
+  readOzxJsonFirst,
+  readOzxVersion,
+} from "../src/io/rfc9_zip.ts";
+import { toNgffZarr, toNgffZarrOzx } from "../src/io/to_ngff_zarr.ts";
+import { itkImageToNgffImage } from "../src/io/itk_image_to_ngff_image.ts";
+import { toMultiscales } from "../src/process/to_multiscales-node.ts";
+import { Methods } from "../src/types/methods.ts";
+import {
+  createAxis,
+  createDataset,
+  createMetadata,
+  createMultiscales,
+} from "../src/utils/factory.ts";
+import { NgffImage } from "../src/types/ngff_image.ts";
+import * as zarr from "zarrita";
+
+// Path to Python test data directory
+const TEST_DATA_DIR = join(Deno.cwd(), "..", "py", "test", "data");
+const INPUT_DIR = join(TEST_DATA_DIR, "input");
+const OUTPUT_DIR = join(Deno.cwd(), "test", "output");
+
+// Ensure output directory exists
+await Deno.mkdir(OUTPUT_DIR, { recursive: true });
+
+// ============================================================================
+// isOzxPath tests
+// ============================================================================
+
+Deno.test("isOzxPath - detects .ozx extension", () => {
+  assertEquals(isOzxPath("test.ozx"), true);
+  assertEquals(isOzxPath("/path/to/file.ozx"), true);
+  assertEquals(isOzxPath("C:\\path\\to\\file.ozx"), true);
+  assertEquals(isOzxPath("file.OZX"), false); // Case sensitive
+});
+
+Deno.test("isOzxPath - rejects non-.ozx extensions", () => {
+  assertEquals(isOzxPath("test.zarr"), false);
+  assertEquals(isOzxPath("test.ome.zarr"), false);
+  assertEquals(isOzxPath("test.zip"), false);
+  assertEquals(isOzxPath("test.ozx.bak"), false);
+  assertEquals(isOzxPath("ozx"), false);
+});
+
+// ============================================================================
+// orderFilesForRfc9 tests
+// ============================================================================
+
+Deno.test("orderFilesForRfc9 - root zarr.json first", () => {
+  const files = ["scale0/zarr.json", "zarr.json", "scale1/zarr.json"];
+  const ordered = orderFilesForRfc9(files);
+
+  assertEquals(ordered[0], "zarr.json");
+});
+
+Deno.test("orderFilesForRfc9 - breadth-first zarr.json ordering", () => {
+  const files = [
+    "scale0/image/zarr.json",
+    "zarr.json",
+    "scale0/zarr.json",
+    "scale1/image/zarr.json",
+    "scale1/zarr.json",
+    "c/0/0",
+  ];
+  const ordered = orderFilesForRfc9(files);
+
+  // zarr.json files should come first, in breadth-first order
+  assertEquals(ordered[0], "zarr.json");
+  // Level 1 (depth 2) before level 2 (depth 3)
+  const zarrJsons = ordered.filter((f) => f.endsWith("zarr.json"));
+  assertEquals(zarrJsons[0], "zarr.json");
+  // scale0/zarr.json and scale1/zarr.json before deeper ones
+  assertEquals(zarrJsons[1].split("/").length, 2);
+  assertEquals(zarrJsons[2].split("/").length, 2);
+
+  // Data files should come after all zarr.json files
+  const dataFileIndex = ordered.indexOf("c/0/0");
+  const lastZarrJsonIndex = ordered.lastIndexOf(
+    ordered.filter((f) => f.endsWith("zarr.json")).pop()!,
+  );
+  assertEquals(dataFileIndex > lastZarrJsonIndex, true);
+});
+
+// ============================================================================
+// memoryStoreToZip tests
+// ============================================================================
+
+Deno.test("memoryStoreToZip - creates valid ZIP", () => {
+  // Create a simple memory store
+  const store = new Map<string, Uint8Array>();
+  store.set("zarr.json", new TextEncoder().encode('{"zarr_format": 3}'));
+  store.set("scale0/zarr.json", new TextEncoder().encode('{"zarr_format": 3}'));
+  store.set("c/0/0", new Uint8Array([1, 2, 3, 4]));
+
+  const zipData = memoryStoreToZip(store, { version: "0.5" });
+
+  // Verify it's a valid ZIP (magic number)
+  assertEquals(zipData[0], 0x50); // 'P'
+  assertEquals(zipData[1], 0x4b); // 'K'
+  assertEquals(zipData[2], 0x03); // Local file header
+  assertEquals(zipData[3], 0x04);
+});
+
+Deno.test("memoryStoreToZip - adds ZIP comment with version and jsonFirst", () => {
+  const store = new Map<string, Uint8Array>();
+  store.set("zarr.json", new TextEncoder().encode('{"zarr_format": 3}'));
+
+  const zipData = memoryStoreToZip(store, { version: "0.5" });
+  const version = readOzxVersion(zipData);
+
+  assertEquals(version, "0.5");
+
+  // Verify jsonFirst flag is set
+  const jsonFirst = readOzxJsonFirst(zipData);
+  assertEquals(jsonFirst, true);
+});
+
+Deno.test("memoryStoreToZip - orders files correctly", () => {
+  const store = new Map<string, Uint8Array>();
+  // Add in wrong order
+  store.set("c/0/0", new Uint8Array([1, 2, 3, 4]));
+  store.set("scale0/zarr.json", new TextEncoder().encode("{}"));
+  store.set("zarr.json", new TextEncoder().encode("{}"));
+
+  const zipData = memoryStoreToZip(store);
+  const files = getZipFileList(zipData);
+
+  // root zarr.json should be first
+  assertEquals(files[0], "zarr.json");
+  // Then other zarr.json files
+  assertEquals(files[1], "scale0/zarr.json");
+  // Data files last
+  assertEquals(files[2], "c/0/0");
+});
+
+Deno.test("memoryStoreToZip - uses no compression (ZIP_STORED)", () => {
+  const store = new Map<string, Uint8Array>();
+  store.set("zarr.json", new TextEncoder().encode('{"zarr_format": 3}'));
+  store.set("data", new Uint8Array(1000).fill(42)); // Compressible data
+
+  const zipData = memoryStoreToZip(store);
+
+  // Check compression method for each file (should be 0 = stored)
+  const zarrJsonCompression = getZipFileCompressionMethod(zipData, "zarr.json");
+  const dataCompression = getZipFileCompressionMethod(zipData, "data");
+
+  assertEquals(zarrJsonCompression, 0); // ZIP_STORED
+  assertEquals(dataCompression, 0); // ZIP_STORED
+});
+
+// ============================================================================
+// readOzxJsonFirst tests
+// ============================================================================
+
+Deno.test("readOzxJsonFirst - returns true for valid OZX files", () => {
+  // Create a memory store and generate ZIP with jsonFirst flag
+  const store = new Map<string, Uint8Array>();
+  store.set("zarr.json", new TextEncoder().encode('{"zarr_format": 3}'));
+  store.set("scale0/zarr.json", new TextEncoder().encode('{"zarr_format": 3}'));
+  store.set("c/0/0", new Uint8Array([1, 2, 3, 4]));
+
+  const zipData = memoryStoreToZip(store, { version: "0.5" });
+
+  // Verify jsonFirst flag is set
+  assertEquals(readOzxJsonFirst(zipData), true);
+});
+
+Deno.test("readOzxJsonFirst - returns false for ZIP without comment", async () => {
+  // Create a minimal ZIP without comment using fflate
+  const { zipSync } = await import("fflate");
+  const zipData = zipSync({ "test.txt": new TextEncoder().encode("test") });
+
+  assertEquals(readOzxJsonFirst(zipData), false);
+});
+
+Deno.test("readOzxJsonFirst - returns false for ZIP with non-JSON comment", () => {
+  // Create ZIP with memoryStoreToZip then manually replace the comment
+  const store = new Map<string, Uint8Array>();
+  store.set("zarr.json", new TextEncoder().encode('{"zarr_format": 3}'));
+  const zipData = memoryStoreToZip(store);
+
+  // Find EOCD and modify comment to be non-JSON
+  let eocdOffset = -1;
+  for (let i = zipData.length - 22; i >= 0; i--) {
+    if (
+      zipData[i] === 0x50 &&
+      zipData[i + 1] === 0x4b &&
+      zipData[i + 2] === 0x05 &&
+      zipData[i + 3] === 0x06
+    ) {
+      eocdOffset = i;
+      break;
+    }
+  }
+
+  // Create new ZIP with non-JSON comment
+  const badComment = new TextEncoder().encode("This is not JSON");
+  const result = new Uint8Array(eocdOffset + 22 + badComment.length);
+  result.set(zipData.subarray(0, eocdOffset + 22));
+  result[eocdOffset + 20] = badComment.length & 0xff;
+  result[eocdOffset + 21] = (badComment.length >> 8) & 0xff;
+  result.set(badComment, eocdOffset + 22);
+
+  assertEquals(readOzxJsonFirst(result), false);
+});
+
+Deno.test("readOzxJsonFirst - returns false for ZIP with missing ome key", () => {
+  const store = new Map<string, Uint8Array>();
+  store.set("zarr.json", new TextEncoder().encode('{"zarr_format": 3}'));
+  const zipData = memoryStoreToZip(store);
+
+  // Find EOCD and replace comment with JSON missing ome key
+  let eocdOffset = -1;
+  for (let i = zipData.length - 22; i >= 0; i--) {
+    if (
+      zipData[i] === 0x50 &&
+      zipData[i + 1] === 0x4b &&
+      zipData[i + 2] === 0x05 &&
+      zipData[i + 3] === 0x06
+    ) {
+      eocdOffset = i;
+      break;
+    }
+  }
+
+  const newComment = new TextEncoder().encode(
+    JSON.stringify({ other: "data" }),
+  );
+  const result = new Uint8Array(eocdOffset + 22 + newComment.length);
+  result.set(zipData.subarray(0, eocdOffset + 22));
+  result[eocdOffset + 20] = newComment.length & 0xff;
+  result[eocdOffset + 21] = (newComment.length >> 8) & 0xff;
+  result.set(newComment, eocdOffset + 22);
+
+  assertEquals(readOzxJsonFirst(result), false);
+});
+
+Deno.test("readOzxJsonFirst - returns false for ZIP with missing zipFile key", () => {
+  const store = new Map<string, Uint8Array>();
+  store.set("zarr.json", new TextEncoder().encode('{"zarr_format": 3}'));
+  const zipData = memoryStoreToZip(store);
+
+  // Find EOCD and replace comment
+  let eocdOffset = -1;
+  for (let i = zipData.length - 22; i >= 0; i--) {
+    if (
+      zipData[i] === 0x50 &&
+      zipData[i + 1] === 0x4b &&
+      zipData[i + 2] === 0x05 &&
+      zipData[i + 3] === 0x06
+    ) {
+      eocdOffset = i;
+      break;
+    }
+  }
+
+  const newComment = new TextEncoder().encode(
+    JSON.stringify({ ome: { version: "0.5" } }),
+  );
+  const result = new Uint8Array(eocdOffset + 22 + newComment.length);
+  result.set(zipData.subarray(0, eocdOffset + 22));
+  result[eocdOffset + 20] = newComment.length & 0xff;
+  result[eocdOffset + 21] = (newComment.length >> 8) & 0xff;
+  result.set(newComment, eocdOffset + 22);
+
+  assertEquals(readOzxJsonFirst(result), false);
+});
+
+Deno.test("readOzxJsonFirst - returns false for ZIP with jsonFirst set to false", () => {
+  const store = new Map<string, Uint8Array>();
+  store.set("zarr.json", new TextEncoder().encode('{"zarr_format": 3}'));
+  const zipData = memoryStoreToZip(store);
+
+  // Find EOCD and replace comment
+  let eocdOffset = -1;
+  for (let i = zipData.length - 22; i >= 0; i--) {
+    if (
+      zipData[i] === 0x50 &&
+      zipData[i + 1] === 0x4b &&
+      zipData[i + 2] === 0x05 &&
+      zipData[i + 3] === 0x06
+    ) {
+      eocdOffset = i;
+      break;
+    }
+  }
+
+  const newComment = new TextEncoder().encode(
+    JSON.stringify({
+      ome: {
+        version: "0.5",
+        zipFile: { centralDirectory: { jsonFirst: false } },
+      },
+    }),
+  );
+  const result = new Uint8Array(eocdOffset + 22 + newComment.length);
+  result.set(zipData.subarray(0, eocdOffset + 22));
+  result[eocdOffset + 20] = newComment.length & 0xff;
+  result[eocdOffset + 21] = (newComment.length >> 8) & 0xff;
+  result.set(newComment, eocdOffset + 22);
+
+  assertEquals(readOzxJsonFirst(result), false);
+});
+
+// ============================================================================
+// toNgffZarrOzx tests with synthetic data
+// ============================================================================
+
+Deno.test("toNgffZarrOzx - creates valid .ozx file", async () => {
+  // Create synthetic test data
+  const store = new Map<string, Uint8Array>();
+  const root = zarr.root(store);
+  const shape = [10, 20];
+  const chunks = [5, 10];
+
+  const array = await zarr.create(root.resolve("data"), {
+    shape,
+    chunk_shape: chunks,
+    data_type: "uint8",
+    fill_value: 0,
+  });
+
+  // Fill with test data
+  const testData = new Uint8Array(shape[0] * shape[1]);
+  for (let i = 0; i < testData.length; i++) {
+    testData[i] = i % 256;
+  }
+  await zarr.set(array, null, {
+    data: testData,
+    shape,
+    stride: [shape[1], 1],
+  });
+
+  // Create NgffImage
+  const image = new NgffImage({
+    data: array,
+    dims: ["y", "x"],
+    scale: { y: 1.0, x: 1.0 },
+    translation: { y: 0.0, x: 0.0 },
+    name: "test",
+    axesUnits: undefined,
+    computedCallbacks: undefined,
+  });
+
+  // Create multiscales
+  const axes = [
+    createAxis("y", "space", "micrometer"),
+    createAxis("x", "space", "micrometer"),
+  ];
+  const datasets = [createDataset("scale0/image", [1.0, 1.0], [0.0, 0.0])];
+  const metadata = createMetadata(axes, datasets, "test", "0.5");
+  const multiscales = createMultiscales([image], metadata);
+
+  // Write to .ozx file
+  const ozxPath = join(OUTPUT_DIR, "test_synthetic.ozx");
+  await toNgffZarrOzx(ozxPath, multiscales);
+
+  // Verify file exists
+  const fileInfo = await Deno.stat(ozxPath);
+  assertEquals(fileInfo.isFile, true);
+
+  // Read the file and verify ZIP structure
+  const zipData = await Deno.readFile(ozxPath);
+
+  // Verify version comment
+  const version = readOzxVersion(zipData);
+  assertEquals(version, "0.5");
+
+  // Verify jsonFirst flag
+  const jsonFirst = readOzxJsonFirst(zipData);
+  assertEquals(jsonFirst, true);
+
+  // Verify file ordering
+  const files = getZipFileList(zipData);
+  assertEquals(files[0], "zarr.json");
+
+  console.log("  Created synthetic .ozx file:", ozxPath);
+});
+
+// ============================================================================
+// toNgffZarr with .ozx path tests
+// ============================================================================
+
+Deno.test("toNgffZarr - detects .ozx path and writes correctly", async () => {
+  // Create synthetic test data
+  const store = new Map<string, Uint8Array>();
+  const root = zarr.root(store);
+  const shape = [8, 8];
+  const chunks = [4, 4];
+
+  const array = await zarr.create(root.resolve("data"), {
+    shape,
+    chunk_shape: chunks,
+    data_type: "uint8",
+    fill_value: 0,
+  });
+
+  const testData = new Uint8Array(shape[0] * shape[1]).fill(42);
+  await zarr.set(array, null, {
+    data: testData,
+    shape,
+    stride: [shape[1], 1],
+  });
+
+  const image = new NgffImage({
+    data: array,
+    dims: ["y", "x"],
+    scale: { y: 1.0, x: 1.0 },
+    translation: { y: 0.0, x: 0.0 },
+    name: "test",
+    axesUnits: undefined,
+    computedCallbacks: undefined,
+  });
+
+  const axes = [
+    createAxis("y", "space", "micrometer"),
+    createAxis("x", "space", "micrometer"),
+  ];
+  const datasets = [createDataset("scale0/image", [1.0, 1.0], [0.0, 0.0])];
+  const metadata = createMetadata(axes, datasets, "test", "0.5");
+  const multiscales = createMultiscales([image], metadata);
+
+  // Use toNgffZarr with .ozx path - should auto-detect and use RFC-9
+  const ozxPath = join(OUTPUT_DIR, "test_auto_detect.ozx");
+  await toNgffZarr(ozxPath, multiscales, { version: "0.5" });
+
+  // Verify file was created as valid .ozx
+  const zipData = await Deno.readFile(ozxPath);
+  const version = readOzxVersion(zipData);
+  assertEquals(version, "0.5");
+
+  console.log("  Auto-detected .ozx path:", ozxPath);
+});
+
+Deno.test("toNgffZarr - requires version 0.5 for .ozx", async () => {
+  const store = new Map<string, Uint8Array>();
+  const root = zarr.root(store);
+  const array = await zarr.create(root.resolve("data"), {
+    shape: [4, 4],
+    chunk_shape: [4, 4],
+    data_type: "uint8",
+    fill_value: 0,
+  });
+
+  const image = new NgffImage({
+    data: array,
+    dims: ["y", "x"],
+    scale: { y: 1.0, x: 1.0 },
+    translation: { y: 0.0, x: 0.0 },
+    name: "test",
+    axesUnits: undefined,
+    computedCallbacks: undefined,
+  });
+
+  const axes = [createAxis("y", "space"), createAxis("x", "space")];
+  const datasets = [createDataset("scale0/image", [1.0, 1.0], [0.0, 0.0])];
+  const metadata = createMetadata(axes, datasets, "test", "0.5");
+  const multiscales = createMultiscales([image], metadata);
+
+  const ozxPath = join(OUTPUT_DIR, "test_version_error.ozx");
+
+  // Should throw error for version 0.4
+  await assertRejects(
+    async () => {
+      await toNgffZarr(ozxPath, multiscales, { version: "0.4" });
+    },
+    Error,
+    "RFC-9 (.ozx) requires OME-Zarr version 0.5",
+  );
+});
+
+Deno.test("toNgffZarr - allows .ozx without specifying version", async () => {
+  // This test verifies that .ozx files work correctly when no version is specified
+  // The function should silently default to version 0.5
+  const store = new Map<string, Uint8Array>();
+  const root = zarr.root(store);
+  const array = await zarr.create(root.resolve("data"), {
+    shape: [4, 4],
+    chunk_shape: [4, 4],
+    data_type: "uint8",
+    fill_value: 0,
+  });
+
+  const testData = new Uint8Array(16).fill(42);
+  await zarr.set(array, null, {
+    data: testData,
+    shape: [4, 4],
+    stride: [4, 1],
+  });
+
+  const image = new NgffImage({
+    data: array,
+    dims: ["y", "x"],
+    scale: { y: 1.0, x: 1.0 },
+    translation: { y: 0.0, x: 0.0 },
+    name: "test",
+    axesUnits: undefined,
+    computedCallbacks: undefined,
+  });
+
+  const axes = [createAxis("y", "space"), createAxis("x", "space")];
+  const datasets = [createDataset("scale0/image", [1.0, 1.0], [0.0, 0.0])];
+  const metadata = createMetadata(axes, datasets, "test", "0.5");
+  const multiscales = createMultiscales([image], metadata);
+
+  const ozxPath = join(OUTPUT_DIR, "test_no_version.ozx");
+
+  // Should succeed without specifying version (defaults to 0.5 for .ozx)
+  await toNgffZarr(ozxPath, multiscales);
+
+  // Verify the file was created correctly
+  const zipData = await Deno.readFile(ozxPath);
+  const version = readOzxVersion(zipData);
+  assertEquals(version, "0.5");
+
+  console.log("  Created .ozx file without version option:", ozxPath);
+});
+
+Deno.test("toNgffZarr - allows .ozx with explicit version 0.5", async () => {
+  // This test verifies that explicitly specifying version 0.5 works correctly
+  const store = new Map<string, Uint8Array>();
+  const root = zarr.root(store);
+  const array = await zarr.create(root.resolve("data"), {
+    shape: [4, 4],
+    chunk_shape: [4, 4],
+    data_type: "uint8",
+    fill_value: 0,
+  });
+
+  const testData = new Uint8Array(16).fill(42);
+  await zarr.set(array, null, {
+    data: testData,
+    shape: [4, 4],
+    stride: [4, 1],
+  });
+
+  const image = new NgffImage({
+    data: array,
+    dims: ["y", "x"],
+    scale: { y: 1.0, x: 1.0 },
+    translation: { y: 0.0, x: 0.0 },
+    name: "test",
+    axesUnits: undefined,
+    computedCallbacks: undefined,
+  });
+
+  const axes = [createAxis("y", "space"), createAxis("x", "space")];
+  const datasets = [createDataset("scale0/image", [1.0, 1.0], [0.0, 0.0])];
+  const metadata = createMetadata(axes, datasets, "test", "0.5");
+  const multiscales = createMultiscales([image], metadata);
+
+  const ozxPath = join(OUTPUT_DIR, "test_explicit_version.ozx");
+
+  // Should succeed with explicit version 0.5
+  await toNgffZarr(ozxPath, multiscales, { version: "0.5" });
+
+  // Verify the file was created correctly
+  const zipData = await Deno.readFile(ozxPath);
+  const version = readOzxVersion(zipData);
+  assertEquals(version, "0.5");
+
+  console.log("  Created .ozx file with explicit version 0.5:", ozxPath);
+});
+
+Deno.test("toNgffZarr - throws error on chunksPerShard for .ozx", async () => {
+  const store = new Map<string, Uint8Array>();
+  const root = zarr.root(store);
+  const array = await zarr.create(root.resolve("data"), {
+    shape: [4, 4],
+    chunk_shape: [4, 4],
+    data_type: "uint8",
+    fill_value: 0,
+  });
+
+  const image = new NgffImage({
+    data: array,
+    dims: ["y", "x"],
+    scale: { y: 1.0, x: 1.0 },
+    translation: { y: 0.0, x: 0.0 },
+    name: "test",
+    axesUnits: undefined,
+    computedCallbacks: undefined,
+  });
+
+  const axes = [createAxis("y", "space"), createAxis("x", "space")];
+  const datasets = [createDataset("scale0/image", [1.0, 1.0], [0.0, 0.0])];
+  const metadata = createMetadata(axes, datasets, "test", "0.5");
+  const multiscales = createMultiscales([image], metadata);
+
+  const ozxPath = join(OUTPUT_DIR, "test_sharding_error.ozx");
+
+  // Should throw error for chunksPerShard
+  await assertRejects(
+    async () => {
+      await toNgffZarr(ozxPath, multiscales, {
+        version: "0.5",
+        chunksPerShard: 2,
+      });
+    },
+    Error,
+    "RFC-9 (.ozx) does not support sharding",
+  );
+});
+
+Deno.test("toNgffZarrOzx - rejects conflicting metadata version", async () => {
+  // Test that toNgffZarrOzx throws an error when the Multiscales object
+  // has a metadata.version that doesn't match the required 0.5
+  const store = new Map<string, Uint8Array>();
+  const root = zarr.root(store);
+  const array = await zarr.create(root.resolve("data"), {
+    shape: [4, 4],
+    chunk_shape: [4, 4],
+    data_type: "uint8",
+    fill_value: 0,
+  });
+
+  const image = new NgffImage({
+    data: array,
+    dims: ["y", "x"],
+    scale: { y: 1.0, x: 1.0 },
+    translation: { y: 0.0, x: 0.0 },
+    name: "test",
+    axesUnits: undefined,
+    computedCallbacks: undefined,
+  });
+
+  const axes = [createAxis("y", "space"), createAxis("x", "space")];
+  const datasets = [createDataset("scale0/image", [1.0, 1.0], [0.0, 0.0])];
+  // Create metadata with version "0.4" - this should conflict with RFC-9
+  const metadata = createMetadata(axes, datasets, "test", "0.4");
+  const multiscales = createMultiscales([image], metadata);
+
+  const ozxPath = join(OUTPUT_DIR, "test_metadata_version_error.ozx");
+
+  // Should throw error because metadata.version is "0.4" but RFC-9 requires "0.5"
+  await assertRejects(
+    async () => {
+      await toNgffZarrOzx(ozxPath, multiscales);
+    },
+    Error,
+    "Inconsistent NGFF version in Multiscales metadata",
+  );
+});
+
+// ============================================================================
+// Integration tests with real Python test data
+// ============================================================================
+
+Deno.test("RFC-9 roundtrip with cthead1.png", async () => {
+  // Read input image from Python test data
+  const inputPath = join(INPUT_DIR, "cthead1.png");
+  const itkImage = await readImageNode(inputPath);
+  assertExists(itkImage);
+
+  // Convert to NgffImage
+  const ngffImage = await itkImageToNgffImage(itkImage, {
+    addAnatomicalOrientation: false,
+    path: "scale0/image",
+  });
+
+  // Generate multiscales with downsampling
+  const multiscales = await toMultiscales(ngffImage, {
+    scaleFactors: [2],
+    method: Methods.ITKWASM_GAUSSIAN,
+  });
+
+  // RFC-9 requires version 0.5, so set it explicitly
+  multiscales.metadata.version = "0.5";
+
+  // Write to .ozx file
+  const ozxPath = join(OUTPUT_DIR, "cthead1_rfc9.ozx");
+  await toNgffZarrOzx(ozxPath, multiscales);
+
+  // Read the file and verify
+  const zipData = await Deno.readFile(ozxPath);
+
+  // Verify version
+  const version = readOzxVersion(zipData);
+  assertEquals(version, "0.5");
+
+  // Verify jsonFirst flag
+  const jsonFirst = readOzxJsonFirst(zipData);
+  assertEquals(jsonFirst, true);
+
+  // Verify file ordering
+  const files = getZipFileList(zipData);
+  assertEquals(files[0], "zarr.json");
+
+  // All zarr.json files should come before data files
+  const zarrJsonFiles = files.filter((f) => f.endsWith("zarr.json"));
+  const otherFiles = files.filter((f) => !f.endsWith("zarr.json"));
+
+  if (otherFiles.length > 0) {
+    const lastZarrJsonIndex = files.indexOf(
+      zarrJsonFiles[zarrJsonFiles.length - 1],
+    );
+    const firstOtherIndex = files.indexOf(otherFiles[0]);
+    assertEquals(
+      lastZarrJsonIndex < firstOtherIndex,
+      true,
+      "All zarr.json files should come before data files",
+    );
+  }
+
+  // Verify no compression
+  for (const file of files.slice(0, 3)) {
+    // Check first few files
+    const compression = getZipFileCompressionMethod(zipData, file);
+    assertEquals(compression, 0, `File ${file} should use ZIP_STORED`);
+  }
+
+  console.log("  Created cthead1 .ozx file:", ozxPath);
+  console.log("  File count:", files.length);
+  console.log("  zarr.json files:", zarrJsonFiles.length);
+});
+
+Deno.test("RFC-9 with MR-head.nrrd (3D data)", async () => {
+  // Read input image from Python test data
+  const inputPath = join(INPUT_DIR, "MR-head.nrrd");
+  const itkImage = await readImageNode(inputPath);
+  assertExists(itkImage);
+
+  // Convert to NgffImage
+  const ngffImage = await itkImageToNgffImage(itkImage, {
+    addAnatomicalOrientation: false,
+    path: "scale0/image",
+  });
+
+  // Generate multiscales
+  const multiscales = await toMultiscales(ngffImage, {
+    scaleFactors: [2],
+    method: Methods.ITKWASM_GAUSSIAN,
+  });
+
+  // RFC-9 requires version 0.5, so set it explicitly
+  multiscales.metadata.version = "0.5";
+
+  // Write to .ozx file
+  const ozxPath = join(OUTPUT_DIR, "mr_head_rfc9.ozx");
+  await toNgffZarrOzx(ozxPath, multiscales);
+
+  // Read and verify
+  const zipData = await Deno.readFile(ozxPath);
+  const version = readOzxVersion(zipData);
+  assertEquals(version, "0.5");
+
+  const files = getZipFileList(zipData);
+  assertEquals(files[0], "zarr.json");
+
+  console.log("  Created MR-head .ozx file:", ozxPath);
+  console.log("  File count:", files.length);
+});


### PR DESCRIPTION
Add support for writing OME-Zarr data to ZIP archives following RFC-9
specification (https://ngff.openmicroscopy.org/rfc/9/index.html).

New features:
- toNgffZarrOzx() function for explicit .ozx writing
- toNgffZarr() auto-detects .ozx paths and handles them
- memoryStoreToZip() utility for converting MemoryStore to ZIP data
- Browser support returns Uint8Array, Node/Deno writes to file

RFC-9 compliance:
- Root zarr.json is first entry in ZIP
- Other zarr.json files follow in breadth-first order
- ZIP_STORED (no compression) for all files
- ZIP comment contains OME-Zarr version metadata

Constraints (per zarrita limitations):
- Requires OME-Zarr version 0.5
- Sharding (chunksPerShard) not supported - throws error
- Reading .ozx files not implemented (zarrita bug)

Uses fflate for ZIP creation with custom ZIP comment handling.

Includes 14 Deno tests and 4 browser tests (Chromium, Firefox, WebKit,
Mobile Chrome, Mobile Safari).
