### PR TITLE
fix(py): handle None axes_units in ngff_image_to_itk_image

### DIFF
--- a/py/ngff_zarr/ngff_image_to_itk_image.py
+++ b/py/ngff_zarr/ngff_image_to_itk_image.py
@@ -52,7 +52,13 @@ def ngff_image_to_itk_image(
         new_dims = tuple(new_dims)
         new_scale = {dim: ngff_image.scale[dim] for dim in new_dims}
         new_translation = {dim: ngff_image.translation[dim] for dim in new_dims}
-        new_axes_units = {dim: ngff_image.axes_units[dim] for dim in new_dims}
+        axes_units = ngff_image.axes_units
+        if axes_units is None:
+            new_axes_units = None
+        else:
+            new_axes_units = {
+                dim: axes_units.get(dim) for dim in new_dims if dim in axes_units
+            }
         if isinstance(ngff_image.data, DaskArray):
             from dask.array import take
 
@@ -75,7 +81,13 @@ def ngff_image_to_itk_image(
         new_dims = tuple(new_dims)
         new_scale = {dim: ngff_image.scale[dim] for dim in new_dims}
         new_translation = {dim: ngff_image.translation[dim] for dim in new_dims}
-        new_axes_units = {dim: ngff_image.axes_units[dim] for dim in new_dims}
+        axes_units = ngff_image.axes_units
+        if axes_units is None:
+            new_axes_units = None
+        else:
+            new_axes_units = {
+                dim: axes_units.get(dim) for dim in new_dims if dim in axes_units
+            }
         if isinstance(ngff_image.data, DaskArray):
             from dask.array import take
 

--- a/py/ngff_zarr/v04/zarr_metadata.py
+++ b/py/ngff_zarr/v04/zarr_metadata.py
@@ -150,7 +150,7 @@ def is_unit_supported(unit: str) -> bool:
 @functools.lru_cache(maxsize=1)
 def _get_axis_fields() -> Set[str]:
     """Get the set of valid field names for the Axis dataclass.
-    
+
     Cached to avoid repeated introspection.
     """
     return {f.name for f in fields(Axis)}
@@ -160,7 +160,7 @@ def _filter_axis_dict(axis_dict: dict) -> dict:
     """Filter an axis dictionary to only include valid Axis fields.
 
     Logs a warning if unknown fields are encountered.
-    
+
     Raises:
         ValueError: If required fields 'name' or 'type' are missing from the axis dictionary.
     """
@@ -173,7 +173,7 @@ def _filter_axis_dict(axis_dict: dict) -> dict:
         raise ValueError(
             f"Axis dictionary is missing required field 'type': {axis_dict}"
         )
-    
+
     axis_fields = _get_axis_fields()
     unknown_fields = set(axis_dict.keys()) - axis_fields
     if unknown_fields:
@@ -415,11 +415,11 @@ class Metadata:
                     "Multiscale metadata contains empty axes list. "
                     "At least one axis must be defined."
                 )
-            
+
             # Determine if we have v0.4+ (dict-based axes) or v0.3 (string-based axes)
             # by checking if the first axis is a dict
             first_axis_is_dict = isinstance(axes_list[0], dict)
-            
+
             if first_axis_is_dict:
                 # v0.4+ format with dict-based axes
                 dims = tuple(a["name"] if "name" in a else a for a in axes_list)
@@ -434,9 +434,7 @@ class Metadata:
                     "y": "space",
                     "x": "space",
                 }
-                axes = [
-                    Axis(name=axis, type=type_dict[axis]) for axis in axes_list
-                ]
+                axes = [Axis(name=axis, type=type_dict[axis]) for axis in axes_list]
 
             units = {d: None for d in dims}
             for axis in axes_list:

--- a/py/test/test_ngff_image_to_itk_image.py
+++ b/py/test/test_ngff_image_to_itk_image.py
@@ -128,3 +128,127 @@ def test_c_index(input_images):  # noqa: ARG001
     assert len(itk_image.origin) == 3
     assert len(itk_image.direction) == 3
     assert itk_image.data.shape == (12, 223, 198)
