### PR TITLE
feat(ci): Add automated GitHub Release workflow with Commitizen changelog integration

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,0 +1,352 @@
+# GitHub Release Automation
+
+This document describes the automated release workflow for the ngff-zarr monorepo.
+
+## Overview
+
+The release workflow automatically creates GitHub Releases with changelog content and build artifacts when version tags are pushed for any of the three sub-projects:
+
+- **Python Package** (`py/`): Tags like `py-v0.22.0`
+- **TypeScript Package** (`ts/`): Tags like `ts-v0.4.0`
+- **MCP Package** (`mcp/`): Tags like `mcp-v0.5.0`
+
+## How It Works
+
+### 1. Tag-Based Triggering
+
+The workflow triggers automatically when you push a tag matching the pattern:
+- `py-v*` for Python packages
+- `ts-v*` for TypeScript packages
+- `mcp-v*` for MCP packages
+
+### 2. Automated Steps
+
+For each tag push, the workflow:
+
+1. **Identifies the project** from the tag prefix
+2. **Extracts the version** from the tag
+3. **Parses the changelog** to get version-specific release notes
+4. **Builds artifacts** for the specific project:
+   - **Python**: Wheel (`.whl`) and source distribution (`.tar.gz`)
+   - **TypeScript**: NPM tarball (`.tgz`)
+   - **MCP**: Wheel (`.whl`) and source distribution (`.tar.gz`)
+5. **Creates a GitHub Release** with:
+   - Release title (e.g., "Python Package v0.22.0")
+   - Changelog content for that version
+   - Build artifacts attached
+   - Pre-release flag (if applicable)
+
+### 3. Pre-release Detection
+
+Tags containing any of these keywords are automatically marked as pre-releases:
+- `alpha`
+- `beta`
+- `rc` (release candidate)
+- `dev`
+- `pre`
+
+Examples:
+- `py-v0.22.0-beta.1` → Pre-release
+- `ts-v0.4.0-rc.2` → Pre-release
+- `mcp-v0.5.0` → Stable release
+
+## Usage
+
+### Creating a Release
+
+#### Option 1: Using Commitizen (Recommended)
+
+Each sub-project has Commitizen configured. Use the bump command to automatically:
+- Increment version
+- Update changelog
+- Create a git tag
+- Commit changes
+
+```bash
+# Python package
+cd py
+pixi run -e lint bump
+
+# TypeScript package
+cd ts
+# Use commitizen from py's pixi environment
+../py/.pixi/envs/lint/bin/cz bump
+
+# MCP package
+cd mcp
+pixi run -e dev bump
+```
+
+After Commitizen creates the tag, push it:
+
+```bash
+git push origin <tag-name>
+```
+
+#### Option 2: Manual Tag Creation
+
+If you prefer to create tags manually:
+
+```bash
+# Create an annotated tag
+git tag -a py-v0.22.0 -m "Release Python package v0.22.0"
+
+# Push the tag
+git push origin py-v0.22.0
+```
+
+**Important**: Make sure the version exists in the corresponding `CHANGELOG.md` file before pushing the tag.
+
+### Monitoring the Release
+
+1. After pushing a tag, go to the **Actions** tab in GitHub
+2. Find the **Release** workflow run
+3. Monitor the build and release creation process
+4. Once complete, check the **Releases** page
+
+### Release Artifacts
+
+Each project type includes specific artifacts:
+
+#### Python Package (`py-v*`)
+- `ngff_zarr-{version}-py3-none-any.whl` - Python wheel
+- `ngff-zarr-{version}.tar.gz` - Source distribution
+
+#### TypeScript Package (`ts-v*`)
+- `fideus-labs-ngff-zarr-{version}.tgz` - NPM package tarball
+
+#### MCP Package (`mcp-v*`)
+- `ngff_zarr_mcp-{version}-py3-none-any.whl` - Python wheel
+- `ngff-zarr-mcp-{version}.tar.gz` - Source distribution
+
+## Publishing to Package Registries
+
+The workflow includes **commented-out** sections for publishing to package registries (PyPI, NPM, JSR). These are disabled by default for safety.
+
+### Enabling Publishing
+
+#### For Python Packages (PyPI)
+
+1. **Create a PyPI API token**:
+   - Go to https://pypi.org/manage/account/token/
+   - Create a token with appropriate scope
+
+2. **Add the token to GitHub Secrets**:
+   - Go to repository Settings → Secrets and variables → Actions
+   - Add `PYPI_API_TOKEN` (for py package)
+   - Optionally add `PYPI_MCP_TOKEN` (for mcp package, or reuse the same token)
+
+3. **Uncomment the publishing step** in `.github/workflows/release.yml`:
+   ```yaml
+   # Find these sections and remove the comment markers (#)
+   - name: Publish Python package to PyPI
+   - name: Publish MCP package to PyPI
+   ```
+
+#### For TypeScript Package (NPM)
+
+1. **Create an NPM access token**:
+   - Go to https://www.npmjs.com/settings/{username}/tokens
+   - Create an "Automation" token
+
+2. **Add the token to GitHub Secrets**:
+   - Add `NPM_TOKEN`
+
+3. **Uncomment the publishing step** in `.github/workflows/release.yml`:
+   ```yaml
+   - name: Publish to NPM
+   ```
+
+#### For TypeScript Package (JSR - Optional)
+
+1. **Create a Deno Deploy token** (if using JSR)
+2. **Add `DENO_DEPLOY_TOKEN` to GitHub Secrets**
+3. **Uncomment the JSR publishing step**
+
+### Testing Publishing
+
+Before enabling automatic publishing:
+
+1. **Test the release creation** with a few tags
+2. **Verify the artifacts** are correctly built
+3. **Download and test artifacts** manually
+4. **Manually publish** one release to confirm everything works
+5. **Then enable** automatic publishing
+
+## Changelog Format
+
+The workflow expects changelogs to follow the [Keep a Changelog](https://keepachangelog.com/) format:
+
+```markdown
+## [VERSION] - YYYY-MM-DD
+
+### Added
+- New features
+
+### Changed
+- Changes to existing features
+
+### Fixed
+- Bug fixes
+
+### Removed
+- Removed features
+```
+
+Or with tag prefixes (higher priority):
+
+```markdown
+## py-v0.22.0 (2024-01-15)
+
+### Features
+- New features
+
+### Bug Fixes
+- Bug fixes
+```
+
+**Note**: Replace `py-v0.22.0` with the appropriate tag prefix for your project (`py-v*`, `ts-v*`, or `mcp-v*`). The workflow prioritizes the tag format (e.g., `## py-v0.22.0`) over the bracket format (e.g., `## [0.22.0]`) when both exist.
+
+## Troubleshooting
+
+### Tag doesn't trigger workflow
+
+**Possible causes**:
+- Tag format doesn't match `{py|ts|mcp}-v*` pattern
+- Tag was created but not pushed to GitHub
+- Workflow file has syntax errors
+
+**Solution**:
+```bash
+# Verify tag format
+git tag -l
+
+# Push tag explicitly
+git push origin <tag-name>
+
+# Check workflow syntax
+# Use GitHub Actions tab or a YAML validator
+```
+
+### Changelog extraction fails
+
+**Possible causes**:
+- Version not found in changelog
+- Changelog format doesn't match expected pattern
+- Wrong tag prefix used
+
+**Solution**:
+```bash
+# Test changelog extraction locally
+.github/scripts/extract-changelog.sh py/CHANGELOG.md 0.22.0 py
+
+# Ensure version exists in changelog
+grep "0.22.0" py/CHANGELOG.md
+```
+
+### Build artifacts not found
+
+**Possible causes**:
+- Build process failed
+- Artifacts in unexpected location
+- Build dependencies missing
+
+**Solution**:
+- Check the workflow logs in GitHub Actions
+- Verify build commands work locally
+- Check artifact paths in release.yml
+
+### Release created but artifacts missing
+
+**Possible causes**:
+- File glob pattern doesn't match artifacts
+- Artifacts were not created successfully
+
+**Solution**:
+- Check the "Verify artifacts" step in workflow logs
+- Ensure build step completed successfully
+- Verify artifact paths in release.yml match actual output
+
+## Workflow Files
+
+- **`.github/workflows/release.yml`** - Main workflow file
+- **`.github/scripts/extract-changelog.sh`** - Changelog extraction script
+- **`.github/RELEASE.md`** - This documentation file
+
+## Examples
+
+### Creating a Python package release
+
+```bash
+# 1. Update version and changelog using commitizen
+cd py
+pixi run -e lint bump
+
+# 2. Commitizen will create a commit and tag, push them
+git push origin main
+git push origin py-v0.23.0
+
+# 3. Wait for GitHub Actions to complete
+# 4. Check the Releases page for your new release
+```
+
+### Creating a pre-release
+
+```bash
+# Create a beta tag manually
+git tag -a ts-v0.5.0-beta.1 -m "Beta release"
+git push origin ts-v0.5.0-beta.1
+
+# The workflow will automatically mark it as a pre-release
+```
+
+### Testing the workflow
+
+```bash
+# Create a test tag on a test branch
+git checkout -b test-release
+git tag -a py-v0.22.1-test -m "Test release"
+git push origin py-v0.22.1-test
+
+# Check the Actions tab
+# If successful, delete the test release and tag
+# If failed, check the logs and fix issues
+```
+
+## Best Practices
+
+1. **Always test** with a test tag first before creating official releases
+2. **Keep changelogs updated** before creating version tags
+3. **Use semantic versioning** for version numbers
+4. **Review build artifacts** in the first few releases before enabling auto-publishing
+5. **Monitor Actions logs** for any warnings or issues
+6. **Create annotated tags** with meaningful messages
+7. **Test publishing manually** before enabling automated publishing
+
+## Security Considerations
+
+- **API tokens** should have minimal required permissions
+- **Never commit tokens** to the repository
+- **Use GitHub Secrets** for all sensitive values
+- **Enable branch protection** to prevent accidental tag deletion
+- **Review workflow changes** carefully before merging
+- **Test on a fork** if making significant workflow changes
+
+## Support
+
+If you encounter issues:
+
+1. Check the workflow logs in GitHub Actions
+2. Test changelog extraction locally
+3. Verify tag format matches expectations
+4. Review this documentation
+5. Check GitHub Actions documentation: https://docs.github.com/en/actions
+
+## Version History
+
+- **2026-02-03**: Initial release automation implementation
+  - Support for py, ts, and mcp packages
+  - Automated changelog extraction
+  - Build artifact creation
+  - Pre-release detection
+  - Publishing infrastructure (commented out)

--- a/.github/scripts/extract-changelog.sh
+++ b/.github/scripts/extract-changelog.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+#
+# Extract changelog content for a specific version from a CHANGELOG.md file
+#
+# Usage: extract-changelog.sh <changelog_file> <version> <tag_prefix>
+#
+# Arguments:
+#   changelog_file: Path to CHANGELOG.md
+#   version: Version number (e.g., 0.22.0)
+#   tag_prefix: Tag prefix (e.g., py, ts, mcp)
+#
+# Example: extract-changelog.sh py/CHANGELOG.md 0.22.0 py
+
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 <changelog_file> <version> <tag_prefix>"
+    exit 1
+fi
+
+CHANGELOG_FILE="$1"
+VERSION="$2"
+TAG_PREFIX="$3"
+
+if [ ! -f "$CHANGELOG_FILE" ]; then
+    echo "Error: Changelog file not found: $CHANGELOG_FILE"
+    exit 1
+fi
+
+# Function to extract changelog content between two version headers
+# Priority order:
+# 1. ## tag-vVERSION (e.g., ## py-v0.22.0)
+# 2. ## [VERSION] - DATE (e.g., ## [0.22.0] - 2026-02-02)
+extract_changelog() {
+    local file="$1"
+    local version="$2"
+    local prefix="$3"
+
+    # Try tag-vVERSION format first (higher priority)
+    local tag_pattern="^## ${prefix}-v${version}"
+    local bracket_pattern="^## \[${version}\]"
+
+    # Check which pattern exists in the file
+    local has_tag_format
+    has_tag_format=$(grep -c "$tag_pattern" "$file" || true)
+    local has_bracket_format
+    has_bracket_format=$(grep -c "$bracket_pattern" "$file" || true)
+
+    if [ "$has_tag_format" -gt 0 ]; then
+        # Use tag-vVERSION format (higher priority)
+        pattern="$tag_pattern"
+    elif [ "$has_bracket_format" -gt 0 ]; then
+        # Use [VERSION] format
+        pattern="$bracket_pattern"
+    else
+        echo "Error: Version $version not found in $file"
+        echo "Looked for patterns:"
+        echo "  1. ## ${prefix}-v${version}"
+        echo "  2. ## [${version}]"
+        exit 1
+    fi
+
+    # Extract content from matched header until next ## header (or end of file)
+    # This preserves all markdown formatting, subsections, dates, etc.
+    awk -v pattern="$pattern" '
+        BEGIN { found=0; print_content=0 }
+
+        # When we find our version header
+        $0 ~ pattern {
+            found=1
+            print_content=1
+            print $0  # Print the header itself
+            next
+        }
+
+        # When we hit the next version header, stop
+        print_content && /^## / {
+            print_content=0
+        }
+
+        # Print lines between our version and the next version
+        print_content {
+            print $0
+        }
+
+        END {
+            if (!found) {
+                exit 1
+            }
+        }
+    ' "$file"
+}
+
+# Extract and output the changelog
+extract_changelog "$CHANGELOG_FILE" "$VERSION" "$TAG_PREFIX"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,307 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'py-v*'
+      - 'ts-v*'
+      - 'mcp-v*'
+
+permissions:
+  contents: write  # Required to create releases
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for changelog extraction
+
+      - name: Identify project and version from tag
+        id: identify
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+          # Extract project prefix and version
+          if [[ "$TAG" =~ ^(py|ts|mcp)-v(.+)$ ]]; then
+            PROJECT="${BASH_REMATCH[1]}"
+            VERSION="${BASH_REMATCH[2]}"
+            echo "project=$PROJECT" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+            # Determine if this is a pre-release
+            if [[ "$VERSION" =~ (alpha|beta|rc|dev|pre) ]]; then
+              echo "prerelease=true" >> $GITHUB_OUTPUT
+            else
+              echo "prerelease=false" >> $GITHUB_OUTPUT
+            fi
+
+            # Set project-specific variables
+            case "$PROJECT" in
+              py)
+                echo "project_name=Python Package" >> $GITHUB_OUTPUT
+                echo "project_dir=py" >> $GITHUB_OUTPUT
+                echo "changelog_path=py/CHANGELOG.md" >> $GITHUB_OUTPUT
+                echo "package_name=ngff-zarr" >> $GITHUB_OUTPUT
+                ;;
+              ts)
+                echo "project_name=TypeScript Package" >> $GITHUB_OUTPUT
+                echo "project_dir=ts" >> $GITHUB_OUTPUT
+                echo "changelog_path=ts/CHANGELOG.md" >> $GITHUB_OUTPUT
+                echo "package_name=@fideus-labs/ngff-zarr" >> $GITHUB_OUTPUT
+                ;;
+              mcp)
+                echo "project_name=MCP Package" >> $GITHUB_OUTPUT
+                echo "project_dir=mcp" >> $GITHUB_OUTPUT
+                echo "changelog_path=mcp/CHANGELOG.md" >> $GITHUB_OUTPUT
+                echo "package_name=ngff-zarr-mcp" >> $GITHUB_OUTPUT
+                ;;
+            esac
+
+            echo "✅ Detected: $PROJECT package version $VERSION"
+          else
+            echo "❌ Error: Tag format not recognized: $TAG"
+            echo "Expected format: {py|ts|mcp}-v{version}"
+            exit 1
+          fi
+
+      - name: Extract changelog
+        id: changelog
+        run: |
+          PROJECT="${{ steps.identify.outputs.project }}"
+          VERSION="${{ steps.identify.outputs.version }}"
+          CHANGELOG_PATH="${{ steps.identify.outputs.changelog_path }}"
+
+          echo "📄 Extracting changelog from $CHANGELOG_PATH for version $VERSION"
+
+          # Extract changelog content
+          CHANGELOG_CONTENT=$(.github/scripts/extract-changelog.sh "$CHANGELOG_PATH" "$VERSION" "$PROJECT")
+
+          if [ -z "$CHANGELOG_CONTENT" ]; then
+            echo "❌ Error: Failed to extract changelog content"
+            exit 1
+          fi
+
+          # Save to file for multi-line content
+          echo "$CHANGELOG_CONTENT" > /tmp/changelog.md
+          echo "changelog_file=/tmp/changelog.md" >> $GITHUB_OUTPUT
+
+          echo "✅ Changelog extracted successfully"
+          echo "--- Changelog Preview ---"
+          head -n 20 /tmp/changelog.md
+          echo "------------------------"
+
+      # ============================================================================
+      # Python Package Build (py/)
+      # ============================================================================
+
+      - name: Set up Python (for Python package)
+        if: steps.identify.outputs.project == 'py'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build dependencies (Python package)
+        if: steps.identify.outputs.project == 'py'
+        run: |
+          python -m pip install --upgrade pip
+          pip install hatch
+
+      - name: Build Python package
+        if: steps.identify.outputs.project == 'py'
+        working-directory: py
+        run: |
+          echo "🔨 Building Python package..."
+          hatch build
+          echo "✅ Build complete"
+          echo "--- Build artifacts ---"
+          ls -lh dist/
+
+      - name: Verify Python package artifacts
+        if: steps.identify.outputs.project == 'py'
+        run: |
+          if [ ! -d "py/dist" ] || [ -z "$(ls -A py/dist)" ]; then
+            echo "❌ Error: No build artifacts found in py/dist/"
+            exit 1
+          fi
+          echo "✅ Python package artifacts verified"
+
+      # ============================================================================
+      # TypeScript Package Build (ts/)
+      # ============================================================================
+
+      - name: Setup pixi (for TypeScript package)
+        if: steps.identify.outputs.project == 'ts'
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.49.0
+          manifest-path: ./py/pyproject.toml
+          frozen: true
+
+      - name: Install deno (for TypeScript package)
+        if: steps.identify.outputs.project == 'ts'
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Setup Node.js (for NPM package)
+        if: steps.identify.outputs.project == 'ts'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build TypeScript packages
+        if: steps.identify.outputs.project == 'ts'
+        working-directory: ts
+        run: |
+          echo "🔨 Building TypeScript/Deno package..."
+          pixi run build
+          echo "✅ Deno build complete"
+
+          echo "🔨 Building NPM package..."
+          pixi run build-npm
+          echo "✅ NPM build complete"
+
+          echo "📦 Creating NPM tarball..."
+          cd npm
+          npm pack
+          echo "✅ NPM tarball created"
+
+          echo "--- Build artifacts ---"
+          ls -lh *.tgz
+
+      - name: Verify TypeScript package artifacts
+        if: steps.identify.outputs.project == 'ts'
+        run: |
+          if [ ! -d "ts/npm" ] || [ -z "$(ls -A ts/npm/*.tgz 2>/dev/null)" ]; then
+            echo "❌ Error: No NPM tarball found in ts/npm/"
+            exit 1
+          fi
+          echo "✅ TypeScript package artifacts verified"
+
+      # ============================================================================
+      # MCP Package Build (mcp/)
+      # ============================================================================
+
+      - name: Set up Python (for MCP package)
+        if: steps.identify.outputs.project == 'mcp'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build dependencies (MCP package)
+        if: steps.identify.outputs.project == 'mcp'
+        run: |
+          python -m pip install --upgrade pip
+          pip install hatch
+
+      - name: Build MCP package
+        if: steps.identify.outputs.project == 'mcp'
+        working-directory: mcp
+        run: |
+          echo "🔨 Building MCP package..."
+          hatch build
+          echo "✅ Build complete"
+          echo "--- Build artifacts ---"
+          ls -lh dist/
+
+      - name: Verify MCP package artifacts
+        if: steps.identify.outputs.project == 'mcp'
+        run: |
+          if [ ! -d "mcp/dist" ] || [ -z "$(ls -A mcp/dist)" ]; then
+            echo "❌ Error: No build artifacts found in mcp/dist/"
+            exit 1
+          fi
+          echo "✅ MCP package artifacts verified"
+
+      # ============================================================================
+      # Create GitHub Release
+      # ============================================================================
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "${{ steps.identify.outputs.project_name }} v${{ steps.identify.outputs.version }}"
+          body_path: ${{ steps.changelog.outputs.changelog_file }}
+          prerelease: ${{ steps.identify.outputs.prerelease }}
+          files: |
+            ${{ steps.identify.outputs.project == 'py' && 'py/dist/*' || '' }}
+            ${{ steps.identify.outputs.project == 'ts' && 'ts/npm/*.tgz' || '' }}
+            ${{ steps.identify.outputs.project == 'mcp' && 'mcp/dist/*' || '' }}
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release summary
+        run: |
+          echo "🎉 Release created successfully!"
+          echo ""
+          echo "📦 Package: ${{ steps.identify.outputs.package_name }}"
+          echo "🏷️  Tag: ${{ steps.identify.outputs.tag }}"
+          echo "📌 Version: ${{ steps.identify.outputs.version }}"
+          echo "🔖 Pre-release: ${{ steps.identify.outputs.prerelease }}"
+          echo ""
+          echo "🔗 View release: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.identify.outputs.tag }}"
+
+      # ============================================================================
+      # Publish to Package Registries (COMMENTED OUT - Enable after testing)
+      # ============================================================================
+
+      # Uncomment the sections below after verifying that releases work correctly
+
+      # --- Python Package Publishing (PyPI) ---
+
+      # - name: Publish Python package to PyPI
+      #   if: steps.identify.outputs.project == 'py'
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     packages-dir: py/dist/
+      #     password: ${{ secrets.PYPI_API_TOKEN }}
+      #     skip-existing: true
+      #     verbose: true
+
+      # --- MCP Package Publishing (PyPI) ---
+
+      # - name: Publish MCP package to PyPI
+      #   if: steps.identify.outputs.project == 'mcp'
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     packages-dir: mcp/dist/
+      #     password: ${{ secrets.PYPI_MCP_TOKEN }}  # Or use PYPI_API_TOKEN if same account
+      #     skip-existing: true
+      #     verbose: true
+
+      # --- TypeScript Package Publishing (NPM) ---
+
+      # - name: Publish to NPM
+      #   if: steps.identify.outputs.project == 'ts'
+      #   working-directory: ts/npm
+      #   run: |
+      #     echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+      #     npm publish --access public
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # --- TypeScript Package Publishing (JSR - Optional) ---
+
+      # - name: Publish to JSR
+      #   if: steps.identify.outputs.project == 'ts'
+      #   working-directory: ts
+      #   run: |
+      #     deno publish --allow-dirty
+      #   env:
+      #     DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
+
+      # ============================================================================
+      # Post-Publishing Notifications (Optional)
+      # ============================================================================
+
+      # - name: Notify publishing success
+      #   if: success()
+      #   run: |
+      #     echo "✅ Package published successfully to registry!"
+      #     echo "📦 ${{ steps.identify.outputs.package_name }} v${{ steps.identify.outputs.version }}"


