### PR TITLE
fix(ts): add bytes+blosc codecs to all zarr.create() calls

### DIFF
--- a/ts/src/io/itk_image_to_ngff_image.ts
+++ b/ts/src/io/itk_image_to_ngff_image.ts
@@ -6,6 +6,7 @@
 
 import type { Image } from "itk-wasm";
 import * as zarr from "zarrita";
+import { DEFAULT_CODECS } from "../utils/codecs.ts";
 import { NgffImage } from "../types/ngff_image.ts";
 import { itkLpsToAnatomicalOrientation } from "../types/rfc4.ts";
 import type { AnatomicalOrientation } from "../types/rfc4.ts";
@@ -125,6 +126,7 @@ export async function itkImageToNgffImage(
     chunk_shape: chunkShape,
     data_type: imageType.componentType as zarr.DataType,
     fill_value: 0,
+    codecs: [...DEFAULT_CODECS],
   });
 
   // Write the ITK-Wasm data to the zarr array

--- a/ts/src/io/ngff_image_to_itk_image.ts
+++ b/ts/src/io/ngff_image_to_itk_image.ts
@@ -13,6 +13,7 @@ import type {
   TypedArray,
 } from "itk-wasm";
 import * as zarr from "zarrita";
+import { DEFAULT_CODECS } from "../utils/codecs.ts";
 import { NgffImage } from "../types/ngff_image.ts";
 
 export interface NgffImageToItkImageOptions {
@@ -144,6 +145,7 @@ export async function ngffImageToItkImage(
       chunk_shape: chunkShape,
       data_type: workingImage.data.dtype,
       fill_value: 0,
+      codecs: [...DEFAULT_CODECS],
     });
 
     // Write the slice data
@@ -202,6 +204,7 @@ export async function ngffImageToItkImage(
       chunk_shape: chunkShape,
       data_type: workingImage.data.dtype,
       fill_value: 0,
+      codecs: [...DEFAULT_CODECS],
     });
 
     // Write the slice data

--- a/ts/src/io/to_ngff_image.ts
+++ b/ts/src/io/to_ngff_image.ts
@@ -1,4 +1,5 @@
 import * as zarr from "zarrita";
+import { DEFAULT_CODECS } from "../utils/codecs.ts";
 import { NgffImage } from "../types/ngff_image.ts";
 import type { MemoryStore } from "../io/from_ngff_zarr.ts";
 
@@ -114,6 +115,7 @@ export async function toNgffImage(
     chunk_shape: chunkShape,
     data_type: "float32",
     fill_value: 0,
+    codecs: [...DEFAULT_CODECS],
   });
 
   // Write data to zarr array

--- a/ts/src/io/to_ngff_zarr-browser.ts
+++ b/ts/src/io/to_ngff_zarr-browser.ts
@@ -7,6 +7,7 @@ import type { Multiscales } from "../types/multiscales.ts";
 import type { NgffImage } from "../types/ngff_image.ts";
 import type { MemoryStore } from "./from_ngff_zarr-browser.ts";
 import { createQueue } from "../utils/create_queue.ts";
+import { DEFAULT_CODECS } from "../utils/codecs.ts";
 import { memoryStoreToZip } from "./rfc9_zip.ts";
 import { writeMultiscalesToMemoryStore } from "./to_ngff_zarr_ozx_common.ts";
 export { isOzxPath } from "./rfc9_zip.ts";