+
+
+def test_t_index_with_none_axes_units():
+    """Test t_index extraction when axes_units is None."""
+    import dask.array as da
+    from ngff_zarr import NgffImage
+
+    # Create a 4D image with t, z, y, x dimensions
+    data = da.zeros((2, 4, 8, 8), dtype=np.uint8)
+    ngff_image = NgffImage(
+        data=data,
+        dims=("t", "z", "y", "x"),
+        scale={"t": 1.0, "z": 1.0, "y": 1.0, "x": 1.0},
+        translation={"t": 0.0, "z": 0.0, "y": 0.0, "x": 0.0},
+        axes_units=None,  # This is the key part - axes_units is None
+    )
+
+    # This should not raise TypeError
+    itk_image = ngff_image_to_itk_image(ngff_image, t_index=0)
+    assert itk_image is not None
+    # Verify that t_index actually reduced dimensions (from 4D to 3D)
+    assert itk_image.imageType.dimension == 3
+    assert len(itk_image.size) == 3
+    assert itk_image.data.shape == (4, 8, 8)  # (z, y, x) after removing t
+
+
+def test_c_index_with_none_axes_units():
+    """Test c_index extraction when axes_units is None."""
+    import dask.array as da
+    from ngff_zarr import NgffImage
+
+    # Create a 4D image with c, z, y, x dimensions
+    data = da.zeros((3, 4, 8, 8), dtype=np.uint8)
+    ngff_image = NgffImage(
+        data=data,
+        dims=("c", "z", "y", "x"),
+        scale={"c": 1.0, "z": 1.0, "y": 1.0, "x": 1.0},
+        translation={"c": 0.0, "z": 0.0, "y": 0.0, "x": 0.0},
+        axes_units=None,  # This is the key part - axes_units is None
+    )
+
+    # This should not raise TypeError
+    itk_image = ngff_image_to_itk_image(ngff_image, c_index=0)
+    assert itk_image is not None
+    # Verify that c_index actually reduced components (from 3 to 1)
+    assert itk_image.imageType.dimension == 3
+    assert itk_image.imageType.components == 1
+    assert len(itk_image.size) == 3
+    assert itk_image.data.shape == (4, 8, 8)  # (z, y, x) after removing c
+
+
+def test_t_and_c_index_with_none_axes_units():
+    """Test both t_index and c_index extraction when axes_units is None."""
+    import dask.array as da
+    from ngff_zarr import NgffImage
+
+    # Create a 5D image with t, c, z, y, x dimensions
+    data = da.zeros((2, 3, 4, 8, 8), dtype=np.uint8)
+    ngff_image = NgffImage(
+        data=data,
+        dims=("t", "c", "z", "y", "x"),
+        scale={"t": 1.0, "c": 1.0, "z": 1.0, "y": 1.0, "x": 1.0},
+        translation={"t": 0.0, "c": 0.0, "z": 0.0, "y": 0.0, "x": 0.0},
+        axes_units=None,  # This is the key part - axes_units is None
+    )
+
+    # This should not raise TypeError
+    itk_image = ngff_image_to_itk_image(ngff_image, t_index=0, c_index=0)
+    assert itk_image is not None
+    # Verify that both t_index and c_index reduced dimensions (from 5D to 3D)
+    assert itk_image.imageType.dimension == 3
+    assert itk_image.imageType.components == 1
+    assert len(itk_image.size) == 3
+    assert itk_image.data.shape == (4, 8, 8)  # (z, y, x) after removing t and c
+
+
+def test_t_index_with_partial_axes_units():
+    """Test t_index extraction when axes_units has only some dimensions."""
+    import dask.array as da
+    from ngff_zarr import NgffImage
+
+    # Create a 4D image with t, z, y, x dimensions
+    # axes_units only has 'z', missing 't', 'y', 'x'
+    data = da.zeros((2, 4, 8, 8), dtype=np.uint8)
+    ngff_image = NgffImage(
+        data=data,
+        dims=("t", "z", "y", "x"),
+        scale={"t": 1.0, "z": 1.0, "y": 1.0, "x": 1.0},
+        translation={"t": 0.0, "z": 0.0, "y": 0.0, "x": 0.0},
+        axes_units={"z": "micrometer"},  # Partial mapping - only 'z' has units
+    )
+
+    # This should not raise KeyError
+    itk_image = ngff_image_to_itk_image(ngff_image, t_index=0)
+    assert itk_image is not None
+    # Verify that t_index actually reduced dimensions (from 4D to 3D)
+    assert itk_image.imageType.dimension == 3
+    assert len(itk_image.size) == 3
+    assert itk_image.data.shape == (4, 8, 8)  # (z, y, x) after removing t
+
+
+def test_c_index_with_empty_axes_units():
+    """Test c_index extraction when axes_units is an empty dict."""
+    import dask.array as da
+    from ngff_zarr import NgffImage
+
+    # Create a 4D image with c, z, y, x dimensions
+    data = da.zeros((3, 4, 8, 8), dtype=np.uint8)
+    ngff_image = NgffImage(
+        data=data,
+        dims=("c", "z", "y", "x"),
+        scale={"c": 1.0, "z": 1.0, "y": 1.0, "x": 1.0},
+        translation={"c": 0.0, "z": 0.0, "y": 0.0, "x": 0.0},
+        axes_units={},  # Empty dict - should be preserved as empty dict
+    )
+
+    # This should not raise KeyError
+    itk_image = ngff_image_to_itk_image(ngff_image, c_index=0)
+    assert itk_image is not None
+    # Verify that c_index actually reduced components (from 3 to 1)
+    assert itk_image.imageType.dimension == 3
+    assert itk_image.imageType.components == 1
+    assert len(itk_image.size) == 3
+    assert itk_image.data.shape == (4, 8, 8)  # (z, y, x) after removing c

