### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/mcp-ci.yml
+++ b/.github/workflows/mcp-ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04-arm, windows-2022, macos-15-intel]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python_dask.yaml
+++ b/.github/workflows/python_dask.yaml
@@ -7,9 +7,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.9"
-            zarr-version: "==2.17.1"
-            dask-version: "==2024.8.0"
           - python-version: "3.12"
             zarr-version: ">=3.0.0"
             dask-version: "==2025.11.0"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The main Python package provides:
 - Process extremely large datasets
 - Conversion of most bioimaging file formats
 - Multiple downscaling methods
-- Supports Python>=3.9
+- Supports Python>=3.10
 - Reads OME-Zarr v0.1 to v0.5 into simple Python data classes with Dask arrays
 - Optional OME-Zarr data model validation during reading
 - Writes OME-Zarr v0.4 to v0.5

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ A lean and kind
 - Process extremely large datasets
 - Conversion of most bioimaging file formats
 - Multiple downscaling methods
-- Supports Python>=3.9
+- Supports Python>=3.10
 - Reads OME-Zarr v0.1 to v0.5 into simple Python data classes with Dask arrays
 - Optional OME-Zarr data model validation during reading
 - Writes OME-Zarr v0.4 to v0.5

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -59,7 +59,7 @@ library.
 
 ### Requirements
 
-- Python >= 3.9
+- Python >= 3.10
 - Cursor, Windsurf, Claude Desktop, VS Code, or another MCP Client
 
 ### Quick Install
@@ -766,7 +766,7 @@ ruff check .
 <details>
 <summary><b>Python Version Issues</b></summary>
 
