### PR TITLE
fix(py): Handle unknown axis fields in Zarr metadata gracefully

### DIFF
--- a/py/ngff_zarr/v04/zarr_metadata.py
+++ b/py/ngff_zarr/v04/zarr_metadata.py
@@ -1,10 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional, Union
+import functools
+import logging
+import re
+from dataclasses import dataclass, fields
+from typing import TYPE_CHECKING, List, Optional, Set, Union
 
 from typing_extensions import Literal
-import re
 
 # Import RFC 4 support
 from ..rfc4 import AnatomicalOrientation
@@ -13,6 +15,8 @@ from .._zarr_types import StoreLike
 
 if TYPE_CHECKING:
     from ..ngff_image import NgffImage
+
+logger = logging.getLogger(__name__)
 
 SupportedDims = Union[
     Literal["c"], Literal["x"], Literal["y"], Literal["z"], Literal["t"]
@@ -141,6 +145,44 @@ def is_dimension_supported(dim: str) -> bool:
 def is_unit_supported(unit: str) -> bool:
     """Helper for string validation"""
     return (unit in time_units) or (unit in space_units)
+
+
+@functools.lru_cache(maxsize=1)
+def _get_axis_fields() -> Set[str]:
+    """Get the set of valid field names for the Axis dataclass.
+    
+    Cached to avoid repeated introspection.
+    """
+    return {f.name for f in fields(Axis)}
+
+
+def _filter_axis_dict(axis_dict: dict) -> dict:
+    """Filter an axis dictionary to only include valid Axis fields.
+
+    Logs a warning if unknown fields are encountered.
+    
+    Raises:
+        ValueError: If required fields 'name' or 'type' are missing from the axis dictionary.
+    """
+    # Check for required fields before filtering
+    if "name" not in axis_dict:
+        raise ValueError(
+            f"Axis dictionary is missing required field 'name': {axis_dict}"
+        )
+    if "type" not in axis_dict:
+        raise ValueError(
+            f"Axis dictionary is missing required field 'type': {axis_dict}"
+        )
+    
+    axis_fields = _get_axis_fields()
+    unknown_fields = set(axis_dict.keys()) - axis_fields
+    if unknown_fields:
+        axis_name = axis_dict.get("name", "unknown")
+        logger.warning(
+            f"Ignoring unknown fields {unknown_fields} in axis '{axis_name}'. "
+            f"These fields are not part of the OME-NGFF v0.4 specification."
+        )
+    return {k: v for k, v in axis_dict.items() if k in axis_fields}
 
 
 @dataclass
@@ -367,11 +409,24 @@ class Metadata:
             ]
             units = {d: None for d in dims}
         else:
-            dims = tuple(a["name"] if "name" in a else a for a in root_attrs["axes"])
-            if "name" in root_attrs["axes"][0]:
-                axes = [Axis(**axis) for axis in root_attrs["axes"]]
+            axes_list = root_attrs["axes"]
+            if not axes_list:
+                raise ValueError(
+                    "Multiscale metadata contains empty axes list. "
+                    "At least one axis must be defined."
+                )
+            
+            # Determine if we have v0.4+ (dict-based axes) or v0.3 (string-based axes)
+            # by checking if the first axis is a dict
+            first_axis_is_dict = isinstance(axes_list[0], dict)
+            
+            if first_axis_is_dict:
+                # v0.4+ format with dict-based axes
+                dims = tuple(a["name"] if "name" in a else a for a in axes_list)
+                axes = [Axis(**_filter_axis_dict(axis)) for axis in axes_list]
             else:
-                # v0.3
+                # v0.3 format with string-based axes
+                dims = tuple(axes_list)
                 type_dict = {
                     "t": "time",
                     "c": "channel",
@@ -380,11 +435,11 @@ class Metadata:
                     "x": "space",
                 }
                 axes = [
-                    Axis(name=axis, type=type_dict[axis]) for axis in root_attrs["axes"]
+                    Axis(name=axis, type=type_dict[axis]) for axis in axes_list
                 ]
 
             units = {d: None for d in dims}
-            for axis in root_attrs["axes"]:
+            for axis in axes_list:
                 # Only process unit information for dict-style axes that have both
                 # a name and a unit (v0.4+). For v0.3 string axes, this loop is a no-op.
                 if isinstance(axis, dict):