### PR DESCRIPTION
## Summary

This PR implements automated GitHub Release creation with Commitizen changelog integration for all three sub-projects in the monorepo (Python, TypeScript, and MCP packages).

## What Changed

### New Files Added
- **`.github/workflows/release.yml`** (307 lines) - Main GitHub Actions workflow
- **`.github/scripts/extract-changelog.sh`** (97 lines) - Changelog extraction helper script
- **`.github/RELEASE.md`** (352 lines) - Comprehensive documentation

### Total Changes
- 3 files added
- 756 lines of new code

## Features Implemented

### 🚀 Automated Release Creation
The workflow automatically creates GitHub Releases when version tags are pushed:
- **Python package**: `py-v*` tags (e.g., `py-v0.22.0`)
- **TypeScript package**: `ts-v*` tags (e.g., `ts-v0.4.0`)
- **MCP package**: `mcp-v*` tags (e.g., `mcp-v0.5.0`)

### 📝 Changelog Integration
- Extracts version-specific changelog content from each sub-project'\''s `CHANGELOG.md`
- Prioritizes tag format (`py-v0.22.0`) over bracket format (`[0.22.0]`)
- Preserves full markdown formatting including dates and subsections

### 📦 Build Artifacts
Each release includes appropriate build artifacts:
- **Python packages** (`py/`, `mcp/`): Wheel (`.whl`) + source distribution (`.tar.gz`) built with Hatch
- **TypeScript package** (`ts/`): NPM tarball (`.tgz`) built with Pixi and `npm pack`

