### PR TITLE
fix(ts): Support exactOptionalPropertyTypes for OMERO worker API

### DIFF
--- a/ts/src/utils/compute_omero-shared.ts
+++ b/ts/src/utils/compute_omero-shared.ts
@@ -490,9 +490,9 @@ export interface ComputeOmeroOptions {
   /** Tuple of (low, high) quantile values for the display window. Default is [0.02, 0.98]. */
   quantiles?: [number, number];
   /** Optional list of hex color strings (without #) for each channel. */
-  colors?: string[];
+  colors?: string[] | undefined;
   /** Optional list of label strings for each channel. */
-  labels?: string[];
+  labels?: string[] | undefined;
 }
 
 /**
@@ -574,8 +574,8 @@ export interface ComputeOmeroWorkerInput {
   shape: readonly number[];
   dims: string[];
   quantiles: [number, number];
-  colors?: string[];
-  labels?: string[];
+  colors?: string[] | undefined;
+  labels?: string[] | undefined;
 }
 
 /**

--- a/ts/test/compute_omero_test.ts
+++ b/ts/test/compute_omero_test.ts
@@ -511,3 +511,27 @@ Deno.test("getDefaultColors cycles for many channels", () => {
   assertEquals(colors.length, nChannels);
   assertEquals(colors[GLASBEY_COLORS.length], GLASBEY_COLORS[0]);
 });
+
+// ============================================================================
+// Tests for explicit undefined values (exactOptionalPropertyTypes support)
+// ============================================================================
+
+Deno.test("undefined colors and labels are handled correctly", async () => {
+  const data = Array(300).fill(1); // 3 channels * 10*10
+  const image = await createTestImage(data, [3, 10, 10], ["c", "y", "x"]);
+
+  // Explicitly pass undefined to test type compatibility with exactOptionalPropertyTypes
+  const omero = await computeOmeroFromNgffImage(image, {
+    colors: undefined,
+    labels: undefined,
+  });
+
+  // Should use default behavior: glasbey colors for multi-channel
+  assertEquals(omero.channels.length, 3);
+  assertEquals(omero.channels[0].color, GLASBEY_COLORS[0]);
+  assertEquals(omero.channels[1].color, GLASBEY_COLORS[1]);
+  assertEquals(omero.channels[2].color, GLASBEY_COLORS[2]);
+  assertEquals(omero.channels[0].label, "");
+  assertEquals(omero.channels[1].label, "");
+  assertEquals(omero.channels[2].label, "");
+});


### PR DESCRIPTION
## Summary

Fixes TypeScript compilation errors (TS2379) in the OMERO computation module when `exactOptionalPropertyTypes: true` is enabled in the compiler options.

## Problem

With TypeScript's strict `exactOptionalPropertyTypes: true` setting (enabled in `deno.json`), optional properties like `colors?: string[]` do not accept explicit `undefined` values. This caused type errors when passing `options.colors` and `options.labels` (type: `string[] | undefined`) to worker API calls.

**Errors occurred at:**
- `ts/src/utils/compute_omero-browser.ts:214` - `api.computeOmero()` call
- `ts/src/utils/compute_omero-browser.ts:225` - `api.initializeComputation()` call

## Changes Made

### 1. Type Definition Updates (`ts/src/utils/compute_omero-shared.ts`)

Updated two interfaces to explicitly allow `undefined` values:

**`ComputeOmeroOptions` interface:**
```typescript
colors?: string[] | undefined;  // was: colors?: string[];
labels?: string[] | undefined;  // was: labels?: string[];
```

**`ComputeOmeroWorkerInput` interface:**
```typescript
colors?: string[] | undefined;  // was: colors?: string[];
labels?: string[] | undefined;  // was: labels?: string[];
```

### 2. Test Coverage (`ts/test/compute_omero_test.ts`)

Added new test case to verify that explicitly passing `undefined` values works correctly:
- Test name: `"undefined colors and labels are handled correctly"`
- Verifies default behavior (Glasbey colors, empty labels) when `undefined` is passed
- Ensures type compatibility with `exactOptionalPropertyTypes: true`

## Technical Details

The `exactOptionalPropertyTypes` compiler option enforces a distinction between:
- **Omitting a property**: `{ quantiles: [0.02, 0.98] }`
- **Explicitly setting to undefined**: `{ quantiles: [0.02, 0.98], colors: undefined }`

Without the `| undefined` annotation, TypeScript only allows the first form. By adding `| undefined`, we support both patterns while maintaining type safety.

## Verification

✅ Type checking passes (`deno check`)  
✅ All OMERO tests pass (29/29)  
✅ New test verifies the fix  
✅ Linter passes  
✅ Formatter passes  
✅ Pre-commit hooks pass  

## Related Files

- `ts/src/utils/compute_omero-shared.ts` - Type definitions
- `ts/src/utils/compute_omero-browser.ts` - Usage site (no changes needed)
- `ts/test/compute_omero_test.ts` - Test coverage