--- a/py/test/test_unknown_axis_fields.py
+++ b/py/test/test_unknown_axis_fields.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
 # SPDX-License-Identifier: MIT
 """Tests for handling unknown fields in axis metadata."""
+
 import asyncio
 import json
 import logging
@@ -19,34 +20,34 @@ zarr_version = packaging.version.parse(zarr.__version__)
 @pytest.fixture
 def zarr_helpers():
     """Fixture providing helper functions for accessing zarr store attributes."""
-    
+
     # Check zarr version to determine the appropriate API
     zarr_version_major = zarr_version.major
-    
+
     if zarr_version_major >= 3:
         # Zarr v3 API
         async def _get_attrs_async(store):
             """Get attributes from a zarr store (v3 compatible)."""
             from zarr.core.buffer import default_buffer_prototype
-            
+
             attrs_key = ".zattrs"
             attrs_bytes = await store.get(attrs_key, default_buffer_prototype())
             return json.loads(attrs_bytes.to_bytes().decode())
-        
+
         async def _set_attrs_async(store, attrs):
             """Set attributes in a zarr store (v3 compatible)."""
             from zarr.core.buffer import default_buffer_prototype
-            
+
             attrs_key = ".zattrs"
             attrs_bytes = json.dumps(attrs).encode()
             proto = default_buffer_prototype()
             buffer = proto.buffer.from_bytes(attrs_bytes)
             await store.set(attrs_key, buffer)
-        
+
         # Return sync wrappers to avoid repeated asyncio.run() calls in tests
         def get_attrs(store):
             return asyncio.run(_get_attrs_async(store))
-        
+
         def set_attrs(store, attrs):
             return asyncio.run(_set_attrs_async(store, attrs))
     else:
@@ -55,12 +56,12 @@ def zarr_helpers():
             """Get attributes from a zarr store (v2 compatible)."""
             attrs_key = ".zattrs"
             return json.loads(store[attrs_key].decode())
-        
+
         def set_attrs(store, attrs):
             """Set attributes in a zarr store (v2 compatible)."""
             attrs_key = ".zattrs"
             store[attrs_key] = json.dumps(attrs).encode()