@@ -218,6 +219,7 @@ async function _writeImage(
       data_type: zarrDataType,
       chunk_shape: chunks,
       fill_value: 0,
+      codecs: [...DEFAULT_CODECS],
     });
 
     await _writeArrayData(

--- a/ts/src/io/to_ngff_zarr.ts
+++ b/ts/src/io/to_ngff_zarr.ts
@@ -5,6 +5,7 @@ import type { Multiscales } from "../types/multiscales.ts";
 import type { NgffImage } from "../types/ngff_image.ts";
 import type { MemoryStore } from "./from_ngff_zarr.ts";
 import { createQueue } from "../utils/create_queue.ts";
+import { DEFAULT_CODECS } from "../utils/codecs.ts";
 import { isOzxPath, memoryStoreToZip } from "./rfc9_zip.ts";
 import {
   processAxesForRfcs,
@@ -293,6 +294,7 @@ async function _writeImage(
       data_type: zarrDataType,
       chunk_shape: chunks,
       fill_value: 0,
+      codecs: [...DEFAULT_CODECS],
     });
 
     await _writeArrayData(

--- a/ts/src/methods/itkwasm-browser.ts
+++ b/ts/src/methods/itkwasm-browser.ts
@@ -12,6 +12,7 @@ import {
   downsampleLabelImage,
 } from "@itk-wasm/downsample";
 import * as zarr from "zarrita";
+import { DEFAULT_CODECS } from "../utils/codecs.ts";
 import { NgffImage } from "../types/ngff_image.ts";
 import {
   type DimFactors,
@@ -94,6 +95,7 @@ async function downsampleGaussian(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
+        codecs: [...DEFAULT_CODECS],
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -148,6 +150,7 @@ async function downsampleGaussian(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
+      codecs: [...DEFAULT_CODECS],
     });
 
     // Copy each downsampled slice into the combined array
@@ -216,6 +219,7 @@ async function downsampleGaussian(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
+        codecs: [...DEFAULT_CODECS],
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -270,6 +274,7 @@ async function downsampleGaussian(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
+      codecs: [...DEFAULT_CODECS],
     });
 
     // Copy each downsampled slice into the combined array
@@ -391,6 +396,7 @@ async function downsampleBinShrinkImpl(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
+        codecs: [...DEFAULT_CODECS],
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -445,6 +451,7 @@ async function downsampleBinShrinkImpl(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
+      codecs: [...DEFAULT_CODECS],
     });
 
     // Copy each downsampled slice into the combined array
@@ -513,6 +520,7 @@ async function downsampleBinShrinkImpl(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
+        codecs: [...DEFAULT_CODECS],
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -567,6 +575,7 @@ async function downsampleBinShrinkImpl(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
+      codecs: [...DEFAULT_CODECS],
     });
 
     // Copy each downsampled slice into the combined array
@@ -684,6 +693,7 @@ async function downsampleLabelImageImpl(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
+        codecs: [...DEFAULT_CODECS],
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -738,6 +748,7 @@ async function downsampleLabelImageImpl(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
+      codecs: [...DEFAULT_CODECS],
     });
 
     // Copy each downsampled slice into the combined array
@@ -806,6 +817,7 @@ async function downsampleLabelImageImpl(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
+        codecs: [...DEFAULT_CODECS],
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -860,6 +872,7 @@ async function downsampleLabelImageImpl(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
+      codecs: [...DEFAULT_CODECS],
     });
 
     // Copy each downsampled slice into the combined array

--- a/ts/src/methods/itkwasm-node.ts
+++ b/ts/src/methods/itkwasm-node.ts
@@ -17,6 +17,7 @@ import {
   downsampleNode as downsample,
 } from "@itk-wasm/downsample";
 import * as zarr from "zarrita";
+import { DEFAULT_CODECS } from "../utils/codecs.ts";
 import { NgffImage } from "../types/ngff_image.ts";
 import {
   type DimFactors,
@@ -99,6 +100,7 @@ async function downsampleGaussian(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
+        codecs: [...DEFAULT_CODECS],
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -153,6 +155,7 @@ async function downsampleGaussian(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
+      codecs: [...DEFAULT_CODECS],
     });
 
     // Copy each downsampled slice into the combined array
@@ -221,6 +224,7 @@ async function downsampleGaussian(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
+        codecs: [...DEFAULT_CODECS],
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -275,6 +279,7 @@ async function downsampleGaussian(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
+      codecs: [...DEFAULT_CODECS],
     });
 
     // Copy each downsampled slice into the combined array
@@ -396,6 +401,7 @@ async function downsampleBinShrinkImpl(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
+        codecs: [...DEFAULT_CODECS],
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -450,6 +456,7 @@ async function downsampleBinShrinkImpl(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
+      codecs: [...DEFAULT_CODECS],
     });
 
     // Copy each downsampled slice into the combined array
@@ -518,6 +525,7 @@ async function downsampleBinShrinkImpl(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
+        codecs: [...DEFAULT_CODECS],
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -572,6 +580,7 @@ async function downsampleBinShrinkImpl(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
+      codecs: [...DEFAULT_CODECS],
     });
 
     // Copy each downsampled slice into the combined array
@@ -689,6 +698,7 @@ async function downsampleLabelImageImpl(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
+        codecs: [...DEFAULT_CODECS],
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -743,6 +753,7 @@ async function downsampleLabelImageImpl(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
+      codecs: [...DEFAULT_CODECS],
     });
 
     // Copy each downsampled slice into the combined array
@@ -811,6 +822,7 @@ async function downsampleLabelImageImpl(
         chunk_shape: sliceChunkShape,
         data_type: image.data.dtype,
         fill_value: 0,
+        codecs: [...DEFAULT_CODECS],
       });
 
       const fullSelection = new Array(sliceShape.length).fill(null);
@@ -865,6 +877,7 @@ async function downsampleLabelImageImpl(
       chunk_shape: computeChunkShape(combinedShape, chunks, image.dims),
       data_type: image.data.dtype,
       fill_value: 0,
+      codecs: [...DEFAULT_CODECS],
     });
 
     // Copy each downsampled slice into the combined array

--- a/ts/src/methods/itkwasm-shared.ts
+++ b/ts/src/methods/itkwasm-shared.ts
@@ -8,6 +8,7 @@
 
 import type { Image } from "itk-wasm";
 import * as zarr from "zarrita";
+import { DEFAULT_CODECS } from "../utils/codecs.ts";
 import { NgffImage } from "../types/ngff_image.ts";
 
 export const SPATIAL_DIMS = ["x", "y", "z"];
@@ -635,6 +636,7 @@ export async function itkImageToZarr(
     chunk_shape: zarrChunkShape,
     data_type: dataType,
     fill_value: 0,
+    codecs: [...DEFAULT_CODECS],
   });
 
   // Write data - preserve the actual data type, don't cast to Float32Array

--- a/ts/src/utils/codecs.ts
+++ b/ts/src/utils/codecs.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * Default zarr v3 codecs for array creation.
+ *
+ * Includes the required `bytes` array-to-bytes codec (little-endian)
+ * and `blosc` bytes-to-bytes compression with zstd.
+ *
+ * Without explicit codecs, zarrita writes `"codecs": []` in zarr.json,
+ * which is not spec-compliant and causes errors in other zarr v3
+ * implementations (e.g., Python zarr-python).
+ */
+export const DEFAULT_CODECS = [
+  { name: "bytes", configuration: { endian: "little" } },
+  {
+    name: "blosc",
+    configuration: { cname: "zstd", clevel: 5, shuffle: 1, blocksize: 0 },
+  },
+] as const;

--- a/ts/src/utils/factory.ts
+++ b/ts/src/utils/factory.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
 // SPDX-License-Identifier: MIT
 import * as zarr from "zarrita";
+import { DEFAULT_CODECS } from "../utils/codecs.ts";
 import { NgffImage } from "../types/ngff_image.ts";
 import { Multiscales } from "../types/multiscales.ts";
 import type {
@@ -30,6 +31,7 @@ async function createTestZarrArray(
     shape,
     chunk_shape: chunks,
     data_type: dtype as zarr.DataType,
+    codecs: [...DEFAULT_CODECS],
   });
 
   return array;


### PR DESCRIPTION
Without explicit codecs, zarrita writes "codecs": [] in zarr.json,
which is not spec-compliant and causes "At least one ArrayBytesCodec
is required" errors in Python zarr-python v3. Add a shared
DEFAULT_CODECS constant with bytes (little-endian) and blosc (zstd,
level 5) codecs to all 31 zarr.create() array calls.
