### PR TITLE
fix(cli): handle filenames with multiple dots in extension detection

### DIFF
--- a/py/ngff_zarr/detect_cli_io_backend.py
+++ b/py/ngff_zarr/detect_cli_io_backend.py
@@ -18,6 +18,17 @@ conversion_backends_values = [b[1] for b in conversion_backends]
 ConversionBackend = Enum("ConversionBackend", conversion_backends)
 
 
+def _matches_extension(extension: str, supported_extensions: tuple) -> bool:
+    """Check if extension ends with any of the supported extensions.
+
+    Checks longer extensions first to ensure precise matching
+    (e.g., '.ome.zarr' before '.zarr').
+    """
+    # Sort by length descending to check longer extensions first
+    sorted_extensions = sorted(supported_extensions, key=len, reverse=True)
+    return any(extension.endswith(ext) for ext in sorted_extensions)
+
+
 def detect_cli_io_backend(input: List[str]) -> ConversionBackend:
     if (Path(input[0]) / ".zarray").exists():
         return ConversionBackend.ZARR_ARRAY
@@ -26,12 +37,12 @@ def detect_cli_io_backend(input: List[str]) -> ConversionBackend:
 
     # RFC-9: Support .ozx (zipped OME-Zarr) files
     ngff_zarr_supported_extensions = (".zarr", ".ome.zarr", ".ozx")
-    if extension in ngff_zarr_supported_extensions:
+    if _matches_extension(extension, ngff_zarr_supported_extensions):
         return ConversionBackend.NGFF_ZARR
 
     # Prioritize NIBABEL for NIfTI files
     nibabel_supported_extensions = (".nii", ".nii.gz")
-    if extension in nibabel_supported_extensions:
+    if _matches_extension(extension, nibabel_supported_extensions):
         return ConversionBackend.NIBABEL
 
     itkwasm_supported_extensions = (
@@ -68,7 +79,7 @@ def detect_cli_io_backend(input: List[str]) -> ConversionBackend:
         ".fdf",
     )
     if (
-        extension in itkwasm_supported_extensions
+        _matches_extension(extension, itkwasm_supported_extensions)
         and len(input) == 1
         and Path(input[0]).is_file()
         and Path(input[0]).stat().st_size < 2e9
@@ -109,16 +120,16 @@ def detect_cli_io_backend(input: List[str]) -> ConversionBackend:
         ".fdf",  # Requires pip install itk-iofdf
     )
 
-    if extension in itk_supported_extensions:
+    if _matches_extension(extension, itk_supported_extensions):
         return ConversionBackend.ITK
 
     try:
         import tifffile
 
-        tifffile_supported_extensions = [
+        tifffile_supported_extensions = tuple(
             f".{ext}" for ext in tifffile.TIFF.FILE_EXTENSIONS
-        ]
-        if extension in tifffile_supported_extensions:
+        )
+        if _matches_extension(extension, tifffile_supported_extensions):
             return ConversionBackend.TIFFFILE
     except ImportError:
         from rich import print

--- a/py/test/test_detect_cli_input_backend.py
+++ b/py/test/test_detect_cli_input_backend.py
@@ -61,3 +61,18 @@ def test_detect_imageio_input_backend():
         ]
     )
     assert backend == ConversionBackend.IMAGEIO
+
+
+def test_detect_ngff_zarr_input_backend_with_extra_dots():
+    """Test that filenames with additional dots like '.qupath.ome.zarr' are correctly detected.
+
+    Regression test for GitHub issue #272.
+    """
+    backend = detect_cli_io_backend(["602a12_z_stack.qupath.ome.zarr"])
+    assert backend == ConversionBackend.NGFF_ZARR
+
+
+def test_detect_nibabel_input_backend_with_extra_dots():
+    """Test that filenames with additional dots like '.scan.nii.gz' are correctly detected."""
+    backend = detect_cli_io_backend(["patient.scan.nii.gz"])
+    assert backend == ConversionBackend.NIBABEL


### PR DESCRIPTION
## Summary

Fixes #272

The CLI backend detection failed for filenames with multiple dots like `602a12_z_stack.qupath.ome.zarr`, causing an `OSError: ImageIO does not generally support reading folders` error.

## Problem

The `detect_cli_io_backend()` function used exact extension matching (`extension in supported_extensions`) which failed for filenames with additional dots. Python's `Path.suffixes` captures **all** suffixes, so:

- `file.ome.zarr` → suffixes: `['.ome', '.zarr']` → extension: `.ome.zarr` ✓
- `602a12_z_stack.qupath.ome.zarr` → suffixes: `['.qupath', '.ome', '.zarr']` → extension: `.qupath.ome.zarr` ✗

The second case didn't match `.ome.zarr` exactly, causing it to fall through to the IMAGEIO backend, which doesn't support folders.

## Solution

- Added `_matches_extension()` helper function that uses `endswith()` matching instead of exact equality
- The helper sorts extensions by length (descending) to check longer extensions first (e.g., `.ome.zarr` before `.zarr`)
- Updated all 5 extension checks to use the new helper: NGFF_ZARR, NIBABEL, ITKWASM, ITK, and TIFFFILE

## Testing

Added 2 new test cases:
- `test_detect_ngff_zarr_input_backend_with_extra_dots()` - regression test for issue #272
- `test_detect_nibabel_input_backend_with_extra_dots()` - test for multi-part nibabel extensions

All 8 tests pass.