### PR TITLE
Fix IndexError in IMAGEIO backend when spacing has fewer elements than dims

### DIFF
--- a/py/ngff_zarr/cli_input_to_ngff_image.py
+++ b/py/ngff_zarr/cli_input_to_ngff_image.py
@@ -93,12 +93,16 @@ def cli_input_to_ngff_image(
 
         props = iio.improps(str(input[0]))
         if props.spacing is not None:
+            # Only apply spacing to spatial dimensions (x, y, z)
+            spatial_dims = [d for d in ngff_image.dims if d in {"x", "y", "z"}]
             if len(props.spacing) == 1:
-                scale = {d: props.spacing for d in ngff_image.dims}
-                ngff_image.scale = scale
+                scale = {d: props.spacing[0] for d in spatial_dims}
             else:
-                scale = {d: props.spacing[i] for i, d in enumerate(ngff_image.dims)}
-                ngff_image.scale = scale
+                # Match spacing values to spatial dims
+                # Spacing from imageio may have fewer values than spatial dims
+                n_spatial = min(len(props.spacing), len(spatial_dims))
+                scale = {spatial_dims[i]: props.spacing[i] for i in range(n_spatial)}
+            ngff_image.scale = scale
 
         return ngff_image
     return None

--- a/py/test/test_cli_input_to_ngff_image.py
+++ b/py/test/test_cli_input_to_ngff_image.py
@@ -68,3 +68,27 @@ def test_cli_input_to_ngff_image_imageio(input_images):  # noqa: ARG001
     ]
     image = cli_input_to_ngff_image(ConversionBackend.IMAGEIO, input)
     assert image.dims == ("y", "x")
+
+
+def test_cli_input_to_ngff_image_imageio_spacing_mismatch():
+    """Test that imageio backend handles spacing with fewer values than dims.
+
+    This tests the fix for GitHub issue #270 where props.spacing from imageio
+    has fewer elements than the image dimensions, causing an IndexError.
+    """
+    import tempfile
+    import numpy as np
+
+    # Create a 2D test image
+    data_2d = np.random.randint(0, 255, size=(64, 64), dtype=np.uint8)
+
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        import imageio.v3 as iio
+
+        iio.imwrite(f.name, data_2d)
+
+        # Test that the imageio backend doesn't crash with spacing
+        image = cli_input_to_ngff_image(ConversionBackend.IMAGEIO, [f.name])
+        assert image.dims == ("y", "x")
+        # Scale should only contain spatial dimensions
+        assert set(image.scale.keys()).issubset({"x", "y", "z"})


### PR DESCRIPTION
## Summary

Fixes #270

This PR fixes an `IndexError: tuple index out of range` that occurs when using the IMAGEIO backend with OME-TIFF files where the spacing metadata has fewer elements than the image dimensions.

## Problem

When processing multi-dimensional OME-TIFF files via the IMAGEIO backend:
1. `to_ngff_image()` assigns dimensions based on the array's `ndim` (e.g., a 5D array gets `("t", "z", "y", "x", "c")`)
2. `imageio.improps()` returns spacing only for the spatial dimensions encoded in the file (typically 2-3 values for Y/X or Z/Y/X)
3. The original code attempted to create a scale dict by iterating over all dims and indexing into `props.spacing`, causing an `IndexError` when `len(props.spacing) < len(ngff_image.dims)`

## Solution

Modified the IMAGEIO backend in `cli_input_to_ngff_image.py` to:
1. Extract only spatial dimensions (`x`, `y`, `z`) from the full dims tuple
2. Map spacing values only to those spatial dimensions
3. Handle cases where spacing has fewer values than spatial dims using `min(len(props.spacing), len(spatial_dims))`

This approach follows the same pattern used in `itk_image_to_ngff_image.py`.

## Changes

- `py/ngff_zarr/cli_input_to_ngff_image.py`: Fixed spacing assignment to only apply to spatial dimensions
- `py/test/test_cli_input_to_ngff_image.py`: Added regression test `test_cli_input_to_ngff_image_imageio_spacing_mismatch`