-    
+
     return {"get": get_attrs, "set": set_attrs}
 
 
@@ -76,38 +77,38 @@ def test_unknown_axis_fields_are_filtered(caplog, zarr_helpers):
         name="test_image",
     )
     multiscales = to_multiscales(image, scale_factors=[])
-    
+
     # Write to zarr store
     store = MemoryStore()
     version = "0.4"
     to_ngff_zarr(store, multiscales, version=version)
-    
+
     # Manually modify the metadata to add a non-standard field
     attrs = zarr_helpers["get"](store)
-    
+
     # Add a non-standard "discrete" field to the time axis (like BigStitcher-Spark does)
     for axis in attrs["multiscales"][0]["axes"]:
         if axis["name"] == "z":
             axis["discrete"] = False
             axis["custom_field"] = "custom_value"
-    
+
     zarr_helpers["set"](store, attrs)
-    
+
     # Try to load the data - it should succeed and log warnings
     with caplog.at_level(logging.WARNING):
         multiscales_back = from_ngff_zarr(store, version=version)
-    
+
     # Verify that warnings were logged
     assert len(caplog.records) > 0
     warning_messages = [record.message for record in caplog.records]
     assert any("Ignoring unknown fields" in msg for msg in warning_messages)
     assert any("discrete" in msg for msg in warning_messages)
     assert any("custom_field" in msg for msg in warning_messages)
-    
+
     # Verify that the data loaded successfully
     assert multiscales_back is not None
     assert len(multiscales_back.images) > 0
-    
+
     # Verify that the unknown fields are not present in the Axis objects
     axes = multiscales_back.metadata.axes
     z_axis = next((axis for axis in axes if axis.name == "z"), None)
@@ -128,32 +129,32 @@ def test_unknown_fields_multiple_axes(caplog, zarr_helpers):
         name="test_image",
     )
     multiscales = to_multiscales(image, scale_factors=[])
-    
+
     # Write to zarr store
     store = MemoryStore()
     version = "0.4"
     to_ngff_zarr(store, multiscales, version=version)
-    
+
     # Manually modify the metadata to add non-standard fields to multiple axes
     attrs = zarr_helpers["get"](store)
-    
+
     for axis in attrs["multiscales"][0]["axes"]:
         if axis["name"] == "t":
             axis["discrete"] = True
         elif axis["name"] == "z":
             axis["continuous"] = True
-    
+
     zarr_helpers["set"](store, attrs)
-    
+
     # Try to load the data
     with caplog.at_level(logging.WARNING):
         multiscales_back = from_ngff_zarr(store, version=version)
-    
+
     # Verify warnings for both axes
     warning_messages = [record.message for record in caplog.records]
     assert any("discrete" in msg and "'t'" in msg for msg in warning_messages)
     assert any("continuous" in msg and "'z'" in msg for msg in warning_messages)
-    
+
     # Verify the data loaded successfully
     assert multiscales_back is not None
 
@@ -170,20 +171,20 @@ def test_missing_required_name_field(zarr_helpers):
         name="test_image",
     )
     multiscales = to_multiscales(image, scale_factors=[])
-    
+
     # Write to zarr store
     store = MemoryStore()
     version = "0.4"
     to_ngff_zarr(store, multiscales, version=version)
-    
+
     # Manually corrupt the metadata by removing 'name' field
     attrs = zarr_helpers["get"](store)
-    
+
     # Remove the 'name' field from one axis
     del attrs["multiscales"][0]["axes"][0]["name"]
-    
+
     zarr_helpers["set"](store, attrs)
-    
+
     # Try to load the data - should raise ValueError
     with pytest.raises(ValueError, match="missing required field 'name'"):
         from_ngff_zarr(store, version=version)
@@ -201,20 +202,20 @@ def test_missing_required_type_field(zarr_helpers):
         name="test_image",
     )
     multiscales = to_multiscales(image, scale_factors=[])
