### PR TITLE
fix(py): remove zarr v2 DirectoryStore usage in CLI input handler

### DIFF
--- a/py/ngff_zarr/cli_input_to_ngff_image.py
+++ b/py/ngff_zarr/cli_input_to_ngff_image.py
@@ -19,16 +19,8 @@ def cli_input_to_ngff_image(
     backend: ConversionBackend, input, output_scale: int = 0
 ) -> NgffImage:
     if backend is ConversionBackend.NGFF_ZARR:
-        # Handle both .ozx and .zarr files
-        if isinstance(input[0], str) and input[0].endswith(".ozx"):
-            # Use from_ngff_zarr which now handles .ozx files
-            multiscales = from_ngff_zarr(input[0])
-            return multiscales.images[output_scale]
-        else:
-            # Standard .zarr directory
-            store = zarr.storage.DirectoryStore(input[0])
-            multiscales = from_ngff_zarr(store)
-            return multiscales.images[output_scale]
+        multiscales = from_ngff_zarr(input[0])
+        return multiscales.images[output_scale]
     if backend is ConversionBackend.ZARR_ARRAY:
         arr = zarr.open_array(input[0], mode="r")
         return to_ngff_image(arr)


### PR DESCRIPTION
Pass the path string directly to from_ngff_zarr() instead of creating
a DirectoryStore, which does not exist in zarr v3. from_ngff_zarr()
already handles both .ozx and string paths internally.