### 🏷️ Pre-release Detection
Automatically marks releases as pre-releases when version strings contain:
- `alpha`, `beta`, `rc`, `dev`, or `pre`
- Example: `py-v0.22.0-beta.1` → marked as pre-release

### 📤 Publishing Infrastructure (Commented Out)
Includes ready-to-enable sections for publishing to:
- **PyPI** for Python and MCP packages
- **NPM** for TypeScript package
- **JSR** for Deno package (optional)

Publishing is commented out by default for safe testing.

## Why These Changes

This addresses the need for automated release management in a monorepo with multiple sub-projects:

1. **Manual release creation is time-consuming** - Automating this saves significant time
2. **Changelog extraction is error-prone** - Script ensures consistency
3. **Build artifact attachment is tedious** - Workflow handles this automatically
4. **Multi-project complexity** - Workflow intelligently handles different build processes

## Implementation Details

### Tag-Based Triggering
```yaml
on:
  push:
    tags:
      - '\''py-v*'\''
      - '\''ts-v*'\''
      - '\''mcp-v*'\''
```

### Project Detection
The workflow automatically:
1. Parses the tag to identify project type and version
2. Selects the appropriate build process
3. Locates the correct changelog file
4. Determines if it'\''s a pre-release

### Changelog Extraction
The bash script uses `awk` to:
- Find the version header in the changelog
- Extract all content until the next version header
- Handle both tag format and bracket format
- Preserve all markdown formatting