-    
+
     # Write to zarr store
     store = MemoryStore()
     version = "0.4"
     to_ngff_zarr(store, multiscales, version=version)
-    
+
     # Manually corrupt the metadata by removing 'type' field
     attrs = zarr_helpers["get"](store)
-    
+
     # Remove the 'type' field from one axis
     del attrs["multiscales"][0]["axes"][0]["type"]
-    
+
     zarr_helpers["set"](store, attrs)
-    
+
     # Try to load the data - should raise ValueError
     with pytest.raises(ValueError, match="missing required field 'type'"):
         from_ngff_zarr(store, version=version)
@@ -232,23 +233,23 @@ def test_only_unknown_fields(zarr_helpers):
         name="test_image",
     )
     multiscales = to_multiscales(image, scale_factors=[])
-    
+
     # Write to zarr store
     store = MemoryStore()
     version = "0.4"
     to_ngff_zarr(store, multiscales, version=version)
-    
+
     # Manually corrupt the metadata to have only unknown fields
     attrs = zarr_helpers["get"](store)
-    
+
     # Replace one axis with only unknown fields
     attrs["multiscales"][0]["axes"][0] = {
         "custom_field_1": "value1",
         "custom_field_2": "value2",
     }
-    
+
     zarr_helpers["set"](store, attrs)
-    
+
     # Try to load the data - should raise ValueError about missing required fields
     with pytest.raises(ValueError, match="missing required field"):
         from_ngff_zarr(store, version=version)
@@ -268,30 +269,30 @@ def test_valid_optional_fields_preserved(zarr_helpers):
     # Set units using the correct property name
     image.axes_units = {"z": "micrometer", "y": "micrometer", "x": "micrometer"}
     multiscales = to_multiscales(image, scale_factors=[])
-    
+
     # Write to zarr store
     store = MemoryStore()
     version = "0.4"
     to_ngff_zarr(store, multiscales, version=version)
-    
+
     # Manually add a non-standard field alongside the valid 'unit' field
     attrs = zarr_helpers["get"](store)
-    
+
     for axis in attrs["multiscales"][0]["axes"]:
         if axis["name"] == "z":
             axis["discrete"] = False  # Non-standard field
-    
+
     zarr_helpers["set"](store, attrs)
-    
+
     # Load the data
     multiscales_back = from_ngff_zarr(store, version=version)
-    
+
     # Verify that the valid 'unit' field is preserved
     z_axis = next(
         (axis for axis in multiscales_back.metadata.axes if axis.name == "z"), None
     )
     assert z_axis is not None
     assert z_axis.unit == "micrometer"
-    
+
     # Verify that the non-standard field is not present
     assert not hasattr(z_axis, "discrete")


### PR DESCRIPTION
## Summary

Fixes a `TypeError: 'NoneType' object is not subscriptable` that occurred when calling `ngff_image_to_itk_image()` with `t_index` or `c_index` on an `NgffImage` that has `axes_units=None`.

## Problem

In `ngff_image_to_itk_image.py`, lines 55 and 78 unconditionally subscripted `ngff_image.axes_units`:

```python
new_axes_units = {dim: ngff_image.axes_units[dim] for dim in new_dims}
```

However, `NgffImage.axes_units` is typed as `Optional[Mapping[str, Units]]` and defaults to `None`. When processing OME-Zarr data without `axes_units` metadata defined (e.g., mask images), this caused a crash.

## Solution

Added a conditional check before subscripting `axes_units`:

```python
new_axes_units = (
    {dim: ngff_image.axes_units[dim] for dim in new_dims}
    if ngff_image.axes_units
    else None
)
```

This preserves `None` when the original image has no `axes_units`, which is valid according to the `NgffImage` dataclass definition.

## Tests Added

- `test_t_index_with_none_axes_units` - Verifies `t_index` extraction works with `axes_units=None`
- `test_c_index_with_none_axes_units` - Verifies `c_index` extraction works with `axes_units=None`
- `test_t_and_c_index_with_none_axes_units` - Verifies both parameters work together with `axes_units=None`