### PR TITLE
feat(ts): export ngffImageToItkImage from browser entry point

### DIFF
--- a/ts/src/browser-mod.ts
+++ b/ts/src/browser-mod.ts
@@ -5,32 +5,59 @@
 //
 // The browser versions support MemoryStore (Map) and HTTP/HTTPS URLs (read-only),
 // but not local file paths (which require Node.js/Deno filesystem APIs).
-export * from "./types/units.ts";
-export * from "./types/methods.ts";
-export * from "./types/array_interface.ts";
-export * from "./types/zarr_metadata.ts";
-export * from "./types/ngff_image.ts";
-export * from "./types/multiscales.ts";
 
-export * from "./schemas/units.ts";
+// Browser-compatible I/O modules
+// Note: Uses browser-specific versions that don't import @zarrita/storage
+// (which contains Node.js-specific modules like node:fs, node:buffer, node:path)
+export {
+  type ChunkCache,
+  fromNgffZarr,
+  type FromNgffZarrOptions,
+  type MemoryStore,
+} from "./io/from_ngff_zarr-browser.ts";
+// ITK-Wasm conversion utilities
+export {
+  itkImageToNgffImage,
+  type ItkImageToNgffImageOptions,
+} from "./io/itk_image_to_ngff_image.ts";
+export {
+  dataTypeToComponentType,
+  ngffImageToItkImage,
+  type NgffImageToItkImageOptions,
+} from "./io/ngff_image_to_itk_image.ts";
+export type { MemoryStoreToZipOptions } from "./io/rfc9_zip.ts";
+// RFC-9 exports
+export {
+  getZipFileCompressionMethod,
+  getZipFileList,
+  memoryStoreToZip,
+  orderFilesForRfc9,
+  readOzxVersion,
+} from "./io/rfc9_zip.ts";
+export {
+  isOzxPath,
+  toNgffZarr,
+  type ToNgffZarrOptions,
+  toNgffZarrOzx,
+  type ToNgffZarrOzxOptions,
+} from "./io/to_ngff_zarr-browser.ts";
+// Browser-compatible processing modules
+export * from "./process/to_multiscales-browser.ts";
 export * from "./schemas/methods.ts";
-export * from "./schemas/zarr_metadata.ts";
-export * from "./schemas/ngff_image.ts";
 export * from "./schemas/multiscales.ts";
-
-export {
-  isValidDimension,
-  isValidUnit,
-  validateMetadata,
-} from "./utils/validation.ts";
-export {
-  createAxis,
-  createDataset,
-  createMetadata,
-  createMultiscales,
-  createNgffImage,
-} from "./utils/factory.ts";
-export { getMethodMetadata } from "./utils/method_metadata.ts";
+export * from "./schemas/ngff_image.ts";
+export * from "./schemas/units.ts";
+export * from "./schemas/zarr_metadata.ts";
+export * from "./types/array_interface.ts";
+export * from "./types/methods.ts";
+export * from "./types/multiscales.ts";
+export * from "./types/ngff_image.ts";
+export * from "./types/units.ts";
+export * from "./types/zarr_metadata.ts";
+export type {
+  ComputeOmeroFromMultiscalesOptions,
+  ComputeOmeroOptions,
+} from "./utils/compute_omero.ts";
 // OMERO computation with WorkerPool
 export {
   computeOmeroFromMultiscales,
@@ -39,11 +66,7 @@ export {
   GLASBEY_COLORS,
   terminateOmeroWorkerPool,
 } from "./utils/compute_omero.ts";
-export type {
-  ComputeOmeroFromMultiscalesOptions,
-  ComputeOmeroOptions,
-} from "./utils/compute_omero.ts";
-
+export type { ChannelStatisticsAccumulator } from "./utils/compute_omero-shared.ts";
 // Shared OMERO computation functions for benchmarking and direct use
 export {
   buildOmeroFromAccumulators,
@@ -55,41 +78,17 @@ export {
   updateAccumulator,
   validateQuantiles,
 } from "./utils/compute_omero-shared.ts";
-export type { ChannelStatisticsAccumulator } from "./utils/compute_omero-shared.ts";
+export {
+  createAxis,
+  createDataset,
+  createMetadata,
+  createMultiscales,
+  createNgffImage,
+} from "./utils/factory.ts";
+export { getMethodMetadata } from "./utils/method_metadata.ts";
+export {
+  isValidDimension,
+  isValidUnit,
+  validateMetadata,
+} from "./utils/validation.ts";
 export { terminateWorkerPool, zarrGet, zarrSet } from "./utils/worker_pool.ts";
-
-// Browser-compatible I/O modules
-// Note: Uses browser-specific versions that don't import @zarrita/storage
-// (which contains Node.js-specific modules like node:fs, node:buffer, node:path)
-export {
-  type ChunkCache,
-  fromNgffZarr,
-  type FromNgffZarrOptions,
-  type MemoryStore,
-} from "./io/from_ngff_zarr-browser.ts";
-export {
-  isOzxPath,
-  toNgffZarr,
-  type ToNgffZarrOptions,
-  toNgffZarrOzx,
-  type ToNgffZarrOzxOptions,
-} from "./io/to_ngff_zarr-browser.ts";
-
-// RFC-9 exports
-export {
-  getZipFileCompressionMethod,
-  getZipFileList,
-  memoryStoreToZip,
-  orderFilesForRfc9,
-  readOzxVersion,
-} from "./io/rfc9_zip.ts";
-export type { MemoryStoreToZipOptions } from "./io/rfc9_zip.ts";
-
-// Browser-compatible processing modules
-export * from "./process/to_multiscales-browser.ts";
-
-// ITK-Wasm conversion utilities
-export {
-  itkImageToNgffImage,
-  type ItkImageToNgffImageOptions,
-} from "./io/itk_image_to_ngff_image.ts";


### PR DESCRIPTION
The function was only available from the main (Node) entry point but
is fully browser-compatible. Exporting it from browser-mod.ts allows
browser consumers to import it directly without deep-path workarounds.
