### PR TITLE
feat: add Leica Image Format (LIF) support

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,7 +19,8 @@ pip install 'ngff-zarr[cli]'
 
 Convert any scientific image file format supported by either
 [itk](https://wasm.itk.org/docs/image_formats),
-[tifffile](https://pypi.org/project/tifffile/), or
+[tifffile](https://pypi.org/project/tifffile/),
+[liffile](https://pypi.org/project/liffile/) (Leica LIF), or
 [imageio](https://imageio.readthedocs.io/en/stable/formats/index.html).
 
 Example:
@@ -29,6 +30,28 @@ ngff-zarr -i ./MR-head.nrrd -o ./MR-head.ome.zarr
 ```
 
 ![ngff-zarr convert](https://i.imgur.com/I7gTG52.png)
+
+### Convert a Leica LIF file
+
+Convert all series from a LIF file:
+
+```shell
+ngff-zarr -i microscopy.lif -o output/
+```
+
+Convert a specific series by index:
+
+```shell
+ngff-zarr -i microscopy.lif -o output.ome.zarr --series 0
+```
+
+Convert series matching a pattern:
+
+```shell
+ngff-zarr -i microscopy.lif -o output/ --series "*GFP*"
+```
+
+For more details on LIF conversion, see [Leica LIF Support](./lif.md).
 
 ### Convert an image volume slice series
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ A lean and kind
 - [Anatomical orientation metadata](./rfc4.md) (RFC-4)
 - **OME-Zarr Zip (.ozx) file support** for single-file OME-Zarr datasets (RFC-9)
 - **High Content Screening (HCS) support** for plate and well data
+- **Leica Image Format (LIF) support** for Leica microscopy data
 - **Model Context Protocol (MCP) server** for AI agent integration
 
 ```{toctree}
@@ -44,6 +45,7 @@ typescript.md
 cli.md
 mcp.md
 hcs.md
+lif.md
 spec_features.md
 itk.md
 methods.md

--- a/docs/lif.md
+++ b/docs/lif.md
@@ -1,0 +1,285 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC -->
+<!-- SPDX-License-Identifier: MIT -->
+# Leica Image Format (LIF) Support
+
+NGFF-Zarr provides comprehensive support for converting Leica Image Format (LIF)
+files to OME-Zarr. LIF is a proprietary format used by Leica microscopy systems
+to store multi-dimensional imaging data, including confocal, widefield, and
+super-resolution microscopy images.
+
+## Background
+
+Leica Image Format (LIF) files are commonly produced by Leica microscopy
+systems, including:
+
+- Leica SP (confocal) series microscopes
+- Leica THUNDER imaging systems
+- Leica STELLARIS systems
+- Leica DMi8 and other widefield systems
+
+LIF files can contain:
+
+- **Multiple series**: Several independent image datasets in a single file
+- **Multi-dimensional data**: X, Y, Z (depth), T (time), C (channels), and M (mosaic/tiles)
+- **Channel information**: Emission (λ), excitation (Λ), and RGB (S) wavelengths
+- **Calibration data**: Pixel sizes, timestamps, and coordinate transformations
+- **Mosaic/tile data**: Large area scans composed of multiple tiles
+
+## Installation
+
+To enable LIF support, install ngff-zarr with the CLI optional dependencies:
+
+```shell
+pip install 'ngff-zarr[cli]'
+```
+
+This installs the [liffile](https://pypi.org/project/liffile/) library for
+reading LIF files.
+
+## Supported File Extensions
+
+- `.lif` - Leica Image Format
+- `.lof` - Leica Object Format
+- `.xlif` - Leica XML Image Format
+- `.xlef` - Leica XML Experiment Format
+- `.xlcf` - Leica XML Configuration Format
+
+## Command Line Usage
+
+### Convert a LIF file
+
+Convert all series from a LIF file:
+
+```shell
+ngff-zarr -i microscopy_data.lif -o output/
+```
+
+Each series in the LIF file will be converted to a separate `.ome.zarr`
+directory within the output folder.
+
+### Convert a specific series by index
+
+```shell
+ngff-zarr -i microscopy_data.lif -o output.ome.zarr --series 0
+```
+
+### Convert series matching a pattern
+
+Use glob patterns to select series by name:
+
+```shell
+# Convert all series containing "GFP"
+ngff-zarr -i microscopy_data.lif -o output/ --series "*GFP*"
+
+# Convert series starting with "Experiment"
+ngff-zarr -i microscopy_data.lif -o output/ --series "Experiment*"
+```
+
+### Inspect LIF file contents
+
+To see information about the series in a LIF file without converting:
+
+```shell
+ngff-zarr -i microscopy_data.lif
+```
+
+### Mosaic/Tile Data (HCS Output)
+
+When a LIF series contains mosaic data (M dimension > 1), ngff-zarr
+automatically converts it to an HCS (High Content Screening) plate structure:
+
+```shell
+ngff-zarr -i tile_scan.lif -o tile_scan.ome.zarr
+```
+
+The output will have the standard HCS plate/well/field hierarchy, making it
+compatible with plate viewers and analysis tools.
+
+## Python API
+
+### Convert a single LIF image
+
+```python
+from liffile import LifFile
+from ngff_zarr import lif_to_ngff_image, to_multiscales, to_ngff_zarr
+
+# Open LIF file and convert first series
+with LifFile("microscopy_data.lif") as lif:
+    # Convert the first image to NgffImage
+    ngff_image = lif_to_ngff_image(lif.images[0])
+
+    print(f"Dimensions: {ngff_image.dims}")
+    print(f"Shape: {ngff_image.data.shape}")
+    print(f"Scale: {ngff_image.scale}")
+
+    # Generate multiscales and write to OME-Zarr
+    multiscales = to_multiscales(ngff_image, scale_factors=[2, 4])
+    to_ngff_zarr("output.ome.zarr", multiscales)
+```
+
+### Convert multiple series with filtering
+
+```python
+from ngff_zarr import lif_file_to_ngff_images, to_multiscales, to_ngff_zarr
+
+# Convert all series
+images = lif_file_to_ngff_images("microscopy_data.lif")
+for name, ngff_image in images:
+    print(f"Series: {name}, Shape: {ngff_image.data.shape}")
+
+# Convert specific series by index
+images = lif_file_to_ngff_images("microscopy_data.lif", series=0)
+
+# Convert series matching a pattern
+images = lif_file_to_ngff_images("microscopy_data.lif", series="*GFP*")
+
+# Process and write each series
+for name, ngff_image in images:
+    multiscales = to_multiscales(ngff_image, scale_factors=[2, 4])
+    to_ngff_zarr(f"{name}.ome.zarr", multiscales)
+```
+
+### Convert mosaic data to HCS plate
+
+```python
+from liffile import LifFile
+from ngff_zarr import (
+    lif_to_ngff_image,
+    lif_to_hcs_plate,
+    has_mosaic_dimension,
+    to_multiscales,
+)
+from ngff_zarr.hcs import HCSPlateWriter
+
+with LifFile("tile_scan.lif") as lif:
+    lif_image = lif.images[0]
+
+    # Check if image has mosaic dimension
+    if has_mosaic_dimension(lif_image):
+        # Convert to HCS plate structure
+        plate_metadata, well_images = lif_to_hcs_plate(
+            lif_image,
+            plate_name="TileScan"
+        )
+
+        # Write as HCS plate
+        with HCSPlateWriter("tile_scan.ome.zarr", plate_metadata) as writer:
+            for row_name, column_name, field_index, field_image in well_images:
+                multiscales = to_multiscales(field_image, scale_factors=[2, 4])
+                writer.write_well_image(
+                    multiscales=multiscales,
+                    row_name=row_name,
+                    column_name=column_name,
+                    field_index=field_index,
+                )
+    else:
+        # Standard image conversion
+        ngff_image = lif_to_ngff_image(lif_image)
+        multiscales = to_multiscales(ngff_image, scale_factors=[2, 4])
+        to_ngff_zarr("output.ome.zarr", multiscales)
+```
+
+### Access metadata
+
+```python
+from liffile import LifFile
+from ngff_zarr import lif_to_ngff_image
+
+with LifFile("microscopy_data.lif") as lif:
+    for i, lif_image in enumerate(lif.images):
+        ngff_image = lif_to_ngff_image(lif_image)
+
+        print(f"\nSeries {i}: {lif_image.path}")
+        print(f"  Dimensions: {ngff_image.dims}")
+        print(f"  Shape: {ngff_image.data.shape}")
+        print(f"  Scale (pixel size): {ngff_image.scale}")
+        print(f"  Translation (origin): {ngff_image.translation}")
+
+        # Access timestamps if available
+        if ngff_image.attrs and "timestamps" in ngff_image.attrs:
+            print(f"  Timestamps: {ngff_image.attrs['timestamps']}")
+```
+
+## Dimension Mapping
+
+LIF files use uppercase dimension names, which are mapped to OME-Zarr's
+lowercase convention:
+
+| LIF Dimension | OME-Zarr Dimension | Description |
+|---------------|-------------------|-------------|
+| X | x | Horizontal spatial axis |
+| Y | y | Vertical spatial axis |
+| Z | z | Depth/focus axis |
+| T | t | Time axis |
+| C | c | Channel axis |
+| λ (lambda) | c | Emission wavelength (flattened to channel) |
+| Λ (Lambda) | c | Excitation wavelength (flattened to channel) |
+| S | c | RGB/spectral (flattened to channel) |
+| M | m | Mosaic/tile index |
+
+**Note:** Multiple channel-like dimensions (C, λ, Λ, S) are automatically
+flattened into a single 'c' dimension for compatibility with OME-Zarr viewers.
+
+## Scale and Translation
+
+NGFF-Zarr automatically extracts calibration information from LIF files:
+
+- **Scale**: Pixel sizes in physical units (typically micrometers)
+- **Translation**: Coordinate offsets for the origin of each dimension
+
+This metadata is preserved in the OME-Zarr output, ensuring accurate
+visualization and measurement in compatible viewers.
+
+## API Reference
+
+### `lif_to_ngff_image(lif_image)`
+
+Convert a single LifImage to an NgffImage.
+
+**Parameters:**
+- `lif_image`: A `liffile.LifImage` object
+
+**Returns:**
+- `NgffImage`: The converted image with proper dimensions, scale, and translation
+
+### `lif_file_to_ngff_images(input_file, series=None)`
+
+Convert a LIF file to a list of NgffImage objects.
+
+**Parameters:**
+- `input_file`: Path to the LIF file
+- `series`: Optional series filter:
+  - `None` or `"all"`: Convert all series
+  - `int`: Convert only the series at this index
+  - `str`: Convert series matching this glob pattern
+
+**Returns:**
+- `list[tuple[str, NgffImage]]`: List of (series_name, ngff_image) pairs
+
+### `lif_to_hcs_plate(lif_image, plate_name=None)`
+
+Convert a mosaic LIF image to an HCS plate structure.
+
+**Parameters:**
+- `lif_image`: A `liffile.LifImage` object with mosaic dimension (M > 1)
+- `plate_name`: Optional name for the plate (defaults to image path)
+
+**Returns:**
+- `tuple[Plate, list]`: Plate metadata and list of (row, column, field_index, NgffImage) tuples
+
+### `has_mosaic_dimension(lif_image)`
+
+Check if a LIF image has a mosaic dimension with size > 1.
+
+**Parameters:**
+- `lif_image`: A `liffile.LifImage` object
+
+**Returns:**
+- `bool`: True if the image has M dimension > 1
+
+## See Also
+
+- [Command Line Interface](./cli.md)
+- [High Content Screening (HCS) Support](./hcs.md)
+- [Python API](./python.md)
+- [liffile documentation](https://pypi.org/project/liffile/)

--- a/py/ngff_zarr/__init__.py
+++ b/py/ngff_zarr/__init__.py
@@ -73,6 +73,12 @@ from .rfc9_zip import (
     read_ozx_version,
     write_store_to_zip,
 )
+from .lif_to_ngff_image import (
+    lif_to_ngff_image,
+    lif_file_to_ngff_images,
+    lif_to_hcs_plate,
+    has_mosaic_dimension,
+)
 
 __all__ = [
     "__version__",
@@ -141,4 +147,9 @@ __all__ = [
     "is_ozx_path",
     "read_ozx_version",
     "write_store_to_zip",
+    # LIF (Leica Image Format) support
+    "lif_to_ngff_image",
+    "lif_file_to_ngff_images",
+    "lif_to_hcs_plate",
+    "has_mosaic_dimension",
 ]

--- a/py/ngff_zarr/cli.py
+++ b/py/ngff_zarr/cli.py
@@ -224,6 +224,12 @@ def main():
         help="Enable specific RFC features. Can be used multiple times. Currently supported: 4 (anatomical orientation)",
         metavar="RFC_NUMBER",
     )
+    metadata_group.add_argument(
+        "--series",
+        help="Series to convert from multi-series files (e.g., LIF). "
+        "Can be: index (0, 1, 2), name pattern ('*area_1*'), or 'all' (default: all)",
+        default=None,
+    )
 
     processing_group = parser.add_argument_group("processing", "Processing options")
     processing_group.add_argument(
@@ -440,6 +446,142 @@ def main():
                     )
             except ImportError:
                 sys.stdout.write("[red]Please install the [i]tifffile[/i] package.\n")
+                sys.exit(1)
+        elif input_backend is ConversionBackend.LIFFILE:
+            try:
+                from liffile import LifFile
+
+                from .lif_to_ngff_image import (
+                    lif_file_to_ngff_images,
+                    lif_to_hcs_plate,
+                )
+                from .hcs import HCSPlateWriter
+
+                with LifFile(args.input[0]) as lif:
+                    # Get series to convert based on --series argument
+                    series_spec = args.series
+                    if series_spec is not None:
+                        # Try to parse as integer
+                        try:
+                            series_spec = int(series_spec)
+                        except ValueError:
+                            pass  # Keep as string (pattern or "all")
+
+                    series_list = lif_file_to_ngff_images(
+                        args.input[0], series=series_spec
+                    )
+
+                    if len(series_list) == 0:
+                        live.console.print("[red]No matching series found in LIF file.")
+                        sys.exit(1)
+
+                    for series_name, ngff_image in series_list:
+                        # Check for mosaic dimension (M > 1) - requires original lif_image
+                        # For now, check if 'm' dimension exists in ngff_image
+                        has_mosaic = (
+                            "m" in ngff_image.dims
+                            and ngff_image.data.shape[list(ngff_image.dims).index("m")]
+                            > 1
+                        )
+
+                        if has_mosaic and args.output:
+                            # HCS output for mosaic data
+                            # Find original LIF image to get mosaic info
+                            lif_image = None
+                            for img in lif.images:
+                                if img.path.replace("/", "_") == series_name:
+                                    lif_image = img
+                                    break
+
+                            if lif_image is not None:
+                                plate, well_images = lif_to_hcs_plate(
+                                    lif_image,
+                                    plate_name=series_name,
+                                    version=args.ome_zarr_version,
+                                )
+
+                                # Determine output path
+                                if len(series_list) > 1:
+                                    output_path = (
+                                        Path(args.output).parent
+                                        / f"{series_name}.ome.zarr"
+                                    )
+                                else:
+                                    output_path = Path(args.output)
+
+                                # Write HCS plate
+                                with HCSPlateWriter(
+                                    str(output_path),
+                                    plate,
+                                    version=args.ome_zarr_version,
+                                ) as writer:
+                                    for (
+                                        row_name,
+                                        column_name,
+                                        field_index,
+                                        field_image,
+                                    ) in well_images:
+                                        # Generate multiscales for this field
+                                        field_multiscales = _ngff_image_to_multiscales(
+                                            live,
+                                            field_image,
+                                            args,
+                                            progress,
+                                            rich_dask_progress,
+                                            subtitle,
+                                            method,
+                                        )
+                                        writer.write_well_image(
+                                            multiscales=field_multiscales,
+                                            row_name=row_name,
+                                            column_name=column_name,
+                                            field_index=field_index,
+                                        )
+                                if not args.quiet:
+                                    live.console.print(
+                                        f"[green]Written HCS plate: {output_path}"
+                                    )
+                                continue
+
+                        # Standard image output
+                        # Determine output path for this series
+                        if args.output:
+                            if len(series_list) > 1:
+                                # Create separate output per series
+                                output_path = (
+                                    Path(args.output).parent / f"{series_name}.ome.zarr"
+                                )
+                                series_store = LocalStore(
+                                    str(output_path), **zarr_kwargs
+                                )
+                            else:
+                                series_store = output_store
+                        else:
+                            series_store = None
+
+                        multiscales = _ngff_image_to_multiscales(
+                            live,
+                            ngff_image,
+                            args,
+                            progress,
+                            rich_dask_progress,
+                            subtitle,
+                            method,
+                        )
+                        _multiscales_to_ngff_zarr(
+                            live,
+                            args,
+                            series_store,
+                            rich_dask_progress,
+                            multiscales,
+                            chunks_per_shard=chunks_per_shard,
+                        )
+
+                        if len(series_list) > 1 and args.output and not args.quiet:
+                            live.console.print(f"[green]Written series: {series_name}")
+
+            except ImportError:
+                sys.stdout.write("[red]Please install the [i]liffile[/i] package.\n")
                 sys.exit(1)
         else:
             # Generate NgffImage

--- a/py/ngff_zarr/cli_input_to_ngff_image.py
+++ b/py/ngff_zarr/cli_input_to_ngff_image.py
@@ -68,6 +68,21 @@ def cli_input_to_ngff_image(
             return itk_image_to_ngff_image(image)
         image = itk.imread(input)
         return itk_image_to_ngff_image(image)
+    if backend is ConversionBackend.LIFFILE:
+        try:
+            from liffile import LifFile
+        except ImportError:
+            print("[red]Please install the [i]liffile[/i] package.")
+            sys.exit(1)
+        from .lif_to_ngff_image import lif_to_ngff_image
+
+        with LifFile(input[0]) as lif:
+            # Default to first series for simple cli_input_to_ngff_image usage
+            # Multi-series handling is done in cli.py
+            if len(lif.images) == 0:
+                print("[red]No images found in LIF file.")
+                sys.exit(1)
+            return lif_to_ngff_image(lif.images[0])
     if backend is ConversionBackend.TIFFFILE:
         try:
             import tifffile

--- a/py/ngff_zarr/detect_cli_io_backend.py
+++ b/py/ngff_zarr/detect_cli_io_backend.py
@@ -11,6 +11,7 @@ conversion_backends = [
     ("NIBABEL", "nibabel"),
     ("ITKWASM", "itkwasm_image_io"),
     ("ITK", "itk"),
+    ("LIFFILE", "liffile"),
     ("TIFFFILE", "tifffile"),
     ("IMAGEIO", "imageio"),
 ]
@@ -122,6 +123,11 @@ def detect_cli_io_backend(input: List[str]) -> ConversionBackend:
 
     if _matches_extension(extension, itk_supported_extensions):
         return ConversionBackend.ITK
+
+    # Leica image file formats (LIF, LOF, XLIF, XLEF, XLCF)
+    liffile_supported_extensions = (".lif", ".lof", ".xlif", ".xlef", ".xlcf")
+    if extension in liffile_supported_extensions:
+        return ConversionBackend.LIFFILE
 
     try:
         import tifffile

--- a/py/ngff_zarr/lif_to_ngff_image.py
+++ b/py/ngff_zarr/lif_to_ngff_image.py
@@ -1,0 +1,582 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""
+Convert Leica Image Format (LIF) files to OME-NGFF.
+
+This module provides functions to convert LIF files (and related formats
+like LOF, XLIF, XLEF, XLCF) to NgffImage objects for further processing
+into OME-Zarr format.
+
+Requires the `liffile` package: pip install liffile
+"""
+
+import re
+from functools import reduce
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import dask
+import dask.array as da
+import numpy as np
+
+from .ngff_image import NgffImage
+from .v04.zarr_metadata import (
+    Plate,
+    PlateColumn,
+    PlateRow,
+    PlateWell,
+)
+
+# Mapping from LIF dimension names to OME-NGFF dimension names
+# LIF uses uppercase, OME-NGFF uses lowercase for spatial dims
+LIF_DIM_TO_NGFF: Dict[str, Optional[str]] = {
+    "X": "x",
+    "Y": "y",
+    "Z": "z",
+    "T": "t",
+    "C": "c",
+    "λ": "c",  # Emission wavelength -> channel
+    "Λ": "c",  # Excitation wavelength -> channel
+    "S": "c",  # RGB samples -> channel
+    "N": None,  # XT slices - special handling
+    "Q": None,  # T slices - special handling
+    "A": None,  # Rotation - special handling
+    "L": None,  # Loop - special handling
+    "M": None,  # Mosaic - special handling for HCS
+    "H": None,  # TCSPC histogram - not supported
+}
+
+# Spatial dimensions in OME-NGFF
+SPATIAL_DIMS = {"x", "y", "z"}
+
+
+def _get_lif_image_data_delayed(lif_image: Any) -> np.ndarray:
+    """Load LIF image data (for use with dask.delayed)."""
+    return lif_image.asarray()
+
+
+def _extract_scale_translation(
+    lif_image: Any, ngff_dims: Sequence[str]
+) -> Tuple[Dict[str, float], Dict[str, float]]:
+    """
+    Extract scale (pixel spacing) and translation (origin) from LIF image coordinates.
+
+    Parameters
+    ----------
+    lif_image : LifImage
+        The LIF image object with coords attribute.
+    ngff_dims : Sequence[str]
+        The mapped NGFF dimension names.
+
+    Returns
+    -------
+    scale : Dict[str, float]
+        Pixel spacing for spatial dimensions.
+    translation : Dict[str, float]
+        Origin offset for spatial dimensions.
+    """
+    scale: Dict[str, float] = {}
+    translation: Dict[str, float] = {}
+
+    coords = getattr(lif_image, "coords", {})
+
+    for lif_dim, ngff_dim in LIF_DIM_TO_NGFF.items():
+        if ngff_dim is None or ngff_dim not in SPATIAL_DIMS:
+            continue
+        if ngff_dim not in ngff_dims:
+            continue
+
+        if lif_dim in coords:
+            coord_array = coords[lif_dim]
+            if len(coord_array) > 1:
+                # Scale is the spacing between coordinates
+                spacing = abs(coord_array[1] - coord_array[0])
+                scale[ngff_dim] = float(spacing)
+            else:
+                scale[ngff_dim] = 1.0
+            # Translation is the origin (first coordinate)
+            translation[ngff_dim] = float(coord_array[0])
+        else:
+            # Default values if coordinates not available
+            if ngff_dim not in scale:
+                scale[ngff_dim] = 1.0
+            if ngff_dim not in translation:
+                translation[ngff_dim] = 0.0
+
+    return scale, translation
+
+
+def _map_lif_dims_to_ngff(
+    lif_dims: Sequence[str], lif_shape: Sequence[int]
+) -> Tuple[Tuple[str, ...], Tuple[int, ...]]:
+    """
+    Map LIF dimensions to OME-NGFF dimensions, flattening channel-like dims.
+
+    Parameters
+    ----------
+    lif_dims : Sequence[str]
+        Original LIF dimension names (e.g., ('T', 'Z', 'C', 'Y', 'X')).
+    lif_shape : Sequence[int]
+        Original shape corresponding to lif_dims.
+
+    Returns
+    -------
+    ngff_dims : Tuple[str, ...]
+        Mapped NGFF dimension names.
+    ngff_shape : Tuple[int, ...]
+        Shape after flattening channel-like dimensions.
+    """
+    # Track which indices map to channels (to be flattened)
+    channel_like_dims = {"C", "λ", "Λ", "S"}
+
+    # First pass: identify channel indices and their sizes
+    channel_indices: List[int] = []
+    channel_sizes: List[int] = []
+    other_dims: List[Tuple[int, str, int]] = []  # (original_idx, ngff_name, size)
+
+    for i, (dim, size) in enumerate(zip(lif_dims, lif_shape)):
+        ngff_dim = LIF_DIM_TO_NGFF.get(dim)
+
+        if dim in channel_like_dims:
+            channel_indices.append(i)
+            channel_sizes.append(size)
+        elif ngff_dim is not None:
+            other_dims.append((i, ngff_dim, size))
+        elif dim == "M":
+            # Mosaic dimension - keep for now, will be handled specially
+            other_dims.append((i, "m", size))
+        else:
+            # Unknown dimension - use lowercase version
+            other_dims.append((i, dim.lower(), size))
+
+    # Build output dimensions and shape
+    ngff_dims_list: List[str] = []
+    ngff_shape_list: List[int] = []
+
+    # Sort other_dims by original index to maintain order
+    other_dims.sort(key=lambda x: x[0])
+
+    # Calculate total channel size
+    total_channels = reduce(lambda x, y: x * y, channel_sizes, 1)
+
+    # Find where to insert the channel dimension
+    # Convention: channels typically come after spatial dims in OME-NGFF
+    # Order is typically: t, c, z, y, x or t, z, c, y, x
+    channel_inserted = False
+
+    for orig_idx, ngff_name, size in other_dims:
+        # Insert channel before spatial dims if we have channels
+        if not channel_inserted and total_channels > 1 and ngff_name in SPATIAL_DIMS:
+            ngff_dims_list.append("c")
+            ngff_shape_list.append(total_channels)
+            channel_inserted = True
+
+        ngff_dims_list.append(ngff_name)
+        ngff_shape_list.append(size)
+
+    # If we haven't inserted channels yet and we have them, append at end
+    if not channel_inserted and total_channels > 1:
+        ngff_dims_list.append("c")
+        ngff_shape_list.append(total_channels)
+
+    return tuple(ngff_dims_list), tuple(ngff_shape_list)
+
+
+def _reshape_for_flattened_channels(
+    data: da.Array,
+    lif_dims: Sequence[str],
+    lif_shape: Sequence[int],
+    ngff_dims: Sequence[str],
+    ngff_shape: Sequence[int],
+) -> da.Array:
+    """
+    Reshape data array to flatten channel-like dimensions.
+
+    This handles the case where LIF has multiple channel-like dimensions
+    (C, λ, Λ, S) that need to be flattened into a single channel dimension.
+    
+    The function ensures channel dimensions are moved to be adjacent before
+    flattening, regardless of their original positions in the array.
+    """
+    channel_like_dims = {"C", "λ", "Λ", "S"}
+
+    # Count channel-like dimensions in the original
+    channel_dim_indices = [i for i, d in enumerate(lif_dims) if d in channel_like_dims]
+
+    if len(channel_dim_indices) <= 1:
+        # No flattening needed, just return reshaped if dims changed
+        if data.shape != ngff_shape:
+            return data.reshape(ngff_shape)
+        return data
+
+    # Need to flatten multiple channel dimensions
+    # Strategy:
+    # 1. Move all channel dimensions to be contiguous
+    # 2. Reshape to flatten them into a single dimension
+    # 3. Move the flattened channel dimension to its target position
+    
+    # Check if channel dimensions are already contiguous
+    are_contiguous = all(
+        channel_dim_indices[i] + 1 == channel_dim_indices[i + 1]
+        for i in range(len(channel_dim_indices) - 1)
+    )
+    
+    if are_contiguous:
+        # Dimensions are contiguous, safe to use reshape directly
+        return data.reshape(ngff_shape)
+    
+    # Move channel dimensions to be adjacent
+    # Move them to the position of the first channel dimension
+    first_channel_pos = channel_dim_indices[0]
+    
+    # Calculate new axis order: non-channel dims + channel dims
+    non_channel_indices = [i for i in range(len(lif_dims)) if i not in channel_dim_indices]
+    
+    # Insert channel dims at the position where the first one was
+    new_axis_order = (
+        non_channel_indices[:first_channel_pos] +
+        channel_dim_indices +
+        non_channel_indices[first_channel_pos:]
+    )
+    
+    # Transpose to new order
+    data = data.transpose(new_axis_order)
+    
+    # Now reshape to flatten the channel dimensions
+    # Calculate the intermediate shape after transposing
+    intermediate_shape = [lif_shape[i] for i in new_axis_order]
+    
+    # Calculate flattened shape: replace the channel dimensions with their product
+    flattened_shape = (
+        intermediate_shape[:first_channel_pos] +
+        [reduce(lambda x, y: x * y, [intermediate_shape[i] for i in range(first_channel_pos, first_channel_pos + len(channel_dim_indices))])] +
+        intermediate_shape[first_channel_pos + len(channel_dim_indices):]
+    )
+    
+    data = data.reshape(flattened_shape)
+    
+    # Now the data has the right shape, but might not match ngff_shape dimension order
+    # Find where 'c' is in ngff_dims
+    if "c" in ngff_dims:
+        target_c_pos = list(ngff_dims).index("c")
+        if target_c_pos != first_channel_pos:
+            # Move channel dimension to target position
+            current_order = list(range(len(flattened_shape)))
+            current_order.pop(first_channel_pos)
+            current_order.insert(target_c_pos, first_channel_pos)
+            data = data.transpose(current_order)
+    
+    return data
+
+
+def lif_to_ngff_image(
+    lif_image: Any,
+    name: Optional[str] = None,
+) -> NgffImage:
+    """
+    Convert a single LifImage to an NgffImage.
+
+    Parameters
+    ----------
+    lif_image : LifImage
+        A LifImage object from the liffile library.
+    name : str, optional
+        Name for the output image. If None, uses lif_image.name.
+
+    Returns
+    -------
+    NgffImage
+        The converted image with metadata.
+
+    Examples
+    --------
+    >>> from liffile import LifFile
+    >>> from ngff_zarr import lif_to_ngff_image
+    >>> with LifFile("sample.lif") as lif:
+    ...     ngff_image = lif_to_ngff_image(lif.images[0])
+    """
+    # Get basic info from LIF image
+    lif_dims = lif_image.dims
+    lif_shape = lif_image.shape
+    dtype = lif_image.dtype
+
+    # Map dimensions
+    ngff_dims, ngff_shape = _map_lif_dims_to_ngff(lif_dims, lif_shape)
+
+    # Extract scale and translation from coordinates
+    scale, translation = _extract_scale_translation(lif_image, ngff_dims)
+
+    # Ensure all spatial dims have scale/translation
+    for dim in ngff_dims:
+        if dim in SPATIAL_DIMS:
+            if dim not in scale:
+                scale[dim] = 1.0
+            if dim not in translation:
+                translation[dim] = 0.0
+
+    # Create lazy dask array from the LIF image
+    # Use delayed to avoid loading data until needed
+    delayed_data = dask.delayed(_get_lif_image_data_delayed)(lif_image)
+    data = da.from_delayed(delayed_data, shape=lif_shape, dtype=dtype)
+
+    # Reshape if needed for flattened channels
+    if data.shape != ngff_shape:
+        data = _reshape_for_flattened_channels(
+            data, lif_dims, lif_shape, ngff_dims, ngff_shape
+        )
+
+    # Get image name
+    if name is None:
+        name = getattr(lif_image, "name", "image")
+
+    return NgffImage(
+        data=data,
+        dims=ngff_dims,
+        scale=scale,
+        translation=translation,
+        name=name,
+    )
+
+
+def lif_file_to_ngff_images(
+    lif_path: Union[str, Path],
+    series: Optional[Union[int, str, List[Union[int, str]]]] = None,
+) -> List[Tuple[str, NgffImage]]:
+    """
+    Convert a LIF file to a list of (name, NgffImage) pairs.
+
+    Parameters
+    ----------
+    lif_path : str or Path
+        Path to the LIF file.
+    series : int, str, or list, optional
+        Series to convert:
+        - None or "all": Convert all series
+        - int: Convert series at that index
+        - str: Convert series matching regex pattern
+        - list: Convert multiple series by index or pattern
+
+    Returns
+    -------
+    List[Tuple[str, NgffImage]]
+        List of (series_name, ngff_image) tuples.
+
+    Examples
+    --------
+    >>> from ngff_zarr import lif_file_to_ngff_images
+    >>> # Convert all series
+    >>> images = lif_file_to_ngff_images("sample.lif")
+    >>> # Convert specific series by index
+    >>> images = lif_file_to_ngff_images("sample.lif", series=0)
+    >>> # Convert series matching pattern
+    >>> images = lif_file_to_ngff_images("sample.lif", series="*area_1*")
+    """
+    try:
+        from liffile import LifFile
+    except ImportError as e:
+        msg = "liffile package is required. Install with: pip install liffile"
+        raise ImportError(msg) from e
+
+    results: List[Tuple[str, NgffImage]] = []
+
+    with LifFile(lif_path) as lif:
+        all_images = list(lif.images)
+
+        # Determine which series to convert
+        if series is None or series == "all":
+            indices_to_convert = list(range(len(all_images)))
+        elif isinstance(series, int):
+            # Explicit index - validate it exists
+            if series < 0 or series >= len(all_images):
+                msg = f"Series index {series} is out of bounds. File has {len(all_images)} series (indices 0-{len(all_images)-1})."
+                raise IndexError(msg)
+            indices_to_convert = [series]
+        elif isinstance(series, str):
+            # Treat as regex pattern
+            pattern = re.compile(series.replace("*", ".*"), re.IGNORECASE)
+            indices_to_convert = [
+                i for i, img in enumerate(all_images) if pattern.search(img.name)
+            ]
+        elif isinstance(series, list):
+            indices_to_convert = []
+            for s in series:
+                if isinstance(s, int):
+                    # Explicit index - validate it exists
+                    if s < 0 or s >= len(all_images):
+                        msg = f"Series index {s} is out of bounds. File has {len(all_images)} series (indices 0-{len(all_images)-1})."
+                        raise IndexError(msg)
+                    indices_to_convert.append(s)
+                elif isinstance(s, str):
+                    pattern = re.compile(s.replace("*", ".*"), re.IGNORECASE)
+                    indices_to_convert.extend(
+                        i
+                        for i, img in enumerate(all_images)
+                        if pattern.search(img.name)
+                    )
+        else:
+            msg = f"Invalid series specification: {series}"
+            raise ValueError(msg)
+
+        # Convert selected series
+        for idx in indices_to_convert:
+            lif_image = all_images[idx]
+            ngff_image = lif_to_ngff_image(lif_image)
+            # Use path as name to preserve hierarchy
+            series_name = lif_image.path.replace("/", "_")
+            results.append((series_name, ngff_image))
+
+    return results
+
+
+def has_mosaic_dimension(lif_image: Any) -> bool:
+    """
+    Check if a LIF image has a mosaic dimension with size > 1.
+
+    Parameters
+    ----------
+    lif_image : LifImage
+        The LIF image to check.
+
+    Returns
+    -------
+    bool
+        True if the image has M dimension with size > 1.
+    """
+    dims = lif_image.dims
+    sizes = lif_image.sizes if hasattr(lif_image, "sizes") else {}
+
+    if "M" in dims:
+        idx = dims.index("M") if isinstance(dims, (list, tuple)) else None
+        if idx is not None:
+            return lif_image.shape[idx] > 1
+        elif "M" in sizes:
+            return sizes["M"] > 1
+
+    return False
+
+
+def lif_to_hcs_plate(
+    lif_image: Any,
+    plate_name: str = "plate",
+    version: str = "0.4",
+) -> Tuple[Plate, List[Tuple[str, str, int, NgffImage]]]:
+    """
+    Convert a LIF image with mosaic dimension to HCS plate structure.
+
+    When a LIF image has M > 1 (multiple mosaic positions), this function
+    creates an HCS plate structure where each position becomes a field of view.
+
+    Parameters
+    ----------
+    lif_image : LifImage
+        A LIF image with mosaic dimension (M > 1).
+    plate_name : str, optional
+        Name for the plate. Default is "plate".
+    version : str, optional
+        OME-Zarr version for the plate. Default is "0.4".
+
+    Returns
+    -------
+    plate : Plate
+        Plate metadata for HCS structure.
+    well_images : List[Tuple[str, str, int, NgffImage]]
+        List of (row_name, column_name, field_index, ngff_image) tuples.
+
+    Raises
+    ------
+    ValueError
+        If the image does not have a mosaic dimension with M > 1.
+
+    Examples
+    --------
+    >>> from liffile import LifFile
+    >>> from ngff_zarr import lif_to_hcs_plate
+    >>> with LifFile("mosaic.lif") as lif:
+    ...     plate, well_images = lif_to_hcs_plate(lif.images[0])
+    ...     # plate contains HCS metadata
+    ...     # well_images contains individual field images
+    """
+    if not has_mosaic_dimension(lif_image):
+        msg = "LIF image does not have a mosaic dimension (M > 1)"
+        raise ValueError(msg)
+
+    # Get mosaic size
+    dims = lif_image.dims
+    shape = lif_image.shape
+    m_idx = list(dims).index("M")
+    n_positions = shape[m_idx]
+
+    # Create plate structure
+    # For simplicity, use a single row with M columns
+    # Each mosaic position becomes a separate well
+    row_name = "A"
+    columns = [PlateColumn(name=str(i + 1)) for i in range(n_positions)]
+    rows = [PlateRow(name=row_name)]
+    wells = [
+        PlateWell(path=f"{row_name}/{i + 1}", rowIndex=0, columnIndex=i)
+        for i in range(n_positions)
+    ]
+
+    plate = Plate(
+        columns=columns,
+        rows=rows,
+        wells=wells,
+        name=plate_name,
+        field_count=1,  # 1 field per well (the mosaic position)
+        version=version,
+    )
+
+    # Extract individual mosaic positions as separate images
+    well_images: List[Tuple[str, str, int, NgffImage]] = []
+
+    # Get the full data
+    lif_dims = lif_image.dims
+    lif_shape = lif_image.shape
+
+    # Create a delayed load for the full data
+    delayed_data = dask.delayed(_get_lif_image_data_delayed)(lif_image)
+    full_data = da.from_delayed(delayed_data, shape=lif_shape, dtype=lif_image.dtype)
+
+    # Build slicing for each mosaic position
+    for pos_idx in range(n_positions):
+        # Create slice that selects this mosaic position
+        slices = [slice(None)] * len(lif_dims)
+        slices[m_idx] = pos_idx
+
+        # Extract the position data
+        pos_data = full_data[tuple(slices)]
+
+        # Remove M dimension from dims and shape
+        new_dims = tuple(d for i, d in enumerate(lif_dims) if i != m_idx)
+        new_shape = tuple(s for i, s in enumerate(lif_shape) if i != m_idx)
+
+        # Map to NGFF dims
+        ngff_dims, ngff_shape = _map_lif_dims_to_ngff(new_dims, new_shape)
+
+        # Extract scale and translation
+        scale, translation = _extract_scale_translation(lif_image, ngff_dims)
+
+        # Ensure all spatial dims have scale/translation
+        for dim in ngff_dims:
+            if dim in SPATIAL_DIMS:
+                if dim not in scale:
+                    scale[dim] = 1.0
+                if dim not in translation:
+                    translation[dim] = 0.0
+
+        # Reshape if needed
+        if pos_data.shape != ngff_shape:
+            pos_data = pos_data.reshape(ngff_shape)
+
+        ngff_image = NgffImage(
+            data=pos_data,
+            dims=ngff_dims,
+            scale=scale,
+            translation=translation,
+            name=f"{lif_image.name}_pos{pos_idx}",
+        )
+
+        column_name = str(pos_idx + 1)
+        well_images.append((row_name, column_name, 0, ngff_image))
+
+    return plate, well_images

--- a/py/pixi.lock
+++ b/py/pixi.lock
@@ -1546,6 +1546,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3f/4a/e20e0d5763f0bda9b34cfd06e3c70889f1b54070c69c3380237763b735f6/liffile-2026.1.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -1752,6 +1753,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3f/4a/e20e0d5763f0bda9b34cfd06e3c70889f1b54070c69c3380237763b735f6/liffile-2026.1.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
@@ -1889,6 +1891,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3f/4a/e20e0d5763f0bda9b34cfd06e3c70889f1b54070c69c3380237763b735f6/liffile-2026.1.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl
@@ -2027,6 +2030,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3f/4a/e20e0d5763f0bda9b34cfd06e3c70889f1b54070c69c3380237763b735f6/liffile-2026.1.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl
@@ -2194,6 +2198,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3f/4a/e20e0d5763f0bda9b34cfd06e3c70889f1b54070c69c3380237763b735f6/liffile-2026.1.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl
@@ -6865,6 +6870,17 @@ packages:
   purls: []
   size: 55476
   timestamp: 1727963768015
+- pypi: https://files.pythonhosted.org/packages/3f/4a/e20e0d5763f0bda9b34cfd06e3c70889f1b54070c69c3380237763b735f6/liffile-2026.1.22-py3-none-any.whl
+  name: liffile
+  version: 2026.1.22
+  sha256: 53bf83dbce791d24943084df12a759fa76e24a3fb13a86d0b91ea060f26a8be6
+  requires_dist:
+  - numpy
+  - xarray ; extra == 'all'
+  - tifffile ; extra == 'all'
+  - imagecodecs ; extra == 'all'
+  - matplotlib ; extra == 'all'
+  requires_python: '>=3.11'
 - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-21.1.8-h472b3d1_0.conda
   sha256: 2a41885f44cbc1546ff26369924b981efa37a29d20dc5445b64539ba240739e6
   md5: e2d811e9f464dd67398b4ce1f9c7c872
@@ -7406,7 +7422,7 @@ packages:
 - pypi: ./
   name: ngff-zarr
   version: 0.21.0
-  sha256: cada4c80c35617b30646173af1994530ab3096139ba55df3f328b03c5f6ac07b
+  sha256: 203f50ff7919d82148a8a8b7670ae420a9de169d005f0a73a32446a5feda2e76
   requires_dist:
   - dask[array]!=2025.12.0,!=2026.1.0,!=2026.1.1
   - importlib-resources
@@ -7429,6 +7445,7 @@ packages:
   - itk-io>=5.3.0 ; extra == 'all'
   - itkwasm-image-io ; extra == 'all'
   - jsonschema ; extra == 'all'
+  - liffile ; extra == 'all'
   - myst-parser>=3.0.1,<4 ; extra == 'all'
   - nibabel ; extra == 'all'
   - pooch ; extra == 'all'
@@ -7448,6 +7465,7 @@ packages:
   - itk-filtering>=5.3.0 ; extra == 'cli'
   - itk-io>=5.3.0 ; extra == 'cli'
   - itkwasm-image-io ; extra == 'cli'
+  - liffile ; extra == 'cli'
   - nibabel ; extra == 'cli'
   - tifffile>=2024.7.24 ; extra == 'cli'
   - dask-image ; extra == 'dask-image'

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -66,6 +66,7 @@ cli = [
   "imageio",
   "nibabel",
   "tifffile>=2024.7.24",
+  "liffile",
   "imagecodecs",
 ]
 tensorstore = ["tensorstore"]

--- a/py/test/test_detect_cli_input_backend.py
+++ b/py/test/test_detect_cli_input_backend.py
@@ -76,3 +76,57 @@ def test_detect_nibabel_input_backend_with_extra_dots():
     """Test that filenames with additional dots like '.scan.nii.gz' are correctly detected."""
     backend = detect_cli_io_backend(["patient.scan.nii.gz"])
     assert backend == ConversionBackend.NIBABEL
+
+def test_detect_liffile_input_backend_lif():
+    """Test detection of .lif (Leica Image File) extension."""
+    extension = ".lif"
+    backend = detect_cli_io_backend(
+        [
+            f"file{extension}",
+        ]
+    )
+    assert backend == ConversionBackend.LIFFILE
+
+
+def test_detect_liffile_input_backend_lof():
+    """Test detection of .lof (Leica Object File) extension."""
+    extension = ".lof"
+    backend = detect_cli_io_backend(
+        [
+            f"file{extension}",
+        ]
+    )
+    assert backend == ConversionBackend.LIFFILE
+
+
+def test_detect_liffile_input_backend_xlif():
+    """Test detection of .xlif (XML Image File) extension."""
+    extension = ".xlif"
+    backend = detect_cli_io_backend(
+        [
+            f"file{extension}",
+        ]
+    )
+    assert backend == ConversionBackend.LIFFILE
+
+
+def test_detect_liffile_input_backend_xlef():
+    """Test detection of .xlef (XML Experiment File) extension."""
+    extension = ".xlef"
+    backend = detect_cli_io_backend(
+        [
+            f"file{extension}",
+        ]
+    )
+    assert backend == ConversionBackend.LIFFILE
+
+
+def test_detect_liffile_input_backend_xlcf():
+    """Test detection of .xlcf (XML Collection File) extension."""
+    extension = ".xlcf"
+    backend = detect_cli_io_backend(
+        [
+            f"file{extension}",
+        ]
+    )
+    assert backend == ConversionBackend.LIFFILE

--- a/py/test/test_lif_to_ngff_image.py
+++ b/py/test/test_lif_to_ngff_image.py
@@ -1,0 +1,429 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Tests for LIF to NGFF image conversion using mocked liffile objects."""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import numpy as np
+import pytest
+
+from ngff_zarr.lif_to_ngff_image import (
+    _extract_scale_translation,
+    _map_lif_dims_to_ngff,
+    has_mosaic_dimension,
+    lif_to_hcs_plate,
+    lif_to_ngff_image,
+)
+
+
+@pytest.fixture
+def mock_lif_image_xyz():
+    """Create a mock LifImage with XYZ dimensions."""
+    image = Mock()
+    image.name = "test_xyz"
+    image.path = "test_xyz"
+    image.shape = (10, 128, 128)  # Z, Y, X
+    image.dims = ("Z", "Y", "X")
+    image.sizes = {"Z": 10, "Y": 128, "X": 128}
+    image.dtype = np.uint8
+    image.coords = {
+        "Z": np.linspace(0, 9e-6, 10),
+        "Y": np.linspace(0, 127e-6, 128),
+        "X": np.linspace(0, 127e-6, 128),
+    }
+    # Return test data when asarray() is called
+    image.asarray.return_value = np.random.randint(
+        0, 255, (10, 128, 128), dtype=np.uint8
+    )
+    return image
+
+
+@pytest.fixture
+def mock_lif_image_xyztc():
+    """Create a mock LifImage with XYZTC dimensions."""
+    image = Mock()
+    image.name = "test_xyztc"
+    image.path = "test_xyztc"
+    image.shape = (5, 10, 2, 128, 128)  # T, Z, C, Y, X
+    image.dims = ("T", "Z", "C", "Y", "X")
+    image.sizes = {"T": 5, "Z": 10, "C": 2, "Y": 128, "X": 128}
+    image.dtype = np.uint16
+    image.coords = {
+        "T": np.linspace(0, 4.0, 5),  # 5 timepoints
+        "Z": np.linspace(0, 9e-6, 10),
+        "Y": np.linspace(0, 127e-6, 128),
+        "X": np.linspace(0, 127e-6, 128),
+    }
+    image.asarray.return_value = np.random.randint(
+        0, 65535, (5, 10, 2, 128, 128), dtype=np.uint16
+    )
+    return image
+
+
+@pytest.fixture
+def mock_lif_image_lambda():
+    """Create a mock LifImage with emission wavelength (lambda) dimension."""
+    image = Mock()
+    image.name = "test_lambda"
+    image.path = "test_lambda"
+    image.shape = (9, 128, 128)  # λ, Y, X
+    image.dims = ("λ", "Y", "X")
+    image.sizes = {"λ": 9, "Y": 128, "X": 128}
+    image.dtype = np.uint8
+    image.coords = {
+        "λ": np.linspace(400e-9, 700e-9, 9),  # wavelength in meters
+        "Y": np.linspace(0, 127e-6, 128),
+        "X": np.linspace(0, 127e-6, 128),
+    }
+    image.asarray.return_value = np.random.randint(
+        0, 255, (9, 128, 128), dtype=np.uint8
+    )
+    return image
+
+
+@pytest.fixture
+def mock_lif_image_mosaic():
+    """Create a mock LifImage with mosaic (M) dimension > 1."""
+    image = Mock()
+    image.name = "test_mosaic"
+    image.path = "test_mosaic"
+    image.shape = (4, 10, 128, 128)  # M, Z, Y, X
+    image.dims = ("M", "Z", "Y", "X")
+    image.sizes = {"M": 4, "Z": 10, "Y": 128, "X": 128}
+    image.dtype = np.uint8
+    image.coords = {
+        "Z": np.linspace(0, 9e-6, 10),
+        "Y": np.linspace(0, 127e-6, 128),
+        "X": np.linspace(0, 127e-6, 128),
+    }
+    image.asarray.return_value = np.random.randint(
+        0, 255, (4, 10, 128, 128), dtype=np.uint8
+    )
+    return image
+
+
+@pytest.fixture
+def mock_lif_image_multi_channel():
+    """Create a mock LifImage with multiple channel-like dimensions."""
+    image = Mock()
+    image.name = "test_multi_channel"
+    image.path = "test_multi_channel"
+    # Z, C, λ, Y, X - both C and λ are channel-like
+    image.shape = (10, 2, 3, 128, 128)
+    image.dims = ("Z", "C", "λ", "Y", "X")
+    image.sizes = {"Z": 10, "C": 2, "λ": 3, "Y": 128, "X": 128}
+    image.dtype = np.uint8
+    image.coords = {
+        "Z": np.linspace(0, 9e-6, 10),
+        "Y": np.linspace(0, 127e-6, 128),
+        "X": np.linspace(0, 127e-6, 128),
+    }
+    image.asarray.return_value = np.random.randint(
+        0, 255, (10, 2, 3, 128, 128), dtype=np.uint8
+    )
+    return image
+
+
+class TestDimensionMapping:
+    """Tests for LIF to NGFF dimension mapping."""
+
+    def test_map_xyz_dims(self):
+        """Test mapping of basic XYZ dimensions."""
+        lif_dims = ("Z", "Y", "X")
+        lif_shape = (10, 128, 128)
+
+        ngff_dims, ngff_shape = _map_lif_dims_to_ngff(lif_dims, lif_shape)
+
+        assert ngff_dims == ("z", "y", "x")
+        assert ngff_shape == (10, 128, 128)
+
+    def test_map_xyztc_dims(self):
+        """Test mapping of XYZTC dimensions."""
+        lif_dims = ("T", "Z", "C", "Y", "X")
+        lif_shape = (5, 10, 2, 128, 128)
+
+        ngff_dims, ngff_shape = _map_lif_dims_to_ngff(lif_dims, lif_shape)
+
+        # C should be mapped to c and placed in appropriate position
+        assert "t" in ngff_dims
+        assert "z" in ngff_dims
+        assert "c" in ngff_dims
+        assert "y" in ngff_dims
+        assert "x" in ngff_dims
+
+    def test_map_lambda_to_channel(self):
+        """Test that emission wavelength (λ) maps to channel (c)."""
+        lif_dims = ("λ", "Y", "X")
+        lif_shape = (9, 128, 128)
+
+        ngff_dims, ngff_shape = _map_lif_dims_to_ngff(lif_dims, lif_shape)
+
+        assert "c" in ngff_dims
+        assert ngff_dims.count("c") == 1  # Only one channel dimension
+
+    def test_flatten_multiple_channel_dims(self):
+        """Test that multiple channel-like dims are flattened."""
+        lif_dims = ("Z", "C", "λ", "Y", "X")
+        lif_shape = (10, 2, 3, 128, 128)  # 2 channels * 3 wavelengths = 6 total
+
+        ngff_dims, ngff_shape = _map_lif_dims_to_ngff(lif_dims, lif_shape)
+
+        # Multiple channel dims should be flattened
+        c_count = ngff_dims.count("c")
+        assert c_count == 1  # Single flattened channel dimension
+        # Total channels = 2 * 3 = 6
+        c_idx = ngff_dims.index("c")
+        assert ngff_shape[c_idx] == 6
+
+    def test_mosaic_dimension_preserved(self):
+        """Test that mosaic (M) dimension is preserved as 'm'."""
+        lif_dims = ("M", "Z", "Y", "X")
+        lif_shape = (4, 10, 128, 128)
+
+        ngff_dims, ngff_shape = _map_lif_dims_to_ngff(lif_dims, lif_shape)
+
+        assert "m" in ngff_dims
+
+
+class TestScaleTranslationExtraction:
+    """Tests for extracting scale and translation from LIF coordinates."""
+
+    def test_extract_xyz_scale_translation(self, mock_lif_image_xyz):
+        """Test extraction of scale and translation for XYZ image."""
+        ngff_dims = ("z", "y", "x")
+
+        scale, translation = _extract_scale_translation(mock_lif_image_xyz, ngff_dims)
+
+        # Check scale is approximately 1 micrometer
+        assert "z" in scale
+        assert "y" in scale
+        assert "x" in scale
+        assert scale["z"] == pytest.approx(1e-6, rel=0.01)
+        assert scale["y"] == pytest.approx(1e-6, rel=0.01)
+        assert scale["x"] == pytest.approx(1e-6, rel=0.01)
+
+        # Check translation (origin)
+        assert "z" in translation
+        assert "y" in translation
+        assert "x" in translation
+        assert translation["z"] == pytest.approx(0.0)
+        assert translation["y"] == pytest.approx(0.0)
+        assert translation["x"] == pytest.approx(0.0)
+
+
+class TestLifToNgffImage:
+    """Tests for the main lif_to_ngff_image conversion function."""
+
+    def test_basic_xyz_conversion(self, mock_lif_image_xyz):
+        """Test basic XYZ image conversion."""
+        ngff_image = lif_to_ngff_image(mock_lif_image_xyz)
+
+        assert ngff_image.name == "test_xyz"
+        assert ngff_image.dims == ("z", "y", "x")
+        assert ngff_image.data.shape == (10, 128, 128)
+        assert ngff_image.data.dtype == np.uint8
+        assert "z" in ngff_image.scale
+        assert "y" in ngff_image.scale
+        assert "x" in ngff_image.scale
+
+    def test_xyztc_conversion(self, mock_lif_image_xyztc):
+        """Test XYZTC image conversion."""
+        ngff_image = lif_to_ngff_image(mock_lif_image_xyztc)
+
+        assert ngff_image.name == "test_xyztc"
+        assert "t" in ngff_image.dims
+        assert "z" in ngff_image.dims
+        assert "c" in ngff_image.dims
+        assert "y" in ngff_image.dims
+        assert "x" in ngff_image.dims
+        assert ngff_image.data.dtype == np.uint16
+
+    def test_custom_name(self, mock_lif_image_xyz):
+        """Test that custom name is applied."""
+        ngff_image = lif_to_ngff_image(mock_lif_image_xyz, name="custom_name")
+
+        assert ngff_image.name == "custom_name"
+
+    def test_lambda_to_channel(self, mock_lif_image_lambda):
+        """Test that λ dimension is converted to channel."""
+        ngff_image = lif_to_ngff_image(mock_lif_image_lambda)
+
+        assert "c" in ngff_image.dims
+        # λ dimension (9) should become channel
+        c_idx = list(ngff_image.dims).index("c")
+        assert ngff_image.data.shape[c_idx] == 9
+
+
+class TestHasMosaicDimension:
+    """Tests for has_mosaic_dimension function."""
+
+    def test_has_mosaic_true(self, mock_lif_image_mosaic):
+        """Test detection of mosaic dimension > 1."""
+        assert has_mosaic_dimension(mock_lif_image_mosaic) is True
+
+    def test_has_mosaic_false_no_m_dim(self, mock_lif_image_xyz):
+        """Test no mosaic when M dimension absent."""
+        assert has_mosaic_dimension(mock_lif_image_xyz) is False
+
+    def test_has_mosaic_false_m_equals_1(self):
+        """Test no mosaic when M dimension equals 1."""
+        image = Mock()
+        image.dims = ("M", "Z", "Y", "X")
+        image.shape = (1, 10, 128, 128)  # M=1
+        image.sizes = {"M": 1, "Z": 10, "Y": 128, "X": 128}
+
+        assert has_mosaic_dimension(image) is False
+
+
+class TestLifToHcsPlate:
+    """Tests for lif_to_hcs_plate conversion."""
+
+    def test_mosaic_to_hcs_plate(self, mock_lif_image_mosaic):
+        """Test conversion of mosaic image to HCS plate."""
+        plate, well_images = lif_to_hcs_plate(
+            mock_lif_image_mosaic, plate_name="test_plate"
+        )
+
+        # Check plate structure
+        assert plate.name == "test_plate"
+        assert len(plate.rows) == 1  # Single row
+        assert plate.rows[0].name == "A"
+        assert len(plate.columns) == 4  # 4 mosaic positions
+        assert len(plate.wells) == 4
+
+        # Check well images
+        assert len(well_images) == 4
+        for row_name, col_name, field_idx, ngff_image in well_images:
+            assert row_name == "A"
+            assert field_idx == 0
+            # Each position should have z, y, x dims (M removed)
+            assert "m" not in ngff_image.dims
+            assert "z" in ngff_image.dims
+            assert "y" in ngff_image.dims
+            assert "x" in ngff_image.dims
+
+    def test_non_mosaic_raises_error(self, mock_lif_image_xyz):
+        """Test that non-mosaic image raises ValueError."""
+        with pytest.raises(ValueError, match="does not have a mosaic dimension"):
+            lif_to_hcs_plate(mock_lif_image_xyz)
+
+
+class TestLifFileToNgffImages:
+    """Tests for lif_file_to_ngff_images function using mocked LifFile."""
+
+    @patch("liffile.LifFile")
+    def test_convert_all_series(self, mock_liffile_class):
+        """Test converting all series from a LIF file."""
+        # Setup mock
+        mock_lif = MagicMock()
+        mock_liffile_class.return_value.__enter__ = Mock(return_value=mock_lif)
+        mock_liffile_class.return_value.__exit__ = Mock(return_value=False)
+
+        # Create mock images
+        mock_img1 = Mock()
+        mock_img1.name = "Series1"
+        mock_img1.path = "Series1"
+        mock_img1.dims = ("Z", "Y", "X")
+        mock_img1.shape = (10, 128, 128)
+        mock_img1.dtype = np.uint8
+        mock_img1.coords = {}
+        mock_img1.asarray.return_value = np.zeros((10, 128, 128), dtype=np.uint8)
+
+        mock_img2 = Mock()
+        mock_img2.name = "Series2"
+        mock_img2.path = "Series2"
+        mock_img2.dims = ("Z", "Y", "X")
+        mock_img2.shape = (5, 64, 64)
+        mock_img2.dtype = np.uint8
+        mock_img2.coords = {}
+        mock_img2.asarray.return_value = np.zeros((5, 64, 64), dtype=np.uint8)
+
+        mock_lif.images = [mock_img1, mock_img2]
+
+        from ngff_zarr.lif_to_ngff_image import lif_file_to_ngff_images
+
+        results = lif_file_to_ngff_images("test.lif", series=None)
+
+        assert len(results) == 2
+        assert results[0][0] == "Series1"
+        assert results[1][0] == "Series2"
+
+    @patch("liffile.LifFile")
+    def test_convert_single_series_by_index(self, mock_liffile_class):
+        """Test converting a single series by index."""
+        mock_lif = MagicMock()
+        mock_liffile_class.return_value.__enter__ = Mock(return_value=mock_lif)
+        mock_liffile_class.return_value.__exit__ = Mock(return_value=False)
+
+        mock_img1 = Mock()
+        mock_img1.name = "Series1"
+        mock_img1.path = "Series1"
+        mock_img1.dims = ("Z", "Y", "X")
+        mock_img1.shape = (10, 128, 128)
+        mock_img1.dtype = np.uint8
+        mock_img1.coords = {}
+        mock_img1.asarray.return_value = np.zeros((10, 128, 128), dtype=np.uint8)
+
+        mock_img2 = Mock()
+        mock_img2.name = "Series2"
+        mock_img2.path = "Series2"
+        mock_img2.dims = ("Z", "Y", "X")
+        mock_img2.shape = (5, 64, 64)
+        mock_img2.dtype = np.uint8
+        mock_img2.coords = {}
+        mock_img2.asarray.return_value = np.zeros((5, 64, 64), dtype=np.uint8)
+
+        mock_lif.images = [mock_img1, mock_img2]
+
+        from ngff_zarr.lif_to_ngff_image import lif_file_to_ngff_images
+
+        results = lif_file_to_ngff_images("test.lif", series=1)
+
+        assert len(results) == 1
+        assert results[0][0] == "Series2"
+
+    @patch("liffile.LifFile")
+    def test_convert_series_by_pattern(self, mock_liffile_class):
+        """Test converting series by name pattern."""
+        mock_lif = MagicMock()
+        mock_liffile_class.return_value.__enter__ = Mock(return_value=mock_lif)
+        mock_liffile_class.return_value.__exit__ = Mock(return_value=False)
+
+        mock_img1 = Mock()
+        mock_img1.name = "SHG_area_1"
+        mock_img1.path = "SHG_area_1"
+        mock_img1.dims = ("Z", "Y", "X")
+        mock_img1.shape = (10, 128, 128)
+        mock_img1.dtype = np.uint8
+        mock_img1.coords = {}
+        mock_img1.asarray.return_value = np.zeros((10, 128, 128), dtype=np.uint8)
+
+        mock_img2 = Mock()
+        mock_img2.name = "Overview"
+        mock_img2.path = "Overview"
+        mock_img2.dims = ("Z", "Y", "X")
+        mock_img2.shape = (5, 64, 64)
+        mock_img2.dtype = np.uint8
+        mock_img2.coords = {}
+        mock_img2.asarray.return_value = np.zeros((5, 64, 64), dtype=np.uint8)
+
+        mock_img3 = Mock()
+        mock_img3.name = "SHG_area_2"
+        mock_img3.path = "SHG_area_2"
+        mock_img3.dims = ("Z", "Y", "X")
+        mock_img3.shape = (10, 128, 128)
+        mock_img3.dtype = np.uint8
+        mock_img3.coords = {}
+        mock_img3.asarray.return_value = np.zeros((10, 128, 128), dtype=np.uint8)
+
+        mock_lif.images = [mock_img1, mock_img2, mock_img3]
+
+        from ngff_zarr.lif_to_ngff_image import lif_file_to_ngff_images
+
+        results = lif_file_to_ngff_images("test.lif", series="*SHG*")
+
+        assert len(results) == 2
+        names = [r[0] for r in results]
+        assert "SHG_area_1" in names
+        assert "SHG_area_2" in names
+        assert "Overview" not in names


### PR DESCRIPTION
## Summary

Add comprehensive support for converting Leica Image Format (LIF) files to OME-Zarr format via the `liffile` library.

## Changes

### New Features

- **CLI support** for `.lif`, `.lof`, `.xlif`, `.xlef`, `.xlcf` file extensions
- **`--series` argument** for selecting specific series from multi-series LIF files:
  - By index: `--series 0`
  - By pattern: `--series "*GFP*"`
  - All series (default): `--series all`
- **Python API** with four new exported functions:
  - `lif_to_ngff_image()` - Convert single LifImage to NgffImage
  - `lif_file_to_ngff_images()` - Convert LIF file with series filtering
  - `lif_to_hcs_plate()` - Convert mosaic data to HCS plate structure
  - `has_mosaic_dimension()` - Check for mosaic dimension
- **HCS plate output** automatically generated for mosaic data (M dimension > 1)

### Implementation Details

- **Dimension mapping**: LIF uppercase dimensions (X, Y, Z, T, C) mapped to OME-Zarr lowercase (x, y, z, t, c)
- **Channel flattening**: Multiple channel-like dimensions (C, λ, Λ, S) automatically flattened into single 'c' dimension
- **Metadata extraction**: Scale (pixel spacing) and translation (origin) extracted from LIF coordinates
- **Lazy loading**: Data loaded via Dask delayed for memory efficiency

### Documentation

- New `docs/lif.md` with full usage guide, examples, and API reference
- Updated `docs/cli.md` with LIF conversion examples
- Updated `docs/index.md` to list LIF support in features

### Tests

- 29 new tests covering dimension mapping, scale extraction, conversion, HCS plate generation, and series filtering
- All tests use mocking (liffile is read-only library)
- All 227 tests pass

## Usage

### CLI
```bash
# Convert all series
ngff-zarr -i microscopy.lif -o output/

# Convert specific series by index
ngff-zarr -i microscopy.lif -o output.ome.zarr --series 0

# Convert series matching pattern
ngff-zarr -i microscopy.lif -o output/ --series "*GFP*"
```

### Python
```python
from liffile import LifFile
from ngff_zarr import lif_to_ngff_image, to_multiscales, to_ngff_zarr

with LifFile("microscopy.lif") as lif:
    ngff_image = lif_to_ngff_image(lif.images[0])
    multiscales = to_multiscales(ngff_image, scale_factors=[2, 4])
    to_ngff_zarr("output.ome.zarr", multiscales)
```

## Files Changed

| File | Change |
|------|--------|
| `py/ngff_zarr/lif_to_ngff_image.py` | New - Core conversion module |
| `py/ngff_zarr/cli.py` | Added --series arg and LIFFILE handling |
| `py/ngff_zarr/detect_cli_io_backend.py` | Added LIFFILE backend detection |
| `py/ngff_zarr/cli_input_to_ngff_image.py` | Added LIFFILE handler |
| `py/ngff_zarr/__init__.py` | Exported new functions |
| `py/pyproject.toml` | Added liffile dependency |
| `py/test/test_lif_to_ngff_image.py` | New - Comprehensive tests |
| `py/test/test_detect_cli_input_backend.py` | Added LIF extension tests |
| `docs/lif.md` | New - Full documentation |
| `docs/cli.md` | Added LIF examples |
| `docs/index.md` | Added LIF to features |