### Build Processes
- **Python/MCP**: Uses `hatch build` with Python 3.12
- **TypeScript**: Uses Pixi for environment management, Deno for building, and `npm pack` for NPM tarball

### Safety Features
- Only runs on tag push (not accidental)
- Validates tag format before proceeding
- Verifies changelog exists and content is extractable
- Confirms artifacts are built before release creation
- Publishing disabled by default

## Testing

The changelog extraction script has been tested successfully with all three sub-projects:
- ✅ Python package (py-v0.22.0)
- ✅ TypeScript package (ts-v0.4.0)
- ✅ MCP package (mcp-v0.5.0)

All pre-commit hooks passed:
- ✅ Shellcheck validation
- ✅ YAML syntax validation
- ✅ Trailing whitespace fixes
- ✅ Commitizen format check

## Usage

### Creating a Release

Using Commitizen (recommended):
```bash
cd py
pixi run -e lint bump
git push origin main
git push origin <tag-created-by-cz>
```

Or manually:
```bash
git tag -a py-v0.22.0 -m "Release Python package v0.22.0"
git push origin py-v0.22.0
```

### Enabling Publishing (After Testing)

1. Add secrets to GitHub repository:
   - `PYPI_API_TOKEN` for Python packages
   - `NPM_TOKEN` for TypeScript package
   - `DENO_DEPLOY_TOKEN` for JSR (optional)

2. Uncomment publishing sections in `.github/workflows/release.yml`

## Documentation

Comprehensive documentation is included in `.github/RELEASE.md`:
- Detailed usage instructions
- Troubleshooting guide
- Publishing setup
- Best practices
- Security considerations

## Next Steps

1. ✅ Merge this PR
2. 🧪 Test with a test tag (e.g., `py-v0.22.1-test`)
3. 👀 Verify release creation and artifacts
4. 🚀 Enable publishing when ready

---

**Related Issue**: Automated release creation for monorepo with Commitizen changelog integration