-The ngff-zarr-mcp server requires Python 3.9 or higher. If you encounter version
+The ngff-zarr-mcp server requires Python 3.10 or higher. If you encounter version
 errors:
 
 ```bash

--- a/mcp/pixi.lock
+++ b/mcp/pixi.lock
@@ -6,6 +6,8 @@ environments:
     - url: https://conda.anaconda.org/pyconda/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -713,6 +715,8 @@ environments:
     - url: https://conda.anaconda.org/pyconda/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1304,6 +1308,8 @@ environments:
     - url: https://conda.anaconda.org/pyconda/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1799,6 +1805,8 @@ environments:
     - url: https://conda.anaconda.org/pyconda/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -4701,8 +4709,8 @@ packages:
   timestamp: 1738196177597
 - pypi: ../py
   name: ngff-zarr
-  version: 0.20.0
-  sha256: dff31971d15bf1cec565d3175fb9e7fcaf6c1126896655244845ef79365963d5
+  version: 0.20.3
+  sha256: 577c66ce0212d3bb42b9458ea80e46a75a6bd2912927bb47807c4b16bc056736
   requires_dist:
   - dask[array]
   - importlib-resources
@@ -4761,12 +4769,11 @@ packages:
   - pooch ; extra == 'test'
   - pytest>=6 ; extra == 'test'
   - jsonschema ; extra == 'validate'
-  requires_python: '>=3.9'
-  editable: true
+  requires_python: '>=3.10'
 - pypi: ./
   name: ngff-zarr-mcp
   version: 0.5.0
-  sha256: 0de3f56b4b53550b2f04c523044ceaa51b2304ff12fa84e3aa54ceb01ee6878a
+  sha256: 5811ee70d2fde8facf6e5ddb10adce1bbe150d81741b5d9e25e236f30c7672c5
   requires_dist:
   - aiofiles
   - aiohttp
@@ -4790,8 +4797,7 @@ packages:
   - ruff>=0.0.243 ; extra == 'dev'
   - types-aiofiles ; extra == 'dev'
   - types-psutil ; extra == 'dev'
-  requires_python: '>=3.9'
-  editable: true
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/b8/f5/7f6aa3bbff013c0bf993129cbb2b1505790091f812accbe85cf001514737/nibabel-5.3.3-py3-none-any.whl
   name: nibabel
   version: 5.3.3

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "ngff-zarr-mcp"
 description = "Model Context Protocol server for OME-Zarr image conversion"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT"
 keywords = ["mcp", "ome-zarr", "image-conversion", "microscopy"]
 authors = [
@@ -21,7 +21,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -113,11 +112,11 @@ all = [
 ]
 
 [tool.black]
-target-version = ["py39"]
+target-version = ["py310"]
 line-length = 88
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 88
 
 [tool.coverage.run]
@@ -164,7 +163,7 @@ platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
 ngff-zarr-mcp = { path = ".", editable = true }
 
 [tool.pixi.dependencies]
-python = ">=3.9,<3.14"
+python = ">=3.10,<3.14"
 pytest = ">=8.4.1,<9"
 pytest-asyncio = ">=1.0.0,<2"
 

--- a/py/README.md
+++ b/py/README.md
@@ -22,7 +22,7 @@ implementation.
 - Process extremely large datasets
 - Conversion of most bioimaging file formats
 - Multiple downscaling methods
-- Supports Python>=3.9
+- Supports Python>=3.10
 - Reads OME-Zarr v0.1 to v0.5 into simple Python data classes with Dask arrays
 - Optional OME-Zarr data model validation during reading
 - Writes OME-Zarr v0.4 to v0.5

--- a/py/pixi.lock
+++ b/py/pixi.lock
@@ -7406,7 +7406,7 @@ packages:
 - pypi: ./
   name: ngff-zarr
   version: 0.20.3
-  sha256: dff31971d15bf1cec565d3175fb9e7fcaf6c1126896655244845ef79365963d5
+  sha256: 577c66ce0212d3bb42b9458ea80e46a75a6bd2912927bb47807c4b16bc056736
   requires_dist:
   - dask[array]
   - importlib-resources
@@ -7465,7 +7465,7 @@ packages:
   - pooch ; extra == 'test'
   - pytest>=6 ; extra == 'test'
   - jsonschema ; extra == 'validate'
-  requires_python: '>=3.9'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/b8/f5/7f6aa3bbff013c0bf993129cbb2b1505790091f812accbe85cf001514737/nibabel-5.3.3-py3-none-any.whl
   name: nibabel
   version: 5.3.3

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 name = "ngff-zarr"
 description = 'A lean and kind Open Microscopy Environment (OME) Next Generation File Format (NGFF) Zarr implementation.'
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT"
 keywords = []
 authors = [{ name = "Matt McCormick", email = "matt@fideus.io" }]
@@ -20,7 +20,6 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -179,7 +178,7 @@ docs = { features = ["docs"], no-default-feature = true, solve-group = "default"
 data = { features = ["data"], no-default-feature = true, solve-group = "default" }
 
 [tool.pixi.feature.test.dependencies]
-python = ">=3.9.19,<3.14.0"
+python = ">=3.10,<3.14.0"
 
 [tool.pixi.feature.test.tasks]
 test = { cmd = "pytest", description = "Run the test suite" }
@@ -206,7 +205,7 @@ build-docs = { cmd = "make html", cwd = "docs", description = "Build the documen
 build-docs = { cmd = "make html", cwd = "docs", description = "Build the documentation" }
 
 [tool.pixi.feature.data.dependencies]
-python = ">=3.9.19,<4"
+python = ">=3.10,<4"
 pooch = ">=1.8.2,<2"
 
 [tool.pixi.feature.data.tasks]


### PR DESCRIPTION
## Summary

Drops Python 3.9 support as it has reached end-of-life per the [Python Developer's Guide](https://devguide.python.org/versions/).

Closes #251

## Changes

### Package Configuration
- Updated `requires-python` from `>=3.9` to `>=3.10` in both `py/pyproject.toml` and `mcp/pyproject.toml`
- Removed `Programming Language :: Python :: 3.9` classifier from both packages
- Updated black and ruff `target-version` from `py39` to `py310` in `mcp/pyproject.toml`
- Updated pixi Python version constraints in both packages

### CI/CD
- Removed Python 3.9 from test matrix in `.github/workflows/python.yml`
- Removed Python 3.9 from test matrix in `.github/workflows/mcp-ci.yml`
- Removed the Python 3.9 + zarr 2.17.1 + dask 2024.8.0 legacy test configuration from `.github/workflows/python_dask.yaml`

### Documentation
- Updated Python version references in `README.md`, `py/README.md`, `docs/index.md`, and `mcp/README.md`

### Lock Files
- Regenerated `py/pixi.lock` and `mcp/pixi.lock` with updated Python constraints