### PR TITLE
fix(ts): bump fizarrita for edge chunk handling

### DIFF
--- a/ts/deno.json
+++ b/ts/deno.json
@@ -34,7 +34,7 @@
     "@std/cli": "jsr:@std/cli@^1.0.27",
     "@std/http": "jsr:@std/http@^1.0.24",
     "@std/path": "jsr:@std/path@^1.1.4",
-    "@fideus-labs/fizarrita": "npm:@fideus-labs/fizarrita@^1.0.0",
+    "@fideus-labs/fizarrita": "npm:@fideus-labs/fizarrita@^1.0.2",
     "@fideus-labs/worker-pool": "npm:@fideus-labs/worker-pool@^1.0.0",
     "@zarrita/storage": "jsr:@zarrita/storage@^0.1.4",
     "dnt": "jsr:@deno/dnt@^0.42.3",

--- a/ts/deno.lock
+++ b/ts/deno.lock
@@ -29,7 +29,7 @@
     "jsr:@ts-morph/common@0.27": "0.27.0",
     "jsr:@zarrita/storage@~0.1.4": "0.1.4",
     "jsr:@zarrita/zarrita@~0.6.1": "0.6.1",
-    "npm:@fideus-labs/fizarrita@1": "1.0.0_zarrita@0.6.0",
+    "npm:@fideus-labs/fizarrita@^1.0.2": "1.0.2_zarrita@0.6.1",
     "npm:@fideus-labs/worker-pool@1": "1.0.0",
     "npm:@itk-wasm/compare-images@^5.4.1": "5.4.1",
     "npm:@itk-wasm/downsample@^1.8.1": "1.8.1",
@@ -184,8 +184,8 @@
         "tslib"
       ]
     },
-    "@fideus-labs/fizarrita@1.0.0_zarrita@0.6.0": {
-      "integrity": "sha512-cgTph5KSFfOGwEZCE9T37cOZ3TafTGJCPl0NOvHM5mLqSCEw6L3wI8TCUUIIJlrY97Eu6T9YwsB960bSmWl1/Q==",
+    "@fideus-labs/fizarrita@1.0.2_zarrita@0.6.1": {
+      "integrity": "sha512-Qectre1TXkSIXNhSguJig8A/pzzvhuDfmiliagO79qhpy8mmu6HHboDsp0Q4bsFHmmu0/AlGsxi+MkDU8/EG1Q==",
       "dependencies": [
         "@fideus-labs/worker-pool",
         "zarrita"
@@ -358,8 +358,8 @@
         "uint8arrays"
       ]
     },
-    "@zarrita/storage@0.1.3": {
-      "integrity": "sha512-ZyCMYN3LuCNtKxro9876r/KyHyXV+ie2Bhk1qYsJR4Jp+sAjoVRRNNSJPsJxk64ZgFFezayO5S2hCu88/1Odwg==",
+    "@zarrita/storage@0.1.4": {
+      "integrity": "sha512-qURfJAQcQGRfDQ4J9HaCjGaj3jlJKc66bnRk6G/IeLUsM7WKyG7Bzsuf1EZurSXyc0I4LVcu6HaeQQ4d3kZ16g==",
       "dependencies": [
         "reference-spec-reader",
         "unzipit"
@@ -1255,8 +1255,8 @@
         "fd-slicer"
       ]
     },
-    "zarrita@0.6.0": {
-      "integrity": "sha512-chNgimqiK3HNskzicYo4lvSKYIRvXFa0f7v4mUZUCkxofvyEyhGKlWvXeFweAAprB9iI0XY8JNaTq8ChvzPASA==",
+    "zarrita@0.6.1": {
+      "integrity": "sha512-YOMTW8FT55Rz+vadTIZeOFZ/F2h4svKizyldvPtMYSxPgSNcRkOzkxCsWpIWlWzB1I/LmISmi0bEekOhLlI+Zw==",
       "dependencies": [
         "@zarrita/storage",
         "numcodecs"
@@ -1310,7 +1310,7 @@
       "jsr:@std/path@^1.1.4",
       "jsr:@zarrita/storage@~0.1.4",
       "jsr:@zarrita/zarrita@~0.6.1",
-      "npm:@fideus-labs/fizarrita@1",
+      "npm:@fideus-labs/fizarrita@^1.0.2",
       "npm:@fideus-labs/worker-pool@1",
       "npm:@itk-wasm/compare-images@^5.4.1",
       "npm:@itk-wasm/downsample@^1.8.1",

--- a/ts/scripts/build_npm.ts
+++ b/ts/scripts/build_npm.ts
@@ -194,7 +194,7 @@ async function createPackageJson(): Promise<void> {
     },
     files: ["esm/", "README.md", "LICENSE.txt"],
     dependencies: {
-      "@fideus-labs/fizarrita": "^1.0.0",
+      "@fideus-labs/fizarrita": "^1.0.2",
       "@fideus-labs/worker-pool": "^1.0.0",
       "@itk-wasm/downsample": "^1.8.1",
       comlink: "^4.4.2",


### PR DESCRIPTION
Zarr v3 edge chunks (at array boundaries) are stored at their actual
smaller size by spec-compliant writers (e.g., Python zarr). The codec
pipeline always reported shape=chunk_shape from metadata, causing
out-of-bounds reads and data corruption when decoding these smaller
chunks.