--- a/py/test/test_unknown_axis_fields.py
+++ b/py/test/test_unknown_axis_fields.py
@@ -1,0 +1,297 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Tests for handling unknown fields in axis metadata."""
+import asyncio
+import json
+import logging
+
+import numpy as np
+import packaging.version
+import pytest
+import zarr
+from zarr.storage import MemoryStore
+
+from ngff_zarr import from_ngff_zarr, to_multiscales, to_ngff_image, to_ngff_zarr
+
+zarr_version = packaging.version.parse(zarr.__version__)
+
+
+@pytest.fixture
+def zarr_helpers():
+    """Fixture providing helper functions for accessing zarr store attributes."""
+    
+    # Check zarr version to determine the appropriate API
+    zarr_version_major = zarr_version.major
+    
+    if zarr_version_major >= 3:
+        # Zarr v3 API
+        async def _get_attrs_async(store):
+            """Get attributes from a zarr store (v3 compatible)."""
+            from zarr.core.buffer import default_buffer_prototype
+            
+            attrs_key = ".zattrs"
+            attrs_bytes = await store.get(attrs_key, default_buffer_prototype())
+            return json.loads(attrs_bytes.to_bytes().decode())
+        
+        async def _set_attrs_async(store, attrs):
+            """Set attributes in a zarr store (v3 compatible)."""
+            from zarr.core.buffer import default_buffer_prototype
+            
+            attrs_key = ".zattrs"
+            attrs_bytes = json.dumps(attrs).encode()
+            proto = default_buffer_prototype()
+            buffer = proto.buffer.from_bytes(attrs_bytes)
+            await store.set(attrs_key, buffer)
+        
+        # Return sync wrappers to avoid repeated asyncio.run() calls in tests
+        def get_attrs(store):
+            return asyncio.run(_get_attrs_async(store))
+        
+        def set_attrs(store, attrs):
+            return asyncio.run(_set_attrs_async(store, attrs))
+    else:
+        # Zarr v2 API
+        def get_attrs(store):
+            """Get attributes from a zarr store (v2 compatible)."""
+            attrs_key = ".zattrs"
+            return json.loads(store[attrs_key].decode())
+        
+        def set_attrs(store, attrs):
+            """Set attributes in a zarr store (v2 compatible)."""
+            attrs_key = ".zattrs"
+            store[attrs_key] = json.dumps(attrs).encode()
+    
+    return {"get": get_attrs, "set": set_attrs}
+
+
+def test_unknown_axis_fields_are_filtered(caplog, zarr_helpers):
+    """Test that non-standard axis fields are filtered out and a warning is logged."""
+    # Create a basic image
+    data = np.random.rand(10, 20, 30).astype(np.float32)
+    image = to_ngff_image(
+        data=data,
+        dims=("z", "y", "x"),
+        scale={"z": 1.0, "y": 1.0, "x": 1.0},
+        translation={"z": 0.0, "y": 0.0, "x": 0.0},
+        name="test_image",
+    )
+    multiscales = to_multiscales(image, scale_factors=[])
+    
+    # Write to zarr store
+    store = MemoryStore()
+    version = "0.4"
+    to_ngff_zarr(store, multiscales, version=version)
+    
+    # Manually modify the metadata to add a non-standard field
+    attrs = zarr_helpers["get"](store)
+    
+    # Add a non-standard "discrete" field to the time axis (like BigStitcher-Spark does)
+    for axis in attrs["multiscales"][0]["axes"]:
+        if axis["name"] == "z":
+            axis["discrete"] = False
+            axis["custom_field"] = "custom_value"
+    
+    zarr_helpers["set"](store, attrs)
+    
+    # Try to load the data - it should succeed and log warnings
+    with caplog.at_level(logging.WARNING):
+        multiscales_back = from_ngff_zarr(store, version=version)
+    
+    # Verify that warnings were logged
+    assert len(caplog.records) > 0
+    warning_messages = [record.message for record in caplog.records]
+    assert any("Ignoring unknown fields" in msg for msg in warning_messages)
+    assert any("discrete" in msg for msg in warning_messages)
+    assert any("custom_field" in msg for msg in warning_messages)
+    
+    # Verify that the data loaded successfully
+    assert multiscales_back is not None
+    assert len(multiscales_back.images) > 0
+    
+    # Verify that the unknown fields are not present in the Axis objects
+    axes = multiscales_back.metadata.axes
+    z_axis = next((axis for axis in axes if axis.name == "z"), None)
+    assert z_axis is not None
+    assert not hasattr(z_axis, "discrete")
+    assert not hasattr(z_axis, "custom_field")
+
+
+def test_unknown_fields_multiple_axes(caplog, zarr_helpers):
+    """Test that unknown fields in multiple axes are all logged."""
+    # Create a 4D image
+    data = np.random.rand(2, 10, 20, 30).astype(np.float32)
+    image = to_ngff_image(
+        data=data,
+        dims=("t", "z", "y", "x"),
+        scale={"t": 1.0, "z": 1.0, "y": 1.0, "x": 1.0},
+        translation={"t": 0.0, "z": 0.0, "y": 0.0, "x": 0.0},
+        name="test_image",
+    )
+    multiscales = to_multiscales(image, scale_factors=[])
+    
+    # Write to zarr store
+    store = MemoryStore()
+    version = "0.4"
+    to_ngff_zarr(store, multiscales, version=version)
+    
+    # Manually modify the metadata to add non-standard fields to multiple axes
+    attrs = zarr_helpers["get"](store)
+    
+    for axis in attrs["multiscales"][0]["axes"]:
+        if axis["name"] == "t":
+            axis["discrete"] = True
+        elif axis["name"] == "z":
+            axis["continuous"] = True
+    
+    zarr_helpers["set"](store, attrs)
+    
+    # Try to load the data
+    with caplog.at_level(logging.WARNING):
+        multiscales_back = from_ngff_zarr(store, version=version)
+    
+    # Verify warnings for both axes
+    warning_messages = [record.message for record in caplog.records]
+    assert any("discrete" in msg and "'t'" in msg for msg in warning_messages)
+    assert any("continuous" in msg and "'z'" in msg for msg in warning_messages)
+    
+    # Verify the data loaded successfully
+    assert multiscales_back is not None
+
+
+def test_missing_required_name_field(zarr_helpers):
+    """Test that missing 'name' field raises ValueError."""
+    # Create a basic image
+    data = np.random.rand(10, 20, 30).astype(np.float32)
+    image = to_ngff_image(
+        data=data,
+        dims=("z", "y", "x"),
+        scale={"z": 1.0, "y": 1.0, "x": 1.0},
+        translation={"z": 0.0, "y": 0.0, "x": 0.0},
+        name="test_image",
+    )
+    multiscales = to_multiscales(image, scale_factors=[])
+    
+    # Write to zarr store
+    store = MemoryStore()
+    version = "0.4"
+    to_ngff_zarr(store, multiscales, version=version)
+    
+    # Manually corrupt the metadata by removing 'name' field
+    attrs = zarr_helpers["get"](store)
+    
+    # Remove the 'name' field from one axis
+    del attrs["multiscales"][0]["axes"][0]["name"]
+    
+    zarr_helpers["set"](store, attrs)
+    
+    # Try to load the data - should raise ValueError
+    with pytest.raises(ValueError, match="missing required field 'name'"):
+        from_ngff_zarr(store, version=version)
+
+
+def test_missing_required_type_field(zarr_helpers):
+    """Test that missing 'type' field raises ValueError."""
+    # Create a basic image
+    data = np.random.rand(10, 20, 30).astype(np.float32)
+    image = to_ngff_image(
+        data=data,
+        dims=("z", "y", "x"),
+        scale={"z": 1.0, "y": 1.0, "x": 1.0},
+        translation={"z": 0.0, "y": 0.0, "x": 0.0},
+        name="test_image",
+    )
+    multiscales = to_multiscales(image, scale_factors=[])
+    
+    # Write to zarr store
+    store = MemoryStore()
+    version = "0.4"
+    to_ngff_zarr(store, multiscales, version=version)
+    
+    # Manually corrupt the metadata by removing 'type' field
+    attrs = zarr_helpers["get"](store)
+    
+    # Remove the 'type' field from one axis
+    del attrs["multiscales"][0]["axes"][0]["type"]
+    
+    zarr_helpers["set"](store, attrs)
+    
+    # Try to load the data - should raise ValueError
+    with pytest.raises(ValueError, match="missing required field 'type'"):
+        from_ngff_zarr(store, version=version)
+
+
+def test_only_unknown_fields(zarr_helpers):
+    """Test that an axis with only unknown fields (no valid fields) raises ValueError."""
+    # Create a basic image
+    data = np.random.rand(10, 20, 30).astype(np.float32)
+    image = to_ngff_image(
+        data=data,
+        dims=("z", "y", "x"),
+        scale={"z": 1.0, "y": 1.0, "x": 1.0},
+        translation={"z": 0.0, "y": 0.0, "x": 0.0},
+        name="test_image",
+    )
+    multiscales = to_multiscales(image, scale_factors=[])
+    
+    # Write to zarr store
+    store = MemoryStore()
+    version = "0.4"
+    to_ngff_zarr(store, multiscales, version=version)
+    
+    # Manually corrupt the metadata to have only unknown fields
+    attrs = zarr_helpers["get"](store)
+    
+    # Replace one axis with only unknown fields
+    attrs["multiscales"][0]["axes"][0] = {
+        "custom_field_1": "value1",
+        "custom_field_2": "value2",
+    }
+    
+    zarr_helpers["set"](store, attrs)
+    
+    # Try to load the data - should raise ValueError about missing required fields
+    with pytest.raises(ValueError, match="missing required field"):
+        from_ngff_zarr(store, version=version)
+
+
+def test_valid_optional_fields_preserved(zarr_helpers):
+    """Test that valid optional fields (like 'unit') are preserved."""
+    # Create a basic image with units
+    data = np.random.rand(10, 20, 30).astype(np.float32)
+    image = to_ngff_image(
+        data=data,
+        dims=("z", "y", "x"),
+        scale={"z": 1.0, "y": 1.0, "x": 1.0},
+        translation={"z": 0.0, "y": 0.0, "x": 0.0},
+        name="test_image",
+    )
+    # Set units using the correct property name
+    image.axes_units = {"z": "micrometer", "y": "micrometer", "x": "micrometer"}
+    multiscales = to_multiscales(image, scale_factors=[])
+    
+    # Write to zarr store
+    store = MemoryStore()
+    version = "0.4"
+    to_ngff_zarr(store, multiscales, version=version)
+    
+    # Manually add a non-standard field alongside the valid 'unit' field
+    attrs = zarr_helpers["get"](store)
+    
+    for axis in attrs["multiscales"][0]["axes"]:
+        if axis["name"] == "z":
+            axis["discrete"] = False  # Non-standard field
+    
+    zarr_helpers["set"](store, attrs)
+    
+    # Load the data
+    multiscales_back = from_ngff_zarr(store, version=version)
+    
+    # Verify that the valid 'unit' field is preserved
+    z_axis = next(
+        (axis for axis in multiscales_back.metadata.axes if axis.name == "z"), None
+    )
+    assert z_axis is not None
+    assert z_axis.unit == "micrometer"
+    
+    # Verify that the non-standard field is not present
+    assert not hasattr(z_axis, "discrete")


### PR DESCRIPTION
## Summary

Fixes a `TypeError` when loading OME-Zarr datasets that contain non-standard fields in axis metadata (e.g., `"discrete": false` added by BigStitcher-Spark).

## Problem

When processing datasets like `SmartSPIM_805163_2025-08-15_12-20-35_stitched_2025-09-12_03-56-47`, the `from_ngff_zarr()` function failed with:

```
TypeError: Axis.__init__() got an unexpected keyword argument 'discrete'
```

This occurred because the axis metadata in `.zattrs` contains fields not part of the OME-NGFF v0.4 specification:

```json
{"type":"time","name":"t","unit":"millisecond","discrete":false}
```

The code was unpacking all dictionary keys directly into the `Axis` dataclass constructor via `Axis(**axis)`, causing a failure on any non-standard field.

## Solution

- Added `_filter_axis_dict()` helper function that filters axis dictionaries to only include valid `Axis` dataclass fields
- Uses `dataclasses.fields()` to dynamically determine valid field names, making it robust to future `Axis` changes
- Logs a warning when unknown fields are encountered, informing users their data contains non-standard extensions
- Changed axis parsing from `Axis(**axis)` to `Axis(**_filter_axis_dict(axis))`

## Example Warning Output

```
WARNING:ngff_zarr.v04.zarr_metadata:Ignoring unknown fields {'discrete'} in axis 't'. These fields are not part of the OME-NGFF v0.4 specification.
```

## Testing

- All 269 existing tests pass
- Verified fix against the problematic SmartSPIM dataset - now loads successfully