### PR TITLE
fix(ts): handle 2D multi-component images in itkImageToNgffImage

### DIFF
--- a/.github/scripts/extract-changelog.sh
+++ b/.github/scripts/extract-changelog.sh
@@ -93,5 +93,90 @@ extract_changelog() {
     ' "$file"
 }
 
+get_release_tags() {
+    local prefix="$1"
+    local version="$2"
+    local current_tag="${prefix}-v${version}"
+    local previous_tag=""
+
+    mapfile -t tags < <(git tag --list "${prefix}-v*" --sort=-version:refname)
+
+    if [ "${#tags[@]}" -eq 0 ]; then
+        echo "${current_tag}|${previous_tag}"
+        return
+    fi
+
+    for ((i=0; i<${#tags[@]}; i++)); do
+        if [ "${tags[$i]}" = "${current_tag}" ]; then
+            if [ $((i+1)) -lt ${#tags[@]} ]; then
+                previous_tag="${tags[$((i+1))]}"
+            fi
+            break
+        fi
+    done
+
+    echo "${current_tag}|${previous_tag}"
+}
+
+append_contributors() {
+    local prefix="$1"
+    local version="$2"
+    local tag_info
+    local current_tag
+    local previous_tag
+    local range
+
+    tag_info=$(get_release_tags "$prefix" "$version")
+    current_tag="${tag_info%%|*}"
+    previous_tag="${tag_info##*|}"
+
+    if [ -n "$previous_tag" ]; then
+        range="${previous_tag}..${current_tag}"
+    else
+        range="${current_tag}"
+    fi
+
+    mapfile -t contributor_lines < <(git shortlog -s -n "$range" | sed 's/^[[:space:]]*[0-9]\+[[:space:]]\+//')
+
+    if [ "${#contributor_lines[@]}" -eq 0 ]; then
+        return
+    fi
+
+    printf "\n## 🤝 Contributors\n\n"
+    printf "We appreciate the contributions from:\n\n"
+    for name in "${contributor_lines[@]}"; do
+        if [ -n "$name" ]; then
+            printf "- %s\n" "$name"
+        fi
+    done
+
+    local new_contributors=()
+
+    if [ -z "$previous_tag" ]; then
+        for name in "${contributor_lines[@]}"; do
+            if [ -n "$name" ]; then
+                new_contributors+=("$name")
+            fi
+        done
+    else
+        for name in "${contributor_lines[@]}"; do
+            if [ -n "$name" ]; then
+                if ! git log --format="%an" "$previous_tag" | grep -Fxq "$name"; then
+                    new_contributors+=("$name")
+                fi
+            fi
+        done
+    fi
+
+    if [ "${#new_contributors[@]}" -gt 0 ]; then
+        printf "\n## 🌟 Congratulations\n\n"
+        printf "Congratulations to our new contributors:\n\n"
+        for name in "${new_contributors[@]}"; do
+            printf "- %s\n" "$name"
+        done
+    fi
+}
+
 # Extract and output the changelog
 extract_changelog "$CHANGELOG_FILE" "$VERSION" "$TAG_PREFIX"
+append_contributors "$TAG_PREFIX" "$VERSION"

--- a/ts/src/io/itk_image_to_ngff_image.ts
+++ b/ts/src/io/itk_image_to_ngff_image.ts
@@ -6,14 +6,14 @@
 
 import type { Image } from "itk-wasm";
 import * as zarr from "zarrita";
-import { defaultCodecs } from "../utils/codecs.ts";
-import { NgffImage } from "../types/ngff_image.ts";
-import { itkLpsToAnatomicalOrientation } from "../types/rfc4.ts";
-import type { AnatomicalOrientation } from "../types/rfc4.ts";
-import { zarrSet } from "../utils/worker_pool.ts";
-
 // Import the get_strides function from zarrita utilities
 import { _zarrita_internal_get_strides as getStrides } from "zarrita";
+
+import { NgffImage } from "../types/ngff_image.ts";
+import type { AnatomicalOrientation } from "../types/rfc4.ts";
+import { itkLpsToAnatomicalOrientation } from "../types/rfc4.ts";
+import { defaultCodecs } from "../utils/codecs.ts";
+import { zarrSet } from "../utils/worker_pool.ts";
 
 export interface ItkImageToNgffImageOptions {
   /**
@@ -52,8 +52,11 @@ export async function itkImageToNgffImage(
   itkImage: Image,
   options: ItkImageToNgffImageOptions = {},
 ): Promise<NgffImage> {
-  const { addAnatomicalOrientation = true, path = "image", chunks = 256 } =
-    options;
+  const {
+    addAnatomicalOrientation = true,
+    path = "image",
+    chunks = 256,
+  } = options;
 
   // Extract image properties from ITK-Wasm Image
   const _data = itkImage.data;
@@ -62,15 +65,25 @@ export async function itkImageToNgffImage(
   const shape = [...itkImage.size].reverse();
   const spacing = itkImage.spacing;
   const origin = itkImage.origin;
+
+  // Check if this is a vector image (multi-component)
+  const imageType = itkImage.imageType;
+  const isVector = imageType.components > 1;
+
+  // ITK-Wasm stores components separately from size (size is spatial-only).
+  // For vector images, append the component count to shape so that ndim and
+  // dims correctly include the "c" dimension — matching the Python
+  // implementation where image_dict["data"] already includes the component
+  // axis in its shape.
+  if (isVector) {
+    shape.push(imageType.components);
+  }
+
   const ndim = shape.length;
 
   // Determine dimension names based on shape and image type
   // This logic matches the Python implementation
   let dims: string[];
-
-  // Check if this is a vector image (multi-component)
-  const imageType = itkImage.imageType;
-  const isVector = imageType.components > 1;
 
   if (ndim === 3 && isVector) {
     // 2D RGB/vector image: 2D spatial + components

--- a/ts/test/itk_image_to_ngff_image_test.ts
+++ b/ts/test/itk_image_to_ngff_image_test.ts
@@ -1,2 +1,176 @@
 // SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
 // SPDX-License-Identifier: MIT
+
+/**
+ * Tests for itkImageToNgffImage conversion, covering scalar and
+ * multi-component (vector/RGB) ITK-Wasm images.
+ */
+
+import { assertEquals } from "@std/assert";
+import type { Image } from "itk-wasm";
+import * as zarr from "zarrita";
+
+import { itkImageToNgffImage } from "../src/io/itk_image_to_ngff_image.ts";
+
+/**
+ * Create identity direction matrix for ITK-Wasm Image
+ */
+function identityMatrix(dimension: number): Float64Array {
+  const m = new Float64Array(dimension * dimension);
+  for (let i = 0; i < dimension; i++) {
+    m[i * dimension + i] = 1;
+  }
+  return m;
+}
+
+/**
+ * Build a mock ITK-Wasm Image.
+ *
+ * `size` is the spatial-only size in physical order [x, y] or [x, y, z],
+ * exactly as ITK-Wasm reports it.  `components` defaults to 1 (scalar).
+ * The data buffer is sized `product(size) * components`.
+ */
+function mockItkImage(
+  size: number[],
+  componentType:
+    | "uint8"
+    | "int8"
+    | "uint16"
+    | "int16"
+    | "uint32"
+    | "int32"
+    | "float32"
+    | "float64",
+  components = 1,
+): Image {
+  const totalElements = size.reduce((a, b) => a * b, 1) * components;
+
+  const ArrayCtor: {
+    new (
+      n: number,
+    ):
+      | Uint8Array
+      | Int8Array
+      | Uint16Array
+      | Int16Array
+      | Uint32Array
+      | Int32Array
+      | Float32Array
+      | Float64Array;
+  } = {
+    uint8: Uint8Array,
+    int8: Int8Array,
+    uint16: Uint16Array,
+    int16: Int16Array,
+    uint32: Uint32Array,
+    int32: Int32Array,
+    float32: Float32Array,
+    float64: Float64Array,
+  }[componentType];
+
+  const data = new ArrayCtor(totalElements);
+  for (let i = 0; i < totalElements; i++) {
+    data[i] = i % 251; // prime modulus for a non-trivial pattern
+  }
+
+  return {
+    imageType: {
+      dimension: size.length,
+      componentType,
+      pixelType: components > 1 ? "VariableLengthVector" : "Scalar",
+      components,
+    },
+    name: "test",
+    origin: size.map(() => 0),
+    spacing: size.map(() => 1),
+    direction: identityMatrix(size.length),
+    size,
+    data,
+    metadata: new Map(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scalar (single-component) images
+// ---------------------------------------------------------------------------
+
+Deno.test("2D scalar image: dims and shape", async () => {
+  // ITK-Wasm size is in physical order [x, y]
+  const image = mockItkImage([100, 80], "uint8");
+  const ngff = await itkImageToNgffImage(image);
+
+  assertEquals(ngff.dims, ["y", "x"]);
+  // shape is size reversed → [y, x] = [80, 100]
+  assertEquals(ngff.data.shape, [80, 100]);
+});
+
+Deno.test("3D scalar image: dims and shape", async () => {
+  const image = mockItkImage([30, 40, 20], "uint16");
+  const ngff = await itkImageToNgffImage(image);
+
+  assertEquals(ngff.dims, ["z", "y", "x"]);
+  assertEquals(ngff.data.shape, [20, 40, 30]);
+});
+
+// ---------------------------------------------------------------------------
+// Multi-component (vector / RGB) images
+// ---------------------------------------------------------------------------
+
+Deno.test("2D RGB image: dims, shape, and data length", async () => {
+  // 2D spatial [x=100, y=80] with 3 components (RGB)
+  const image = mockItkImage([100, 80], "uint8", 3);
+  const ngff = await itkImageToNgffImage(image);
+
+  assertEquals(ngff.dims, ["y", "x", "c"]);
+  assertEquals(ngff.data.shape, [80, 100, 3]);
+
+  // Verify zarr array contains the full RGB data
+  const result = await zarr.get(ngff.data);
+  assertEquals(result.data.length, 80 * 100 * 3);
+});
+
+Deno.test("2D RGBA image: dims, shape, and data length", async () => {
+  const image = mockItkImage([64, 48], "uint8", 4);
+  const ngff = await itkImageToNgffImage(image);
+
+  assertEquals(ngff.dims, ["y", "x", "c"]);
+  assertEquals(ngff.data.shape, [48, 64, 4]);
+
+  const result = await zarr.get(ngff.data);
+  assertEquals(result.data.length, 48 * 64 * 4);
+});
+
+Deno.test("3D vector image: dims, shape, and data length", async () => {
+  // 3D spatial [x=16, y=20, z=10] with 3 components
+  const image = mockItkImage([16, 20, 10], "float32", 3);
+  const ngff = await itkImageToNgffImage(image);
+
+  assertEquals(ngff.dims, ["z", "y", "x", "c"]);
+  assertEquals(ngff.data.shape, [10, 20, 16, 3]);
+
+  const result = await zarr.get(ngff.data);
+  assertEquals(result.data.length, 10 * 20 * 16 * 3);
+});
+
+// ---------------------------------------------------------------------------
+// Spatial metadata
+// ---------------------------------------------------------------------------
+
+Deno.test("2D RGB image: scale and translation are spatial-only", async () => {
+  const image = mockItkImage([100, 80], "uint8", 3);
+  const ngff = await itkImageToNgffImage(image);
+
+  // Scale and translation should only have spatial keys
+  assertEquals(Object.keys(ngff.scale).sort(), ["x", "y"]);
+  assertEquals(Object.keys(ngff.translation).sort(), ["x", "y"]);
+});
+
+Deno.test("2D RGB image: data round-trips correctly", async () => {
+  const image = mockItkImage([4, 3], "uint8", 3);
+  const ngff = await itkImageToNgffImage(image);
+
+  const result = await zarr.get(ngff.data);
+  const actual = Array.from(result.data as Uint8Array);
+  const expected = Array.from(image.data as Uint8Array);
+  assertEquals(actual, expected);
+});


### PR DESCRIPTION
ITK-Wasm reports size as spatial-only (e.g. [width, height]) with components stored separately in imageType.components. For vector images (RGB/RGBA), the component count must be appended to the shape array before computing ndim so the dimension-naming logic correctly includes the "c" axis. Without this, 2D RGB images got dims=["y","x"] and a 2D zarr array, causing downstream multiscale code to fail with:
  IndexError: too many indices for array; expected 2, got 3