### PR TITLE
feat(py,ts): add OMERO metadata computation from NgffImage

### DIFF
--- a/py/ngff_zarr/__init__.py
+++ b/py/ngff_zarr/__init__.py
@@ -6,6 +6,11 @@
 from .__about__ import __version__
 from ._supported_versions import SUPPORTED_VERSIONS
 from .cli_input_to_ngff_image import cli_input_to_ngff_image
+from .compute_omero import (
+    GLASBEY_COLORS,
+    compute_omero_from_multiscales,
+    compute_omero_from_ngff_image,
+)
 from .config import config
 from .detect_cli_io_backend import ConversionBackend, detect_cli_io_backend
 from .from_ngff_zarr import from_ngff_zarr
@@ -78,6 +83,10 @@ __all__ = [
     "__version__",
     "SUPPORTED_VERSIONS",
     "config",
+    # OMERO computation
+    "compute_omero_from_ngff_image",
+    "compute_omero_from_multiscales",
+    "GLASBEY_COLORS",
     "NgffImage",
     "Multiscales",
     "to_ngff_image",

--- a/py/ngff_zarr/cli.py
+++ b/py/ngff_zarr/cli.py
@@ -7,6 +7,7 @@ if __name__ == "__main__" and __package__ is None:
 
 import argparse
 import atexit
+import re
 import signal
 import sys
 from pathlib import Path
@@ -35,6 +36,7 @@ else:
     LocalStore = zarr.storage.LocalStore
 
 from .cli_input_to_ngff_image import cli_input_to_ngff_image
+from .compute_omero import compute_omero_from_multiscales
 from .config import config
 from .detect_cli_io_backend import (
     ConversionBackend,
@@ -48,13 +50,131 @@ from .rich_dask_progress import NgffProgress, NgffProgressCallback
 from .to_multiscales import to_multiscales
 from .to_ngff_image import to_ngff_image
 from .to_ngff_zarr import to_ngff_zarr
-from .v04.zarr_metadata import is_unit_supported
+from .v04.zarr_metadata import Omero, OmeroChannel, OmeroWindow, is_unit_supported
 from ._zarr_kwargs import zarr_kwargs
+
+
+def _apply_omero_metadata(live, args, multiscales):
+    """Apply OMERO metadata to multiscales based on CLI arguments.
+
+    If --no-omero is specified, skip OMERO computation.
+    If --omero-window is specified, use manual values.
+    Otherwise, compute OMERO metadata from the image data.
+    """
+    # Skip if --no-omero is specified
+    if args.no_omero:
+        return
+
+    # Validate quantiles early
+    if args.omero_quantiles:
+        low, high = args.omero_quantiles
+        if not (0.0 <= low <= 1.0):
+            raise ValueError(
+                f"Low quantile must be between 0 and 1, got {low}. "
+                "Use --omero-quantiles LOW HIGH (e.g., --omero-quantiles 0.02 0.98)"
+            )
+        if not (0.0 <= high <= 1.0):
+            raise ValueError(
+                f"High quantile must be between 0 and 1, got {high}. "
+                "Use --omero-quantiles LOW HIGH (e.g., --omero-quantiles 0.02 0.98)"
+            )
+        if low >= high:
+            raise ValueError(
+                f"Low quantile must be less than high quantile, got ({low}, {high}). "
+                "Use --omero-quantiles LOW HIGH (e.g., --omero-quantiles 0.02 0.98)"
+            )
+
+    # Validate colors early if provided
+    if args.omero_colors:
+        for color in args.omero_colors:
+            if not re.fullmatch(r"[0-9A-Fa-f]{6}", color):
+                raise ValueError(
+                    f"Color must be a 6-digit hexadecimal string without # prefix, got '{color}'. "
+                    "Use --omero-colors RRGGBB RRGGBB (e.g., --omero-colors FF0000 00FF00)"
+                )
+
+    # If multiscales already has OMERO metadata and no manual override, keep it
+    if multiscales.metadata.omero is not None and args.omero_window is None:
+        return
+
+    # If manual OMERO windows are specified, use them
+    if args.omero_window is not None:
+        channels = []
+        n_windows = len(args.omero_window)
+
+        # Get colors (default to white for single, glasbey for multiple)
+        if args.omero_colors:
+            # Validate we have enough colors
+            if len(args.omero_colors) < n_windows:
+                raise ValueError(
+                    f"Not enough colors provided for {n_windows} windows. "
+                    f"Got {len(args.omero_colors)} colors. "
+                    "Provide at least one color per --omero-window."
+                )
+            colors = args.omero_colors
+        else:
+            from .compute_omero import get_default_colors
+
+            colors = get_default_colors(n_windows)
+
+        # Get labels (default to empty)
+        if args.omero_labels:
+            # Validate we have enough labels
+            if len(args.omero_labels) < n_windows:
+                raise ValueError(
+                    f"Not enough labels provided for {n_windows} windows. "
+                    f"Got {len(args.omero_labels)} labels. "
+                    "Provide at least one label per --omero-window."
+                )
+            labels = args.omero_labels
+        else:
+            labels = [""] * n_windows
+
+        for i, window_values in enumerate(args.omero_window):
+            min_val, max_val, start_val, end_val = window_values
+            window = OmeroWindow(
+                min=min_val, max=max_val, start=start_val, end=end_val
+            )
+            color = colors[i]
+            label = labels[i]
+            channel = OmeroChannel(color=color, window=window, label=label)
+            channels.append(channel)
+
+        multiscales.metadata.omero = Omero(channels=channels)
+        return
+
+    # Compute OMERO metadata from image data
+    if not args.quiet:
+        live.console.log("[yellow]Computing OMERO visualization metadata...")
+
+    quantiles = tuple(args.omero_quantiles)
+    colors = args.omero_colors
+    labels = args.omero_labels
+
+    try:
+        omero = compute_omero_from_multiscales(
+            multiscales,
+            quantiles=quantiles,
+            colors=colors,
+            labels=labels,
+            use_lowest_resolution=True,  # Use lowest resolution for speed
+        )
+        multiscales.metadata.omero = omero
+        if not args.quiet:
+            live.console.log(
+                f"[green]Computed OMERO metadata for {len(omero.channels)} channel(s)"
+            )
+    except Exception as e:
+        if not args.quiet:
+            live.console.log(f"[yellow]Warning: Could not compute OMERO metadata: {e}")
 
 
 def _multiscales_to_ngff_zarr(
     live, args, output_store, rich_dask_progress, multiscales, chunks_per_shard=None
 ):
+    # Apply OMERO metadata before displaying or writing
+    _apply_omero_metadata(live, args, multiscales)
+
     if not args.output:
         if args.quiet:
             live.update(Pretty(multiscales))
@@ -223,6 +343,44 @@ def main():
         type=int,
         help="Enable specific RFC features. Can be used multiple times. Currently supported: 4 (anatomical orientation)",
         metavar="RFC_NUMBER",
+    )
+
+    # OMERO metadata options
+    omero_group = parser.add_argument_group(
+        "omero", "OMERO visualization metadata options"
+    )
+    omero_group.add_argument(
+        "--no-omero",
+        action="store_true",
+        help="Disable automatic OMERO metadata computation",
+    )
+    omero_group.add_argument(
+        "--omero-quantiles",
+        nargs=2,
+        type=float,
+        metavar=("LOW", "HIGH"),
+        default=[0.02, 0.98],
+        help="Quantiles for OMERO window start/end (default: 0.02 0.98)",
+    )
+    omero_group.add_argument(
+        "--omero-window",
+        nargs=4,
+        type=float,
+        action="append",
+        metavar=("MIN", "MAX", "START", "END"),
+        help="Manually specify OMERO window for a channel. Can be used multiple times for multi-channel images.",
+    )
+    omero_group.add_argument(
+        "--omero-colors",
+        nargs="+",
+        metavar="COLOR",
+        help="Hex colors for channels without # prefix (e.g., FF0000 00FF00 0000FF)",
+    )
+    omero_group.add_argument(
+        "--omero-labels",
+        nargs="+",
+        metavar="LABEL",
+        help="Labels for channels (e.g., DAPI GFP RFP)",
     )
 
     processing_group = parser.add_argument_group("processing", "Processing options")

--- a/py/ngff_zarr/compute_omero.py
+++ b/py/ngff_zarr/compute_omero.py
@@ -1,0 +1,568 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Compute OMERO metadata from NgffImage data."""
+
+import re
+from typing import List, Optional, Sequence, Tuple, Union
+
+import dask.array as da
+
+from .ngff_image import NgffImage
+from .v04.zarr_metadata import Omero, OmeroChannel, OmeroWindow
+
+# Glasbey color palette from colorcet's glasbey_hv
+# Extended from HoloViews default colors using the Glasbey algorithm
+# for maximum distinguishability across 256 categorical colors.
+# See: https://colorcet.holoviz.org/user_guide/Categorical.html
+GLASBEY_COLORS: List[str] = [
+    "30A2DA",
+    "FC4F30",
+    "E5AE38",
+    "6D904F",
+    "8B8B8B",
+    "17BECF",
+    "9467BD",
+    "D62728",
+    "1F77B4",
+    "E377C2",
+    "8C564B",
+    "BCBD22",
+    "3A0183",
+    "004300",
+    "0FFFA9",
+    "5E0040",
+    "C6BDFF",
+    "425052",
+    "B80080",
+    "FFB7B3",
+    "7D0200",
+    "6126FF",
+    "FFFF9A",
+    "AEC9AB",
+    "00867C",
+    "553A00",
+    "94FCFF",
+    "00BF00",
+    "7D00A0",
+    "AB7200",
+    "91FF00",
+    "01BE8A",
+    "00457B",
+    "C8826F",
+    "FF1F83",
+    "DD00FF",
+    "057400",
+    "644461",
+    "888FFF",
+    "FFB6F4",
+    "536237",
+    "CE85FF",
+    "686A84",
+    "BEB4BE",
+    "A56089",
+    "95D3FF",
+    "0100F8",
+    "FF8002",
+    "8B2945",
+    "ADA06D",
+    "53458B",
+    "C8FFD9",
+    "AA4600",
+    "FF798F",
+    "83D371",
+    "909EBF",
+    "9400F5",
+    "EBD09B",
+    "AD8BB1",
+    "00634A",
+    "FFDC00",
+    "887751",
+    "7EABA3",
+    "000097",
+    "F500C6",
+    "653329",
+    "006678",
+    "04E3C8",
+    "A737AE",
+    "C5DBE1",
+    "4D6EFF",
+    "9B9301",
+    "CD586B",
+    "EFDEFE",
+    "795A00",
+    "5F889A",
+    "B4FF92",
+    "5E726B",
+    "520066",
+    "058751",
+    "84206F",
+    "3C9605",
+    "657300",
+    "F1A06C",
+    "5F5045",
+    "BD004A",
+    "D06827",
+    "D796AB",
+    "895DFF",
+    "826C76",
+    "2B55B9",
+    "6E7CBB",
+    "E7D5D3",
+    "5D0018",
+    "7C3B01",
+    "80B17D",
+    "C8D97D",
+    "00E83B",
+    "7CB2FF",
+    "FF55FF",
+    "A42721",
+    "1DE4FF",
+    "7DAF3B",
+    "7B4B91",
+    "E0FF48",
+    "6B00C4",
+    "CDA897",
+    "BE63C4",
+    "89CDCE",
+    "4603C8",
+    "5E9279",
+    "414A01",
+    "05A79D",
+    "CF8C37",
+    "FFF8D0",
+    "435471",
+    "B544FF",
+    "CF4993",
+    "CFA4DF",
+    "94D400",
+    "A794DA",
+    "2DA558",
+    "8DE3B6",
+    "A4A99D",
+    "6C5CB7",
+    "FF7E5E",
+    "A7838A",
+    "AFBED8",
+    "2AC4FF",
+    "A6683D",
+    "F691FE",
+    "874B64",
+    "FF0C4B",
+    "215E23",
+    "4292FF",
+    "87839D",
+    "672D45",
+    "B14F41",
+    "004E53",
+    "5F1B00",
+    "AD4167",
+    "503267",
+    "D6FFFD",
+    "7FB5D1",
+    "A9B969",
+    "FF96CB",
+    "C87495",
+    "365039",
+    "FFD063",
+    "5E5862",
+    "879476",
+    "A978FF",
+    "03C863",
+    "E7BED4",
+    "D4E3D0",
+    "876790",
+    "897C27",
+    "CDDCFF",
+    "AA676B",
+    "323474",
+    "FF5EA9",
+    "009BB0",
+    "71FFDD",
+    "785C38",
+    "50659B",
+    "CC00B3",
+    "577B55",
+    "516E7B",
+    "015F92",
+    "AABDBE",
+    "017F99",
+    "04DD97",
+    "873A2C",
+    "F0968E",
+    "75C6AA",
+    "70695D",
+    "CCDC09",
+    "AF8557",
+    "D80075",
+    "9D3F81",
+    "D94500",
+    "DD6754",
+    "5FFF79",
+    "D5B173",
+    "62265E",
+    "BAA23D",
+    "D9F2B3",
+    "57028F",
+    "A19BAA",
+    "4D4A27",
+    "A4A9FF",
+    "ACE8DB",
+    "995901",
+    "AC00E2",
+    "47822F",
+    "CBC3AD",
+    "00C5B6",
+    "615378",
+    "336D68",
+    "A59280",
+    "8499A2",
+    "FD5764",
+    "7096D2",
+    "728D07",
+    "7F004C",
+    "1530A0",
+    "D1C1E2",
+    "C985D0",
+    "6C454B",
+    "7F0024",
+    "00A279",
+    "B2A9CF",
+    "F90000",
+    "B0E9FF",
+    "939E50",
+    "727A82",
+    "D92E55",
+    "476101",
+    "0059FF",
+    "7740B5",
+    "ACE460",
+    "674525",
+    "525D51",
+    "957368",
+    "A9E49A",
+    "A30058",
+    "D962F6",
+    "8E7DCF",
+    "FFBD93",
+    "A30092",
+    "9AFFB9",
+    "A7C2FF",
+    "F46200",
+    "E5F0FF",
+    "B89CA4",
+    "609694",
+    "FF9F35",
+    "8C2900",
+    "726B32",
+    "DF824E",
+    "AF7BD5",
+    "BC2D00",
+    "7B6FA3",
+    "484362",
+    "C7A3FF",
+    "004D28",
+    "C4C68E",
+    "E048D7",
+    "E7E965",
+    "E5C10B",
+    "00F4F1",
+    "9F5BA2",
+    "4C41B7",
+    "65338E",
+    "767E6C",
+    "A98A36",
+]
+
+
+def _validate_quantiles(quantiles: Tuple[float, float]) -> None:
+    """Validate that quantiles are in valid range and properly ordered.
+
+    Args:
+        quantiles: Tuple of (low, high) quantile values
+
+    Raises:
+        ValueError: If quantiles are invalid
+    """
+    if len(quantiles) != 2:
+        raise ValueError(f"Expected 2 quantiles, got {len(quantiles)}")
+
+    low, high = quantiles
+    if not (0.0 <= low <= 1.0):
+        raise ValueError(f"Low quantile must be between 0 and 1, got {low}")
+    if not (0.0 <= high <= 1.0):
+        raise ValueError(f"High quantile must be between 0 and 1, got {high}")
+    if low >= high:
+        raise ValueError(
+            f"Low quantile must be less than high quantile, got ({low}, {high})"
+        )
+
+
+def _validate_color(color: str) -> None:
+    """Validate that a color is a valid 6-digit hexadecimal string.
+
+    Args:
+        color: Hex color string (without # prefix)
+
+    Raises:
+        ValueError: If color is invalid
+    """
+    if not isinstance(color, str):
+        raise ValueError(f"Color must be a string, got {type(color).__name__}")
+    if not re.fullmatch(r"[0-9A-Fa-f]{6}", color):
+        raise ValueError(
+            f"Color must be a 6-digit hexadecimal string without # prefix, got '{color}'"
+        )
+
+
+def get_default_colors(n_channels: int) -> List[str]:
+    """Get default colors for channels.
+
+    For a single channel, returns white (FFFFFF).
+    For multiple channels, uses the Glasbey color progression.
+
+    Args:
+        n_channels: Number of channels
+
+    Returns:
+        List of hex color strings (without # prefix)
+    """
+    if n_channels == 1:
+        return ["FFFFFF"]
+    # Cycle through Glasbey colors if we have more channels than colors
+    return [GLASBEY_COLORS[i % len(GLASBEY_COLORS)] for i in range(n_channels)]
+
+
+def _compute_channel_statistics(
+    data: da.Array,
+    quantiles: Tuple[float, float],
+) -> Tuple[float, float, float, float]:
+    """Compute min, max, and quantiles for a single channel.
+
+    Uses dask.array operations to efficiently compute statistics without
+    loading all data into memory. Uses approximate quantile computation
+    that works across chunks, which is suitable for visualization parameters.
+
+    Args:
+        data: Dask array for a single channel (can be multi-dimensional)
+        quantiles: Tuple of (low, high) quantile values (e.g., (0.02, 0.98))
+
+    Returns:
+        Tuple of (min, max, q_low, q_high) as floats
+
+    Note:
+        The quantile computation uses Dask's approximate percentile algorithm
+        which processes chunks independently and merges results. This is
+        memory-efficient and suitable for visualization window parameters,
+        though results may differ slightly from exact quantiles.
+    """
+    import numpy as np
+
+    # Flatten the array for statistics computation
+    flat_data = data.ravel()
+
+    # Set up lazy computations for min/max (these are exact)
+    data_min = da.nanmin(flat_data)
+    data_max = da.nanmax(flat_data)
+
+    # First compute min/max to check for all-NaN case
+    min_val, max_val = da.compute(data_min, data_max)
+
+    # Handle all-NaN case: if min is NaN, all values are NaN
+    if np.isnan(min_val):
+        return (float("nan"), float("nan"), float("nan"), float("nan"))
+
+    # Use dask's approximate percentile computation which works across chunks
+    # without loading all data into memory. Convert quantiles to percentiles (0-100).
+    # Filter out NaN values before computing percentiles since da.percentile
+    # doesn't have a nan-aware variant for 1-D arrays with approximate methods.
+    percentiles = [q * 100 for q in quantiles]
+    valid_data = flat_data[~da.isnan(flat_data)]
+
+    # da.percentile works on 1-D arrays and uses approximate methods
+    # that compute per-chunk percentiles and merge them efficiently
+    q_low = da.percentile(valid_data, percentiles[0])
+    q_high = da.percentile(valid_data, percentiles[1])
+
+    # Compute quantile statistics (min/max already computed above)
+    low_val, high_val = da.compute(q_low, q_high)
+
+    return (
+        float(min_val),
+        float(max_val),
+        float(low_val),
+        float(high_val),
+    )
+
+
+def compute_omero_from_ngff_image(
+    ngff_image: NgffImage,
+    quantiles: Tuple[float, float] = (0.02, 0.98),
+    colors: Optional[Sequence[str]] = None,
+    labels: Optional[Sequence[str]] = None,
+) -> Omero:
+    """Compute OMERO metadata from an NgffImage.
+
+    This function computes visualization parameters (OMERO metadata) from image data:
+    - min/max: The actual data range (exact values)
+    - start/end: Display window based on quantiles (default 2% and 98%)
+
+    For multi-channel images (with 'c' dimension), statistics are computed
+    separately for each channel, resulting in per-channel OMERO windows.
+
+    This function uses memory-efficient approximate quantile computation that
+    processes data in chunks without loading the entire dataset into memory.
+    The approximate quantiles are well-suited for visualization parameters
+    where slight variations from exact values are acceptable.
+
+    Edge cases:
+    - If all values in a channel are NaN, the statistics will be NaN.
+    - If a channel has constant values, min/max/start/end will all be the same.
+
+    Args:
+        ngff_image: The NgffImage to compute metadata for
+        quantiles: Tuple of (low, high) quantile values for the display window.
+                   Must be between 0 and 1, with low < high.
+                   Default is (0.02, 0.98) for 2% and 98% quantiles.
+        colors: Optional list of hex color strings (without #) for each channel.
+                Must be 6-digit hexadecimal strings (e.g., "FF0000" for red).
+                If not provided, uses white for single channel or Glasbey
+                progression for multi-channel.
+        labels: Optional list of label strings for each channel.
+                If not provided, uses empty strings.
+
+    Returns:
+        Omero metadata with computed window parameters for each channel.
+
+    Raises:
+        ValueError: If quantiles are invalid, colors are invalid format,
+                    or not enough colors/labels provided.
+
+    Example:
+        >>> image = to_ngff_image(data, dims=["c", "z", "y", "x"])
+        >>> omero = compute_omero_from_ngff_image(image)
+        >>> multiscales.metadata.omero = omero
+    """
+    # Validate quantiles
+    _validate_quantiles(quantiles)
+
+    data = ngff_image.data
+    dims = list(ngff_image.dims)
+
+    # Check if there's a channel dimension
+    has_channel_dim = "c" in dims
+    if has_channel_dim:
+        c_index = dims.index("c")
+        n_channels = data.shape[c_index]
+    else:
+        n_channels = 1
+
+    # Get colors
+    if colors is not None:
+        if len(colors) < n_channels:
+            raise ValueError(
+                f"Not enough colors provided. Got {len(colors)}, need {n_channels}."
+            )
+        # Validate each color
+        for color in colors[:n_channels]:
+            _validate_color(color)
+        channel_colors = list(colors[:n_channels])
+    else:
+        channel_colors = get_default_colors(n_channels)
+
+    # Get labels
+    if labels is not None:
+        if len(labels) < n_channels:
+            raise ValueError(
+                f"Not enough labels provided. Got {len(labels)}, need {n_channels}."
+            )
+        channel_labels = list(labels[:n_channels])
+    else:
+        channel_labels = [""] * n_channels
+
+    # Compute statistics for each channel
+    channels: List[OmeroChannel] = []
+
+    for ch_idx in range(n_channels):
+        if has_channel_dim:
+            # Extract this channel's data
+            # Build a slice tuple to select this channel
+            slices: List[Union[int, slice]] = [slice(None)] * len(data.shape)
+            slices[c_index] = ch_idx
+            channel_data = data[tuple(slices)]
+        else:
+            channel_data = data
+
+        # Compute statistics
+        data_min, data_max, q_low, q_high = _compute_channel_statistics(
+            channel_data, quantiles
+        )
+
+        # Create OMERO window
+        window = OmeroWindow(
+            min=data_min,
+            max=data_max,
+            start=q_low,
+            end=q_high,
+        )
+
+        # Create channel metadata
+        channel = OmeroChannel(
+            color=channel_colors[ch_idx],
+            window=window,
+            label=channel_labels[ch_idx],
+        )
+        channels.append(channel)
+
+    return Omero(channels=channels)
+
+
+def compute_omero_from_multiscales(
+    multiscales: "Multiscales",  # noqa: F821
+    quantiles: Tuple[float, float] = (0.02, 0.98),
+    colors: Optional[Sequence[str]] = None,
+    labels: Optional[Sequence[str]] = None,
+    use_lowest_resolution: bool = True,
+) -> Omero:
+    """Compute OMERO metadata from a Multiscales object.
+
+    This is a convenience function that computes OMERO metadata from the
+    highest or lowest resolution image in a multiscales pyramid.
+
+    Uses memory-efficient approximate quantile computation that processes
+    data in chunks. This makes it safe to use with very large datasets
+    without risk of memory exhaustion.
+
+    Args:
+        multiscales: The Multiscales object to compute metadata for
+        quantiles: Tuple of (low, high) quantile values for the display window.
+        colors: Optional list of hex color strings for each channel.
+        labels: Optional list of label strings for each channel.
+        use_lowest_resolution: If True (default), use the lowest resolution
+            (smallest) image for faster computation. If False, use the highest
+            resolution (largest) image.
+
+    Returns:
+        Omero metadata with computed window parameters for each channel.
+    """
+    from .multiscales import Multiscales
+
+    if not isinstance(multiscales, Multiscales):
+        raise TypeError(f"Expected Multiscales, got {type(multiscales)}")
+
+    if not multiscales.images:
+        raise ValueError("Multiscales has no images")
+
+    # Select which image to use based on resolution preference
+    if use_lowest_resolution:
+        # Use the last image (lowest resolution, smallest)
+        image = multiscales.images[-1]
+    else:
+        # Use the first image (highest resolution, largest)
+        image = multiscales.images[0]
+
+    return compute_omero_from_ngff_image(
+        image,
+        quantiles=quantiles,
+        colors=colors,
+        labels=labels,
+    )

--- a/py/test/test_compute_omero.py
+++ b/py/test/test_compute_omero.py
@@ -1,0 +1,422 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Tests for compute_omero functionality."""
+
+import numpy as np
+import pytest
+
+from ngff_zarr import (
+    GLASBEY_COLORS,
+    compute_omero_from_multiscales,
+    compute_omero_from_ngff_image,
+    to_multiscales,
+    to_ngff_image,
+)
+
+
+class TestComputeOmeroSingleChannel:
+    """Tests for single-channel images."""
+
+    def test_compute_basic_statistics(self):
+        """Test that min, max, and quantiles are computed correctly."""
+        # Create a simple array with known values
+        # Values 0-99, so min=0, max=99, 2%=~2, 98%=~97
+        data = np.arange(100).reshape((10, 10)).astype(np.float32)
+        image = to_ngff_image(data, dims=["y", "x"])
+
+        omero = compute_omero_from_ngff_image(image)
+
+        assert len(omero.channels) == 1
+        channel = omero.channels[0]
+
+        # Check min/max
+        assert channel.window.min == 0.0
+        assert channel.window.max == 99.0
+
+        # Check quantiles (approximate due to interpolation)
+        assert 0.0 <= channel.window.start <= 5.0
+        assert 94.0 <= channel.window.end <= 99.0
+
+    def test_single_channel_uses_white_color(self):
+        """Test that single channel defaults to white color."""
+        data = np.ones((10, 10), dtype=np.float32)
+        image = to_ngff_image(data, dims=["y", "x"])
+
+        omero = compute_omero_from_ngff_image(image)
+
+        assert omero.channels[0].color == "FFFFFF"
+
+    def test_custom_quantiles(self):
+        """Test that custom quantiles are respected."""
+        data = np.arange(100).reshape((10, 10)).astype(np.float32)
+        image = to_ngff_image(data, dims=["y", "x"])
+
+        # Use 10% and 90% quantiles
+        omero = compute_omero_from_ngff_image(image, quantiles=(0.10, 0.90))
+
+        channel = omero.channels[0]
+        # 10% of 100 values is ~10, 90% is ~90
+        assert 5.0 <= channel.window.start <= 15.0
+        assert 85.0 <= channel.window.end <= 95.0
+
+    def test_custom_color(self):
+        """Test that custom colors are applied."""
+        data = np.ones((10, 10), dtype=np.float32)
+        image = to_ngff_image(data, dims=["y", "x"])
+
+        omero = compute_omero_from_ngff_image(image, colors=["FF0000"])
+
+        assert omero.channels[0].color == "FF0000"
+
+    def test_custom_label(self):
+        """Test that custom labels are applied."""
+        data = np.ones((10, 10), dtype=np.float32)
+        image = to_ngff_image(data, dims=["y", "x"])
+
+        omero = compute_omero_from_ngff_image(image, labels=["DAPI"])
+
+        assert omero.channels[0].label == "DAPI"
+
+    def test_default_label_is_empty(self):
+        """Test that default label is empty string."""
+        data = np.ones((10, 10), dtype=np.float32)
+        image = to_ngff_image(data, dims=["y", "x"])
+
+        omero = compute_omero_from_ngff_image(image)
+
+        assert omero.channels[0].label == ""
+
+
+class TestComputeOmeroMultiChannel:
+    """Tests for multi-channel images."""
+
+    def test_per_channel_statistics(self):
+        """Test that statistics are computed separately per channel."""
+        # Create 3 channels with different value ranges
+        ch0 = np.full((10, 10), 0.0, dtype=np.float32)  # All zeros
+        ch1 = np.full((10, 10), 100.0, dtype=np.float32)  # All 100s
+        ch2 = np.full((10, 10), 255.0, dtype=np.float32)  # All 255s
+        data = np.stack([ch0, ch1, ch2], axis=0)
+
+        image = to_ngff_image(data, dims=["c", "y", "x"])
+        omero = compute_omero_from_ngff_image(image)
+
+        assert len(omero.channels) == 3
+
+        # Channel 0: all zeros
+        assert omero.channels[0].window.min == 0.0
+        assert omero.channels[0].window.max == 0.0
+
+        # Channel 1: all 100s
+        assert omero.channels[1].window.min == 100.0
+        assert omero.channels[1].window.max == 100.0
+
+        # Channel 2: all 255s
+        assert omero.channels[2].window.min == 255.0
+        assert omero.channels[2].window.max == 255.0
+
+    def test_multi_channel_uses_glasbey_colors(self):
+        """Test that multi-channel images use Glasbey color progression."""
+        data = np.ones((3, 10, 10), dtype=np.float32)
+        image = to_ngff_image(data, dims=["c", "y", "x"])
+
+        omero = compute_omero_from_ngff_image(image)
+
+        assert omero.channels[0].color == GLASBEY_COLORS[0]  # Red
+        assert omero.channels[1].color == GLASBEY_COLORS[1]  # Green
+        assert omero.channels[2].color == GLASBEY_COLORS[2]  # Blue
+
+    def test_many_channels_cycle_colors(self):
+        """Test that colors cycle when there are more channels than colors."""
+        n_channels = len(GLASBEY_COLORS) + 5
+        data = np.ones((n_channels, 10, 10), dtype=np.float32)
+        image = to_ngff_image(data, dims=["c", "y", "x"])
+
+        omero = compute_omero_from_ngff_image(image)
+
+        # Check that colors cycle
+        assert omero.channels[len(GLASBEY_COLORS)].color == GLASBEY_COLORS[0]
+        assert omero.channels[len(GLASBEY_COLORS) + 1].color == GLASBEY_COLORS[1]
+
+    def test_custom_colors_for_channels(self):
+        """Test that custom colors override defaults."""
+        data = np.ones((3, 10, 10), dtype=np.float32)
+        image = to_ngff_image(data, dims=["c", "y", "x"])
+
+        custom_colors = ["AABBCC", "DDEEFF", "112233"]
+        omero = compute_omero_from_ngff_image(image, colors=custom_colors)
+
+        assert omero.channels[0].color == "AABBCC"
+        assert omero.channels[1].color == "DDEEFF"
+        assert omero.channels[2].color == "112233"
+
+    def test_custom_labels_for_channels(self):
+        """Test that custom labels are applied to channels."""
+        data = np.ones((3, 10, 10), dtype=np.float32)
+        image = to_ngff_image(data, dims=["c", "y", "x"])
+
+        custom_labels = ["DAPI", "GFP", "RFP"]
+        omero = compute_omero_from_ngff_image(image, labels=custom_labels)
+
+        assert omero.channels[0].label == "DAPI"
+        assert omero.channels[1].label == "GFP"
+        assert omero.channels[2].label == "RFP"
+
+    def test_insufficient_colors_raises_error(self):
+        """Test that providing too few colors raises an error."""
+        data = np.ones((3, 10, 10), dtype=np.float32)
+        image = to_ngff_image(data, dims=["c", "y", "x"])
+
+        with pytest.raises(ValueError, match="Not enough colors"):
+            compute_omero_from_ngff_image(image, colors=["FF0000", "00FF00"])
+
+    def test_insufficient_labels_raises_error(self):
+        """Test that providing too few labels raises an error."""
+        data = np.ones((3, 10, 10), dtype=np.float32)
+        image = to_ngff_image(data, dims=["c", "y", "x"])
+
+        with pytest.raises(ValueError, match="Not enough labels"):
+            compute_omero_from_ngff_image(image, labels=["DAPI"])
+
+
+class TestComputeOmeroHigherDimensions:
+    """Tests for higher-dimensional images (3D, 4D with time)."""
+
+    def test_3d_image_no_channel(self):
+        """Test 3D image without channel dimension."""
+        data = np.arange(1000).reshape((10, 10, 10)).astype(np.float32)
+        image = to_ngff_image(data, dims=["z", "y", "x"])
+
+        omero = compute_omero_from_ngff_image(image)
+
+        assert len(omero.channels) == 1
+        assert omero.channels[0].window.min == 0.0
+        assert omero.channels[0].window.max == 999.0
+
+    def test_4d_image_with_channel(self):
+        """Test 4D image with channel dimension."""
+        # Shape: (c, z, y, x) = (2, 5, 10, 10)
+        ch0 = np.zeros((5, 10, 10), dtype=np.float32)
+        ch1 = np.ones((5, 10, 10), dtype=np.float32) * 100
+        data = np.stack([ch0, ch1], axis=0)
+
+        image = to_ngff_image(data, dims=["c", "z", "y", "x"])
+        omero = compute_omero_from_ngff_image(image)
+
+        assert len(omero.channels) == 2
+        assert omero.channels[0].window.min == 0.0
+        assert omero.channels[0].window.max == 0.0
+        assert omero.channels[1].window.min == 100.0
+        assert omero.channels[1].window.max == 100.0
+
+    def test_5d_image_with_time_and_channel(self):
+        """Test 5D image with time and channel dimensions."""
+        # Shape: (t, c, z, y, x) = (2, 2, 5, 10, 10)
+        data = np.ones((2, 2, 5, 10, 10), dtype=np.float32)
+        data[0, 0] = 10  # t=0, c=0
+        data[0, 1] = 20  # t=0, c=1
+        data[1, 0] = 30  # t=1, c=0
+        data[1, 1] = 40  # t=1, c=1
+
+        image = to_ngff_image(data, dims=["t", "c", "z", "y", "x"])
+        omero = compute_omero_from_ngff_image(image)
+
+        # Should have 2 channels (across all time points)
+        assert len(omero.channels) == 2
+
+        # Channel 0 has values 10 and 30 (across time)
+        assert omero.channels[0].window.min == 10.0
+        assert omero.channels[0].window.max == 30.0
+
+        # Channel 1 has values 20 and 40 (across time)
+        assert omero.channels[1].window.min == 20.0
+        assert omero.channels[1].window.max == 40.0
+
+
+class TestComputeOmeroSpecialValues:
+    """Tests for special values like NaN and edge cases."""
+
+    def test_handles_nan_values(self):
+        """Test that NaN values are handled correctly."""
+        data = np.array([[1, 2, np.nan], [4, np.nan, 6], [7, 8, 9]], dtype=np.float32)
+        image = to_ngff_image(data, dims=["y", "x"])
+
+        omero = compute_omero_from_ngff_image(image)
+
+        # Should ignore NaN values
+        assert omero.channels[0].window.min == 1.0
+        assert omero.channels[0].window.max == 9.0
+
+    def test_constant_value_array(self):
+        """Test array where all values are the same."""
+        data = np.full((10, 10), 42.0, dtype=np.float32)
+        image = to_ngff_image(data, dims=["y", "x"])
+
+        omero = compute_omero_from_ngff_image(image)
+
+        assert omero.channels[0].window.min == 42.0
+        assert omero.channels[0].window.max == 42.0
+        assert omero.channels[0].window.start == 42.0
+        assert omero.channels[0].window.end == 42.0
+
+    def test_integer_dtype(self):
+        """Test that integer dtypes work correctly."""
+        data = np.arange(256, dtype=np.uint8).reshape((16, 16))
+        image = to_ngff_image(data, dims=["y", "x"])
+
+        omero = compute_omero_from_ngff_image(image)
+
+        assert omero.channels[0].window.min == 0.0
+        assert omero.channels[0].window.max == 255.0
+
+
+class TestComputeOmeroFromMultiscales:
+    """Tests for compute_omero_from_multiscales function."""
+
+    def test_uses_lowest_resolution_by_default(self):
+        """Test that lowest resolution is used by default for speed."""
+        # Create data with distinct values at different scales
+        data = np.arange(64).reshape((8, 8)).astype(np.float32)
+        image = to_ngff_image(data, dims=["y", "x"])
+        multiscales = to_multiscales(image, scale_factors=[2], chunks=4)
+
+        # The lowest resolution image should have been downsampled
+        # and may have different statistics
+        omero = compute_omero_from_multiscales(multiscales, use_lowest_resolution=True)
+
+        assert len(omero.channels) == 1
+
+    def test_can_use_highest_resolution(self):
+        """Test that highest resolution can be selected."""
+        data = np.arange(64).reshape((8, 8)).astype(np.float32)
+        image = to_ngff_image(data, dims=["y", "x"])
+        multiscales = to_multiscales(image, scale_factors=[2], chunks=4)
+
+        omero = compute_omero_from_multiscales(multiscales, use_lowest_resolution=False)
+
+        assert len(omero.channels) == 1
+        # Highest resolution should have original values
+        assert omero.channels[0].window.min == 0.0
+        assert omero.channels[0].window.max == 63.0
+
+    def test_passes_through_options(self):
+        """Test that quantiles, colors, labels are passed through."""
+        data = np.ones((2, 8, 8), dtype=np.float32)
+        image = to_ngff_image(data, dims=["c", "y", "x"])
+        multiscales = to_multiscales(image, scale_factors=[2], chunks=4)
+
+        omero = compute_omero_from_multiscales(
+            multiscales,
+            quantiles=(0.1, 0.9),
+            colors=["FF0000", "00FF00"],
+            labels=["Red", "Green"],
+        )
+
+        assert omero.channels[0].color == "FF0000"
+        assert omero.channels[0].label == "Red"
+        assert omero.channels[1].color == "00FF00"
+        assert omero.channels[1].label == "Green"
+
+    def test_empty_multiscales_raises_error(self):
+        """Test that empty multiscales raises an error."""
+        from ngff_zarr import Multiscales
+        from ngff_zarr.v04.zarr_metadata import Axis, Dataset, Metadata, Scale
+
+        # Create empty multiscales
+        metadata = Metadata(
+            axes=[Axis(name="y", type="space"), Axis(name="x", type="space")],
+            datasets=[Dataset(path="0", coordinateTransformations=[Scale([1.0, 1.0])])],
+            coordinateTransformations=None,
+        )
+        multiscales = Multiscales(images=[], metadata=metadata)
+
+        with pytest.raises(ValueError, match="no images"):
+            compute_omero_from_multiscales(multiscales)
+
+
+class TestGlasbeyColors:
+    """Tests for the Glasbey color palette constant."""
+
+    def test_has_at_least_20_colors(self):
+        """Test that there are at least 20 colors."""
+        assert len(GLASBEY_COLORS) >= 20
+
+    def test_colors_are_valid_hex(self):
+        """Test that all colors are valid 6-digit hex strings."""
+        import re
+
+        for color in GLASBEY_COLORS:
+            assert re.fullmatch(r"[0-9A-Fa-f]{6}", color), f"Invalid color: {color}"
+
+    def test_first_color_values(self):
+        """Test that the first three colors match glasbey_hv from colorcet."""
+        assert GLASBEY_COLORS[0] == "30A2DA"
+        assert GLASBEY_COLORS[1] == "FC4F30"
+        assert GLASBEY_COLORS[2] == "E5AE38"
+
+
+class TestValidation:
+    """Tests for input validation."""
+
+    def test_invalid_quantile_low_out_of_range(self):
+        """Test that invalid low quantile raises ValueError."""
+        data = np.ones((10, 10), dtype=np.float32)
+        image = to_ngff_image(data, dims=["y", "x"])
+
+        with pytest.raises(ValueError, match="Low quantile must be between 0 and 1"):
+            compute_omero_from_ngff_image(image, quantiles=(-0.1, 0.98))
+
+    def test_invalid_quantile_high_out_of_range(self):
+        """Test that invalid high quantile raises ValueError."""
+        data = np.ones((10, 10), dtype=np.float32)
+        image = to_ngff_image(data, dims=["y", "x"])
+
+        with pytest.raises(ValueError, match="High quantile must be between 0 and 1"):
+            compute_omero_from_ngff_image(image, quantiles=(0.02, 1.5))
+
+    def test_invalid_quantile_order(self):
+        """Test that reversed quantiles raise ValueError."""
+        data = np.ones((10, 10), dtype=np.float32)
+        image = to_ngff_image(data, dims=["y", "x"])
+
+        with pytest.raises(
+            ValueError, match="Low quantile must be less than high quantile"
+        ):
+            compute_omero_from_ngff_image(image, quantiles=(0.98, 0.02))
+
+    def test_invalid_color_format_too_short(self):
+        """Test that colors with wrong length raise ValueError."""
+        data = np.ones((10, 10), dtype=np.float32)
+        image = to_ngff_image(data, dims=["y", "x"])
+
+        with pytest.raises(ValueError, match="6-digit hexadecimal string"):
+            compute_omero_from_ngff_image(image, colors=["FFF"])
+
+    def test_invalid_color_format_with_hash(self):
+        """Test that colors with # prefix raise ValueError."""
+        data = np.ones((10, 10), dtype=np.float32)
+        image = to_ngff_image(data, dims=["y", "x"])
+
+        with pytest.raises(ValueError, match="6-digit hexadecimal string"):
+            compute_omero_from_ngff_image(image, colors=["#FF0000"])
+
+    def test_invalid_color_format_non_hex(self):
+        """Test that colors with non-hex characters raise ValueError."""
+        data = np.ones((10, 10), dtype=np.float32)
+        image = to_ngff_image(data, dims=["y", "x"])
+
+        with pytest.raises(ValueError, match="6-digit hexadecimal string"):
+            compute_omero_from_ngff_image(image, colors=["GGGGGG"])
+
+    def test_all_nan_channel(self):
+        """Test edge case where all values in a channel are NaN."""
+        data = np.full((10, 10), np.nan, dtype=np.float32)
+        image = to_ngff_image(data, dims=["y", "x"])
+
+        omero = compute_omero_from_ngff_image(image)
+
+        # Should return NaN statistics
+        assert np.isnan(omero.channels[0].window.min)
+        assert np.isnan(omero.channels[0].window.max)
+        assert np.isnan(omero.channels[0].window.start)
+        assert np.isnan(omero.channels[0].window.end)

--- a/ts/src/browser-mod.ts
+++ b/ts/src/browser-mod.ts
@@ -31,6 +31,16 @@ export {
   createNgffImage,
 } from "./utils/factory.ts";
 export { getMethodMetadata } from "./utils/method_metadata.ts";
+export {
+  computeOmeroFromMultiscales,
+  computeOmeroFromNgffImage,
+  getDefaultColors,
+  GLASBEY_COLORS,
+} from "./utils/compute_omero.ts";
+export type {
+  ComputeOmeroFromMultiscalesOptions,
+  ComputeOmeroOptions,
+} from "./utils/compute_omero.ts";
 
 // Browser-compatible I/O modules
 // Note: Uses browser-specific versions that don't import @zarrita/storage

--- a/ts/src/mod.ts
+++ b/ts/src/mod.ts
@@ -34,6 +34,16 @@ export {
   extractMethodMetadata,
   parseOmero,
 } from "./utils/parse_metadata.ts";
+export {
+  computeOmeroFromMultiscales,
+  computeOmeroFromNgffImage,
+  getDefaultColors,
+  GLASBEY_COLORS,
+} from "./utils/compute_omero.ts";
+export type {
+  ComputeOmeroFromMultiscalesOptions,
+  ComputeOmeroOptions,
+} from "./utils/compute_omero.ts";
 export { fromZarrAttrsV04, fromZarrAttrsV05 } from "./utils/from_zarr_attrs.ts";
 
 export * from "./io/from_ngff_zarr.ts";

--- a/ts/src/utils/compute_omero.ts
+++ b/ts/src/utils/compute_omero.ts
@@ -1,0 +1,638 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * Compute OMERO metadata from NgffImage data.
+ */
+
+import * as zarr from "zarrita";
+import type { NgffImage } from "../types/ngff_image.ts";
+import type { Multiscales } from "../types/multiscales.ts";
+import type {
+  Omero,
+  OmeroChannel,
+  OmeroWindow,
+} from "../types/zarr_metadata.ts";
+
+/**
+ * Glasbey color palette from colorcet's glasbey_hv.
+ * Extended from HoloViews default colors using the Glasbey algorithm
+ * for maximum distinguishability across 256 categorical colors.
+ * See: https://colorcet.holoviz.org/user_guide/Categorical.html
+ */
+export const GLASBEY_COLORS: readonly string[] = [
+  "30A2DA",
+  "FC4F30",
+  "E5AE38",
+  "6D904F",
+  "8B8B8B",
+  "17BECF",
+  "9467BD",
+  "D62728",
+  "1F77B4",
+  "E377C2",
+  "8C564B",
+  "BCBD22",
+  "3A0183",
+  "004300",
+  "0FFFA9",
+  "5E0040",
+  "C6BDFF",
+  "425052",
+  "B80080",
+  "FFB7B3",
+  "7D0200",
+  "6126FF",
+  "FFFF9A",
+  "AEC9AB",
+  "00867C",
+  "553A00",
+  "94FCFF",
+  "00BF00",
+  "7D00A0",
+  "AB7200",
+  "91FF00",
+  "01BE8A",
+  "00457B",
+  "C8826F",
+  "FF1F83",
+  "DD00FF",
+  "057400",
+  "644461",
+  "888FFF",
+  "FFB6F4",
+  "536237",
+  "CE85FF",
+  "686A84",
+  "BEB4BE",
+  "A56089",
+  "95D3FF",
+  "0100F8",
+  "FF8002",
+  "8B2945",
+  "ADA06D",
+  "53458B",
+  "C8FFD9",
+  "AA4600",
+  "FF798F",
+  "83D371",
+  "909EBF",
+  "9400F5",
+  "EBD09B",
+  "AD8BB1",
+  "00634A",
+  "FFDC00",
+  "887751",
+  "7EABA3",
+  "000097",
+  "F500C6",
+  "653329",
+  "006678",
+  "04E3C8",
+  "A737AE",
+  "C5DBE1",
+  "4D6EFF",
+  "9B9301",
+  "CD586B",
+  "EFDEFE",
+  "795A00",
+  "5F889A",
+  "B4FF92",
+  "5E726B",
+  "520066",
+  "058751",
+  "84206F",
+  "3C9605",
+  "657300",
+  "F1A06C",
+  "5F5045",
+  "BD004A",
+  "D06827",
+  "D796AB",
+  "895DFF",
+  "826C76",
+  "2B55B9",
+  "6E7CBB",
+  "E7D5D3",
+  "5D0018",
+  "7C3B01",
+  "80B17D",
+  "C8D97D",
+  "00E83B",
+  "7CB2FF",
+  "FF55FF",
+  "A42721",
+  "1DE4FF",
+  "7DAF3B",
+  "7B4B91",
+  "E0FF48",
+  "6B00C4",
+  "CDA897",
+  "BE63C4",
+  "89CDCE",
+  "4603C8",
+  "5E9279",
+  "414A01",
+  "05A79D",
+  "CF8C37",
+  "FFF8D0",
+  "435471",
+  "B544FF",
+  "CF4993",
+  "CFA4DF",
+  "94D400",
+  "A794DA",
+  "2DA558",
+  "8DE3B6",
+  "A4A99D",
+  "6C5CB7",
+  "FF7E5E",
+  "A7838A",
+  "AFBED8",
+  "2AC4FF",
+  "A6683D",
+  "F691FE",
+  "874B64",
+  "FF0C4B",
+  "215E23",
+  "4292FF",
+  "87839D",
+  "672D45",
+  "B14F41",
+  "004E53",
+  "5F1B00",
+  "AD4167",
+  "503267",
+  "D6FFFD",
+  "7FB5D1",
+  "A9B969",
+  "FF96CB",
+  "C87495",
+  "365039",
+  "FFD063",
+  "5E5862",
+  "879476",
+  "A978FF",
+  "03C863",
+  "E7BED4",
+  "D4E3D0",
+  "876790",
+  "897C27",
+  "CDDCFF",
+  "AA676B",
+  "323474",
+  "FF5EA9",
+  "009BB0",
+  "71FFDD",
+  "785C38",
+  "50659B",
+  "CC00B3",
+  "577B55",
+  "516E7B",
+  "015F92",
+  "AABDBE",
+  "017F99",
+  "04DD97",
+  "873A2C",
+  "F0968E",
+  "75C6AA",
+  "70695D",
+  "CCDC09",
+  "AF8557",
+  "D80075",
+  "9D3F81",
+  "D94500",
+  "DD6754",
+  "5FFF79",
+  "D5B173",
+  "62265E",
+  "BAA23D",
+  "D9F2B3",
+  "57028F",
+  "A19BAA",
+  "4D4A27",
+  "A4A9FF",
+  "ACE8DB",
+  "995901",
+  "AC00E2",
+  "47822F",
+  "CBC3AD",
+  "00C5B6",
+  "615378",
+  "336D68",
+  "A59280",
+  "8499A2",
+  "FD5764",
+  "7096D2",
+  "728D07",
+  "7F004C",
+  "1530A0",
+  "D1C1E2",
+  "C985D0",
+  "6C454B",
+  "7F0024",
+  "00A279",
+  "B2A9CF",
+  "F90000",
+  "B0E9FF",
+  "939E50",
+  "727A82",
+  "D92E55",
+  "476101",
+  "0059FF",
+  "7740B5",
+  "ACE460",
+  "674525",
+  "525D51",
+  "957368",
+  "A9E49A",
+  "A30058",
+  "D962F6",
+  "8E7DCF",
+  "FFBD93",
+  "A30092",
+  "9AFFB9",
+  "A7C2FF",
+  "F46200",
+  "E5F0FF",
+  "B89CA4",
+  "609694",
+  "FF9F35",
+  "8C2900",
+  "726B32",
+  "DF824E",
+  "AF7BD5",
+  "BC2D00",
+  "7B6FA3",
+  "484362",
+  "C7A3FF",
+  "004D28",
+  "C4C68E",
+  "E048D7",
+  "E7E965",
+  "E5C10B",
+  "00F4F1",
+  "9F5BA2",
+  "4C41B7",
+  "65338E",
+  "767E6C",
+  "A98A36",
+] as const;
+
+/**
+ * Get default colors for channels.
+ *
+ * For a single channel, returns white (FFFFFF).
+ * For multiple channels, uses the Glasbey color progression.
+ */
+export function getDefaultColors(nChannels: number): string[] {
+  if (nChannels === 1) {
+    return ["FFFFFF"];
+  }
+  // Cycle through Glasbey colors if we have more channels than colors
+  return Array.from(
+    { length: nChannels },
+    (_, i) => GLASBEY_COLORS[i % GLASBEY_COLORS.length],
+  );
+}
+
+/**
+ * Options for computing OMERO metadata.
+ */
+export interface ComputeOmeroOptions {
+  /** Tuple of (low, high) quantile values for the display window. Default is [0.02, 0.98]. */
+  quantiles?: [number, number];
+  /** Optional list of hex color strings (without #) for each channel. */
+  colors?: string[];
+  /** Optional list of label strings for each channel. */
+  labels?: string[];
+}
+
+/**
+ * Validate that quantiles are in valid range and properly ordered.
+ */
+function validateQuantiles(quantiles: [number, number]): void {
+  const [low, high] = quantiles;
+  if (!(low >= 0.0 && low <= 1.0)) {
+    throw new Error(`Low quantile must be between 0 and 1, got ${low}`);
+  }
+  if (!(high >= 0.0 && high <= 1.0)) {
+    throw new Error(`High quantile must be between 0 and 1, got ${high}`);
+  }
+  if (low >= high) {
+    throw new Error(
+      `Low quantile must be less than high quantile, got (${low}, ${high})`,
+    );
+  }
+}
+
+/**
+ * Validate that a color is a valid 6-digit hexadecimal string.
+ */
+function validateColor(color: string): void {
+  const hexPattern = /^[0-9A-Fa-f]{6}$/;
+  if (!hexPattern.test(color)) {
+    throw new Error(
+      `Color must be a 6-digit hexadecimal string without # prefix, got '${color}'`,
+    );
+  }
+}
+
+/**
+ * Maximum sample size for approximate quantile computation.
+ * For datasets larger than this, we use reservoir sampling for memory efficiency.
+ */
+const QUANTILE_SAMPLE_SIZE = 10_000;
+
+/**
+ * Helper function to compute quantile from a sorted array.
+ */
+function computeQuantile(sortedValues: number[], q: number): number {
+  if (sortedValues.length === 0) {
+    return NaN;
+  }
+  if (sortedValues.length === 1) {
+    return sortedValues[0];
+  }
+
+  const index = q * (sortedValues.length - 1);
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  const weight = index - lower;
+
+  if (lower === upper) {
+    return sortedValues[lower];
+  }
+
+  return sortedValues[lower] * (1 - weight) + sortedValues[upper] * weight;
+}
+
+/**
+ * Compute channel statistics (min, max, and quantiles) from array data.
+ *
+ * For large datasets (>10,000 non-NaN values), uses reservoir sampling
+ * to compute approximate quantiles with reduced memory footprint.
+ * Min and max are always exact.
+ */
+function computeChannelStatistics(
+  data: ArrayLike<number>,
+  quantiles: [number, number],
+): { min: number; max: number; qLow: number; qHigh: number } {
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+
+  // Reservoir sample for approximate quantile computation
+  const sample: number[] = [];
+  let count = 0;
+
+  for (let i = 0; i < data.length; i++) {
+    const v = data[i];
+    if (Number.isNaN(v)) {
+      continue;
+    }
+
+    // Update min and max (always exact)
+    if (v < min) min = v;
+    if (v > max) max = v;
+
+    // Update reservoir sample for quantiles
+    if (sample.length < QUANTILE_SAMPLE_SIZE) {
+      sample.push(v);
+    } else {
+      // Reservoir sampling: replace random element with probability QUANTILE_SAMPLE_SIZE/(count+1)
+      const j = Math.floor(Math.random() * (count + 1));
+      if (j < QUANTILE_SAMPLE_SIZE) {
+        sample[j] = v;
+      }
+    }
+
+    count++;
+  }
+
+  if (count === 0) {
+    return { min: NaN, max: NaN, qLow: NaN, qHigh: NaN };
+  }
+
+  // Sort sample for quantile computation
+  sample.sort((a, b) => a - b);
+
+  const qLow = computeQuantile(sample, quantiles[0]);
+  const qHigh = computeQuantile(sample, quantiles[1]);
+
+  return { min, max, qLow, qHigh };
+}
+
+/**
+ * Extract a single channel from multi-dimensional typed array data.
+ */
+function extractChannel(
+  data: ArrayLike<number>,
+  shape: readonly number[],
+  channelIndex: number,
+  channelDimIndex: number,
+): number[] {
+  const nChannels = shape[channelDimIndex];
+  const result: number[] = [];
+
+  // Calculate the stride for the channel dimension
+  let channelStride = 1;
+  for (let i = channelDimIndex + 1; i < shape.length; i++) {
+    channelStride *= shape[i];
+  }
+
+  // Calculate the total size of dimensions before the channel dimension
+  let outerSize = 1;
+  for (let i = 0; i < channelDimIndex; i++) {
+    outerSize *= shape[i];
+  }
+
+  // Extract all values for this channel
+  for (let outer = 0; outer < outerSize; outer++) {
+    const outerOffset = outer * nChannels * channelStride;
+    const channelOffset = outerOffset + channelIndex * channelStride;
+    for (let inner = 0; inner < channelStride; inner++) {
+      result.push(data[channelOffset + inner]);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Compute OMERO metadata from an NgffImage.
+ *
+ * This function computes visualization parameters (OMERO metadata) from image data:
+ * - min/max: The actual data range
+ * - start/end: Display window based on quantiles (default 2% and 98%)
+ *
+ * For multi-channel images (with 'c' dimension), statistics are computed
+ * separately for each channel, resulting in per-channel OMERO windows.
+ *
+ * Memory requirements: This function loads the entire image data into memory
+ * for statistics computation. For large images, use the lowest resolution
+ * image from a multiscales pyramid.
+ *
+ * Edge cases:
+ * - If all values in a channel are NaN, the statistics will be NaN.
+ * - If a channel has constant values, min/max/start/end will all be the same.
+ *
+ * @param image - The NgffImage to compute metadata for
+ * @param options - Optional configuration for quantiles, colors, and labels
+ *   - quantiles: Tuple of (low, high) quantile values. Must be between 0 and 1,
+ *                with low < high. Default is [0.02, 0.98] for 2% and 98% quantiles.
+ *   - colors: List of hex color strings (without #) for each channel.
+ *             Must be 6-digit hexadecimal strings (e.g., "FF0000" for red).
+ *             If not provided, uses white for single channel or Glasbey
+ *             progression for multi-channel.
+ *   - labels: List of label strings for each channel.
+ *             If not provided, uses empty strings.
+ * @returns Promise resolving to Omero metadata with computed window parameters
+ * @throws {Error} If quantiles are invalid, colors are invalid format,
+ *                 or not enough colors/labels provided.
+ *
+ * @example
+ * ```ts
+ * const omero = await computeOmeroFromNgffImage(image);
+ * multiscales.metadata.omero = omero;
+ * ```
+ */
+export async function computeOmeroFromNgffImage(
+  image: NgffImage,
+  options: ComputeOmeroOptions = {},
+): Promise<Omero> {
+  const quantiles = options.quantiles ?? [0.02, 0.98];
+
+  // Validate quantiles
+  validateQuantiles(quantiles as [number, number]);
+
+  const dims = image.dims;
+  const shape = image.data.shape;
+
+  // Check if there's a channel dimension
+  const hasChannelDim = dims.includes("c");
+  const cIndex = hasChannelDim ? dims.indexOf("c") : -1;
+  const nChannels = hasChannelDim ? shape[cIndex] : 1;
+
+  // Get colors
+  let channelColors: string[];
+  if (options.colors !== undefined) {
+    if (options.colors.length < nChannels) {
+      throw new Error(
+        `Not enough colors provided. Got ${options.colors.length}, need ${nChannels}.`,
+      );
+    }
+    // Validate each color
+    for (const color of options.colors.slice(0, nChannels)) {
+      validateColor(color);
+    }
+    channelColors = options.colors.slice(0, nChannels);
+  } else {
+    channelColors = getDefaultColors(nChannels);
+  }
+
+  // Get labels
+  let channelLabels: string[];
+  if (options.labels !== undefined) {
+    if (options.labels.length < nChannels) {
+      throw new Error(
+        `Not enough labels provided. Got ${options.labels.length}, need ${nChannels}.`,
+      );
+    }
+    channelLabels = options.labels.slice(0, nChannels);
+  } else {
+    channelLabels = Array(nChannels).fill("");
+  }
+
+  // Read all data from the zarr array
+  const result = await zarr.get(image.data);
+  const fullData = result.data as ArrayLike<number>;
+
+  // Compute statistics for each channel
+  const channels: OmeroChannel[] = [];
+
+  for (let chIdx = 0; chIdx < nChannels; chIdx++) {
+    let channelData: ArrayLike<number>;
+
+    if (hasChannelDim) {
+      // Extract this channel's data
+      channelData = extractChannel(fullData, shape, chIdx, cIndex);
+    } else {
+      channelData = fullData;
+    }
+
+    // Compute statistics
+    const stats = computeChannelStatistics(
+      channelData,
+      quantiles as [number, number],
+    );
+
+    // Create OMERO window
+    const window: OmeroWindow = {
+      min: stats.min,
+      max: stats.max,
+      start: stats.qLow,
+      end: stats.qHigh,
+    };
+
+    // Create channel metadata
+    const channel: OmeroChannel = {
+      color: channelColors[chIdx],
+      window,
+      label: channelLabels[chIdx],
+    };
+    channels.push(channel);
+  }
+
+  return { channels };
+}
+
+/**
+ * Options for computing OMERO metadata from multiscales.
+ */
+export interface ComputeOmeroFromMultiscalesOptions
+  extends ComputeOmeroOptions {
+  /**
+   * If true (default), use the lowest resolution (smallest) image for faster computation.
+   * If false, use the highest resolution (largest) image for more accurate statistics.
+   */
+  useLowestResolution?: boolean;
+}
+
+/**
+ * Compute OMERO metadata from a Multiscales object.
+ *
+ * This is a convenience function that computes OMERO metadata from the
+ * highest or lowest resolution image in a multiscales pyramid.
+ *
+ * @param multiscales - The Multiscales object to compute metadata for
+ * @param options - Optional configuration for quantiles, colors, labels, and resolution
+ * @returns Promise resolving to Omero metadata with computed window parameters
+ */
+export async function computeOmeroFromMultiscales(
+  multiscales: Multiscales,
+  options: ComputeOmeroFromMultiscalesOptions = {},
+): Promise<Omero> {
+  if (!multiscales.images || multiscales.images.length === 0) {
+    throw new Error("Multiscales has no images");
+  }
+
+  const useLowestResolution = options.useLowestResolution ?? true;
+
+  // Select which image to use based on resolution preference
+  const image = useLowestResolution
+    ? multiscales.images[multiscales.images.length - 1] // Last image (lowest resolution)
+    : multiscales.images[0]; // First image (highest resolution)
+
+  const computeOptions: ComputeOmeroOptions = {};
+  if (options.quantiles !== undefined) {
+    computeOptions.quantiles = options.quantiles;
+  }
+  if (options.colors !== undefined) {
+    computeOptions.colors = options.colors;
+  }
+  if (options.labels !== undefined) {
+    computeOptions.labels = options.labels;
+  }
+
+  return await computeOmeroFromNgffImage(image, computeOptions);
+}

--- a/ts/test/compute_omero_test.ts
+++ b/ts/test/compute_omero_test.ts
@@ -1,0 +1,513 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+import { assertEquals, assertExists, assertRejects } from "@std/assert";
+import * as zarr from "zarrita";
+import { NgffImage } from "../src/types/ngff_image.ts";
+import {
+  computeOmeroFromMultiscales,
+  computeOmeroFromNgffImage,
+  getDefaultColors,
+  GLASBEY_COLORS,
+} from "../src/utils/compute_omero.ts";
+import {
+  createAxis,
+  createDataset,
+  createMetadata,
+  createMultiscales,
+} from "../src/utils/factory.ts";
+import { Methods } from "../src/types/methods.ts";
+
+// Helper function to compute stride from shape
+function computeStride(shape: number[]): number[] {
+  const stride: number[] = new Array(shape.length);
+  let current = 1;
+  for (let i = shape.length - 1; i >= 0; i--) {
+    stride[i] = current;
+    current *= shape[i];
+  }
+  return stride;
+}
+
+// Helper function to create a test NgffImage with data
+async function createTestImage(
+  data: ArrayLike<number>,
+  shape: number[],
+  dims: string[],
+  dtype: zarr.DataType = "float32",
+): Promise<NgffImage> {
+  const store = new Map<string, Uint8Array>();
+  const root = zarr.root(store);
+
+  const zarrArray = await zarr.create(root.resolve("test"), {
+    shape,
+    chunk_shape: shape, // Single chunk for simplicity
+    data_type: dtype,
+  });
+
+  // Write data to the array with proper format
+  const typedData = dtype === "uint8"
+    ? new Uint8Array(data as number[])
+    : new Float32Array(data as number[]);
+
+  await zarr.set(zarrArray, null, {
+    data: typedData,
+    shape: shape,
+    stride: computeStride(shape),
+  });
+
+  const scale: Record<string, number> = {};
+  const translation: Record<string, number> = {};
+  for (const dim of dims) {
+    scale[dim] = 1.0;
+    translation[dim] = 0.0;
+  }
+
+  return new NgffImage({
+    data: zarrArray,
+    dims,
+    scale,
+    translation,
+    name: "test",
+    axesUnits: undefined,
+    computedCallbacks: undefined,
+  });
+}
+
+// ============================================================================
+// Tests for single-channel images
+// ============================================================================
+
+Deno.test("compute basic statistics for single channel", async () => {
+  // Create array with values 0-99
+  const data = Array.from({ length: 100 }, (_, i) => i);
+  const image = await createTestImage(data, [10, 10], ["y", "x"]);
+
+  const omero = await computeOmeroFromNgffImage(image);
+
+  assertEquals(omero.channels.length, 1);
+  const channel = omero.channels[0];
+
+  // Check min/max
+  assertEquals(channel.window.min, 0);
+  assertEquals(channel.window.max, 99);
+
+  // Check quantiles are approximately correct
+  assertExists(channel.window.start);
+  assertExists(channel.window.end);
+  // 2% of 100 values is ~2, 98% is ~97
+  assertEquals(channel.window.start! >= 0 && channel.window.start! <= 5, true);
+  assertEquals(channel.window.end! >= 94 && channel.window.end! <= 99, true);
+});
+
+Deno.test("single channel uses white color", async () => {
+  const data = Array(100).fill(1);
+  const image = await createTestImage(data, [10, 10], ["y", "x"]);
+
+  const omero = await computeOmeroFromNgffImage(image);
+
+  assertEquals(omero.channels[0].color, "FFFFFF");
+});
+
+Deno.test("custom quantiles are respected", async () => {
+  const data = Array.from({ length: 100 }, (_, i) => i);
+  const image = await createTestImage(data, [10, 10], ["y", "x"]);
+
+  // Use 10% and 90% quantiles
+  const omero = await computeOmeroFromNgffImage(image, {
+    quantiles: [0.1, 0.9],
+  });
+
+  const channel = omero.channels[0];
+  // 10% of 100 values is ~10, 90% is ~90
+  assertEquals(
+    channel.window.start! >= 5 && channel.window.start! <= 15,
+    true,
+  );
+  assertEquals(channel.window.end! >= 85 && channel.window.end! <= 95, true);
+});
+
+Deno.test("custom color is applied", async () => {
+  const data = Array(100).fill(1);
+  const image = await createTestImage(data, [10, 10], ["y", "x"]);
+
+  const omero = await computeOmeroFromNgffImage(image, {
+    colors: ["FF0000"],
+  });
+
+  assertEquals(omero.channels[0].color, "FF0000");
+});
+
+Deno.test("custom label is applied", async () => {
+  const data = Array(100).fill(1);
+  const image = await createTestImage(data, [10, 10], ["y", "x"]);
+
+  const omero = await computeOmeroFromNgffImage(image, {
+    labels: ["DAPI"],
+  });
+
+  assertEquals(omero.channels[0].label, "DAPI");
+});
+
+Deno.test("default label is empty string", async () => {
+  const data = Array(100).fill(1);
+  const image = await createTestImage(data, [10, 10], ["y", "x"]);
+
+  const omero = await computeOmeroFromNgffImage(image);
+
+  assertEquals(omero.channels[0].label, "");
+});
+
+// ============================================================================
+// Tests for multi-channel images
+// ============================================================================
+
+Deno.test("per-channel statistics are computed", async () => {
+  // 3 channels with different values
+  // Channel 0: all 0s, Channel 1: all 100s, Channel 2: all 255s
+  const ch0 = Array(100).fill(0);
+  const ch1 = Array(100).fill(100);
+  const ch2 = Array(100).fill(255);
+  const data = [...ch0, ...ch1, ...ch2];
+
+  const image = await createTestImage(data, [3, 10, 10], ["c", "y", "x"]);
+  const omero = await computeOmeroFromNgffImage(image);
+
+  assertEquals(omero.channels.length, 3);
+
+  // Channel 0: all zeros
+  assertEquals(omero.channels[0].window.min, 0);
+  assertEquals(omero.channels[0].window.max, 0);
+
+  // Channel 1: all 100s
+  assertEquals(omero.channels[1].window.min, 100);
+  assertEquals(omero.channels[1].window.max, 100);
+
+  // Channel 2: all 255s
+  assertEquals(omero.channels[2].window.min, 255);
+  assertEquals(omero.channels[2].window.max, 255);
+});
+
+Deno.test("multi-channel uses glasbey colors", async () => {
+  const data = Array(300).fill(1); // 3 channels * 10*10
+  const image = await createTestImage(data, [3, 10, 10], ["c", "y", "x"]);
+
+  const omero = await computeOmeroFromNgffImage(image);
+
+  assertEquals(omero.channels[0].color, GLASBEY_COLORS[0]); // Red
+  assertEquals(omero.channels[1].color, GLASBEY_COLORS[1]); // Green
+  assertEquals(omero.channels[2].color, GLASBEY_COLORS[2]); // Blue
+});
+
+Deno.test("many channels cycle colors", async () => {
+  const nChannels = GLASBEY_COLORS.length + 5;
+  const data = Array(nChannels * 100).fill(1);
+  const image = await createTestImage(
+    data,
+    [nChannels, 10, 10],
+    ["c", "y", "x"],
+  );
+
+  const omero = await computeOmeroFromNgffImage(image);
+
+  // Check that colors cycle
+  assertEquals(
+    omero.channels[GLASBEY_COLORS.length].color,
+    GLASBEY_COLORS[0],
+  );
+  assertEquals(
+    omero.channels[GLASBEY_COLORS.length + 1].color,
+    GLASBEY_COLORS[1],
+  );
+});
+
+Deno.test("custom colors for channels", async () => {
+  const data = Array(300).fill(1);
+  const image = await createTestImage(data, [3, 10, 10], ["c", "y", "x"]);
+
+  const omero = await computeOmeroFromNgffImage(image, {
+    colors: ["AABBCC", "DDEEFF", "112233"],
+  });
+
+  assertEquals(omero.channels[0].color, "AABBCC");
+  assertEquals(omero.channels[1].color, "DDEEFF");
+  assertEquals(omero.channels[2].color, "112233");
+});
+
+Deno.test("custom labels for channels", async () => {
+  const data = Array(300).fill(1);
+  const image = await createTestImage(data, [3, 10, 10], ["c", "y", "x"]);
+
+  const omero = await computeOmeroFromNgffImage(image, {
+    labels: ["DAPI", "GFP", "RFP"],
+  });
+
+  assertEquals(omero.channels[0].label, "DAPI");
+  assertEquals(omero.channels[1].label, "GFP");
+  assertEquals(omero.channels[2].label, "RFP");
+});
+
+Deno.test("insufficient colors throws error", async () => {
+  const data = Array(300).fill(1);
+  const image = await createTestImage(data, [3, 10, 10], ["c", "y", "x"]);
+
+  await assertRejects(
+    async () => {
+      await computeOmeroFromNgffImage(image, {
+        colors: ["FF0000", "00FF00"],
+      });
+    },
+    Error,
+    "Not enough colors",
+  );
+});
+
+Deno.test("insufficient labels throws error", async () => {
+  const data = Array(300).fill(1);
+  const image = await createTestImage(data, [3, 10, 10], ["c", "y", "x"]);
+
+  await assertRejects(
+    async () => {
+      await computeOmeroFromNgffImage(image, {
+        labels: ["DAPI"],
+      });
+    },
+    Error,
+    "Not enough labels",
+  );
+});
+
+// ============================================================================
+// Tests for higher-dimensional images
+// ============================================================================
+
+Deno.test("3D image without channel dimension", async () => {
+  const data = Array.from({ length: 1000 }, (_, i) => i);
+  const image = await createTestImage(data, [10, 10, 10], ["z", "y", "x"]);
+
+  const omero = await computeOmeroFromNgffImage(image);
+
+  assertEquals(omero.channels.length, 1);
+  assertEquals(omero.channels[0].window.min, 0);
+  assertEquals(omero.channels[0].window.max, 999);
+});
+
+Deno.test("4D image with channel dimension", async () => {
+  // Shape: [c, z, y, x] = [2, 5, 10, 10] = 1000 values
+  // Channel 0: all 0s, Channel 1: all 100s
+  const ch0 = Array(500).fill(0);
+  const ch1 = Array(500).fill(100);
+  const data = [...ch0, ...ch1];
+
+  const image = await createTestImage(data, [2, 5, 10, 10], [
+    "c",
+    "z",
+    "y",
+    "x",
+  ]);
+  const omero = await computeOmeroFromNgffImage(image);
+
+  assertEquals(omero.channels.length, 2);
+  assertEquals(omero.channels[0].window.min, 0);
+  assertEquals(omero.channels[0].window.max, 0);
+  assertEquals(omero.channels[1].window.min, 100);
+  assertEquals(omero.channels[1].window.max, 100);
+});
+
+// ============================================================================
+// Tests for special values
+// ============================================================================
+
+Deno.test("handles NaN values", async () => {
+  const data = [1, 2, NaN, 4, NaN, 6, 7, 8, 9];
+  const image = await createTestImage(data, [3, 3], ["y", "x"]);
+
+  const omero = await computeOmeroFromNgffImage(image);
+
+  // Should ignore NaN values
+  assertEquals(omero.channels[0].window.min, 1);
+  assertEquals(omero.channels[0].window.max, 9);
+});
+
+Deno.test("constant value array", async () => {
+  const data = Array(100).fill(42);
+  const image = await createTestImage(data, [10, 10], ["y", "x"]);
+
+  const omero = await computeOmeroFromNgffImage(image);
+
+  assertEquals(omero.channels[0].window.min, 42);
+  assertEquals(omero.channels[0].window.max, 42);
+  assertEquals(omero.channels[0].window.start, 42);
+  assertEquals(omero.channels[0].window.end, 42);
+});
+
+Deno.test("integer dtype works correctly", async () => {
+  const data = Array.from({ length: 256 }, (_, i) => i);
+  const image = await createTestImage(data, [16, 16], ["y", "x"], "uint8");
+
+  const omero = await computeOmeroFromNgffImage(image);
+
+  assertEquals(omero.channels[0].window.min, 0);
+  assertEquals(omero.channels[0].window.max, 255);
+});
+
+// ============================================================================
+// Tests for computeOmeroFromMultiscales
+// ============================================================================
+
+Deno.test("computeOmeroFromMultiscales uses lowest resolution by default", async () => {
+  // Create a simple image
+  const data = Array.from({ length: 64 }, (_, i) => i);
+  const image = await createTestImage(data, [8, 8], ["y", "x"]);
+
+  const axes = [
+    createAxis("y", "space"),
+    createAxis("x", "space"),
+  ];
+  const datasets = [
+    createDataset("0", [1.0, 1.0], [0.0, 0.0]),
+    createDataset("1", [2.0, 2.0], [0.0, 0.0]),
+  ];
+  const metadata = createMetadata(axes, datasets, "test");
+  const multiscales = createMultiscales(
+    [image, image], // Two scales (same image for simplicity)
+    metadata,
+    [2],
+    Methods.ITKWASM_GAUSSIAN,
+  );
+
+  const omero = await computeOmeroFromMultiscales(multiscales);
+
+  assertEquals(omero.channels.length, 1);
+});
+
+Deno.test("computeOmeroFromMultiscales can use highest resolution", async () => {
+  const data = Array.from({ length: 64 }, (_, i) => i);
+  const image = await createTestImage(data, [8, 8], ["y", "x"]);
+
+  const axes = [
+    createAxis("y", "space"),
+    createAxis("x", "space"),
+  ];
+  const datasets = [
+    createDataset("0", [1.0, 1.0], [0.0, 0.0]),
+  ];
+  const metadata = createMetadata(axes, datasets, "test");
+  const multiscales = createMultiscales(
+    [image],
+    metadata,
+    undefined,
+    Methods.ITKWASM_GAUSSIAN,
+  );
+
+  const omero = await computeOmeroFromMultiscales(multiscales, {
+    useLowestResolution: false,
+  });
+
+  assertEquals(omero.channels.length, 1);
+  assertEquals(omero.channels[0].window.min, 0);
+  assertEquals(omero.channels[0].window.max, 63);
+});
+
+Deno.test("computeOmeroFromMultiscales passes through options", async () => {
+  const data = Array(200).fill(1); // 2 channels * 10*10
+  const image = await createTestImage(data, [2, 10, 10], ["c", "y", "x"]);
+
+  const axes = [
+    createAxis("c", "channel"),
+    createAxis("y", "space"),
+    createAxis("x", "space"),
+  ];
+  const datasets = [
+    createDataset("0", [1.0, 1.0, 1.0], [0.0, 0.0, 0.0]),
+  ];
+  const metadata = createMetadata(axes, datasets, "test");
+  const multiscales = createMultiscales(
+    [image],
+    metadata,
+    undefined,
+    Methods.ITKWASM_GAUSSIAN,
+  );
+
+  const omero = await computeOmeroFromMultiscales(multiscales, {
+    quantiles: [0.1, 0.9],
+    colors: ["FF0000", "00FF00"],
+    labels: ["Red", "Green"],
+  });
+
+  assertEquals(omero.channels[0].color, "FF0000");
+  assertEquals(omero.channels[0].label, "Red");
+  assertEquals(omero.channels[1].color, "00FF00");
+  assertEquals(omero.channels[1].label, "Green");
+});
+
+Deno.test("computeOmeroFromMultiscales throws error for empty multiscales", async () => {
+  const axes = [
+    createAxis("y", "space"),
+    createAxis("x", "space"),
+  ];
+  const datasets = [
+    createDataset("0", [1.0, 1.0], [0.0, 0.0]),
+  ];
+  const metadata = createMetadata(axes, datasets, "test");
+  const multiscales = createMultiscales(
+    [], // Empty images array
+    metadata,
+    undefined,
+    Methods.ITKWASM_GAUSSIAN,
+  );
+
+  await assertRejects(
+    async () => {
+      await computeOmeroFromMultiscales(multiscales);
+    },
+    Error,
+    "no images",
+  );
+});
+
+// ============================================================================
+// Tests for GLASBEY_COLORS constant
+// ============================================================================
+
+Deno.test("GLASBEY_COLORS has at least 20 colors", () => {
+  assertEquals(GLASBEY_COLORS.length >= 20, true);
+});
+
+Deno.test("GLASBEY_COLORS contains valid hex strings", () => {
+  const hexPattern = /^[0-9A-Fa-f]{6}$/;
+  for (const color of GLASBEY_COLORS) {
+    assertEquals(hexPattern.test(color), true, `Invalid color: ${color}`);
+  }
+});
+
+Deno.test("first GLASBEY_COLORS values match glasbey_hv", () => {
+  assertEquals(GLASBEY_COLORS[0], "30A2DA");
+  assertEquals(GLASBEY_COLORS[1], "FC4F30");
+  assertEquals(GLASBEY_COLORS[2], "E5AE38");
+});
+
+// ============================================================================
+// Tests for getDefaultColors helper
+// ============================================================================
+
+Deno.test("getDefaultColors returns white for single channel", () => {
+  const colors = getDefaultColors(1);
+  assertEquals(colors.length, 1);
+  assertEquals(colors[0], "FFFFFF");
+});
+
+Deno.test("getDefaultColors returns glasbey for multiple channels", () => {
+  const colors = getDefaultColors(3);
+  assertEquals(colors.length, 3);
+  assertEquals(colors[0], GLASBEY_COLORS[0]);
+  assertEquals(colors[1], GLASBEY_COLORS[1]);
+  assertEquals(colors[2], GLASBEY_COLORS[2]);
+});
+
+Deno.test("getDefaultColors cycles for many channels", () => {
+  const nChannels = GLASBEY_COLORS.length + 3;
+  const colors = getDefaultColors(nChannels);
+  assertEquals(colors.length, nChannels);
+  assertEquals(colors[GLASBEY_COLORS.length], GLASBEY_COLORS[0]);
+});


### PR DESCRIPTION
Add functions to compute OMERO visualization metadata (min, max, and
quantile-based display windows) from NgffImage data in both Python and
TypeScript implementations.

Key features:
- Per-channel statistics computation for multi-channel images
- Default colors: white for single channel, Glasbey progression for multi
- Configurable quantiles (default 2% and 98% for display window)
- NaN-safe statistics using nanmin/nanmax/nanquantile
- CLI integration with --no-omero, --omero-quantiles, --omero-window,
  --omero-colors, and --omero-labels flags
- Automatic OMERO computation enabled by default in CLI

Python: compute_omero_from_ngff_image(), compute_omero_from_multiscales()
TypeScript: computeOmeroFromNgffImage(), computeOmeroFromMultiscales()
