### PR TITLE
build(pre-commit): add --use-default-range for commitizen

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,3 +57,4 @@ repos:
         stages: [commit-msg]
       - id: commitizen-branch
         stages: [pre-push]
+        args: ["--use-default-range"]


### PR DESCRIPTION
Do not check errors in the history.