### PR TITLE
fix(ts): handle padded edge chunks and fix biased reservoir merge

### DIFF
--- a/ts/src/utils/compute_omero-shared.ts
+++ b/ts/src/utils/compute_omero-shared.ts
@@ -438,31 +438,49 @@ export function mergeAccumulators(
   a: ChannelStatisticsAccumulator,
   b: ChannelStatisticsAccumulator,
 ): ChannelStatisticsAccumulator {
-  const merged: ChannelStatisticsAccumulator = {
-    min: Math.min(a.min, b.min),
-    max: Math.max(a.max, b.max),
-    count: a.count + b.count,
-    sample: [...a.sample, ...b.sample],
-  };
+  const totalCount = a.count + b.count;
 
-  // Downsample if combined reservoir exceeds limit
-  if (merged.sample.length > QUANTILE_SAMPLE_SIZE) {
-    // Use reservoir sampling over the concatenated sample for unbiased downsampling
-    const k = QUANTILE_SAMPLE_SIZE;
-    const n = merged.sample.length;
-
-    // Treat the first k elements as the initial reservoir and
-    // stream the remaining elements, applying the reservoir update rule.
-    for (let i = k; i < n; i++) {
-      const j = Math.floor(Math.random() * (i + 1));
-      if (j < k) {
-        merged.sample[j] = merged.sample[i];
-      }
-    }
-    merged.sample.length = k;
+  // When neither accumulator has data, return an empty accumulator
+  if (totalCount === 0) {
+    return {
+      min: Math.min(a.min, b.min),
+      max: Math.max(a.max, b.max),
+      count: 0,
+      sample: [],
+    };
   }
 
-  return merged;
+  // Build a merged sample that is proportionally representative of each
+  // population.  Each accumulator's reservoir is a uniform random sample
+  // of its population, so we select from each reservoir in proportion to
+  // its population size (count) to keep the combined sample unbiased.
+  const k = QUANTILE_SAMPLE_SIZE;
+  const aWeight = a.count / totalCount;
+  const aTarget = Math.round(k * aWeight);
+  const bTarget = k - aTarget;
+
+  // Helper: take `want` random elements from `src` (Fisher-Yates partial shuffle)
+  function subsample(src: number[], want: number): number[] {
+    if (want >= src.length) return src.slice();
+    const arr = src.slice();
+    for (let i = 0; i < want; i++) {
+      const j = i + Math.floor(Math.random() * (arr.length - i));
+      const tmp = arr[i];
+      arr[i] = arr[j];
+      arr[j] = tmp;
+    }
+    return arr.slice(0, want);
+  }
+
+  const aSamples = subsample(a.sample, aTarget);
+  const bSamples = subsample(b.sample, bTarget);
+
+  return {
+    min: Math.min(a.min, b.min),
+    max: Math.max(a.max, b.max),
+    count: totalCount,
+    sample: aSamples.concat(bSamples),
+  };
 }
 
 /**

--- a/ts/src/workers/omero_codec_worker.ts
+++ b/ts/src/workers/omero_codec_worker.ts
@@ -17,6 +17,7 @@
  *   decode_and_stats: → decoded_and_stats    (decode + compute channel stats)
  */
 
+import type { CodecChunkMeta } from "@fideus-labs/fizarrita";
 // fizarrita internals for codec pipeline
 import { create_codec_pipeline } from "@fideus-labs/fizarrita/internals/codec-pipeline";
 import {
@@ -24,9 +25,7 @@ import {
   set_from_chunk_binary,
 } from "@fideus-labs/fizarrita/internals/setter";
 import { get_ctr, get_strides } from "@fideus-labs/fizarrita/internals/util";
-
 import type { Chunk, DataType } from "zarrita";
-import type { CodecChunkMeta } from "@fideus-labs/fizarrita";
 
 // Projection type — plain serializable data describing chunk→output mapping.
 // Mirrors fizarrita's Projection type for worker messages.
@@ -59,14 +58,66 @@ function fixEdgeChunkShapeStride<D extends DataType>(
     const expectedElements = actualChunkShape.reduce((a, b) => a * b, 1);
     const actualElements = (chunk.data as unknown as ArrayLike<unknown>).length;
     if (actualElements === expectedElements) {
+      // Decoded size matches the actual edge shape — just fix shape/stride
       return {
         data: chunk.data,
         shape: actualChunkShape,
         stride: get_strides(actualChunkShape, "C"),
       };
     }
+    if (actualElements > expectedElements) {
+      // Decoded chunk is padded to full chunk_shape (e.g. by setWorker).
+      // Extract the valid sub-region into a compact contiguous buffer.
+      // deno-lint-ignore no-explicit-any
+      const src = chunk.data as any;
+      const Ctr = src.constructor as new (n: number) => typeof src;
+      const dst = new Ctr(expectedElements);
+      const srcStrides = get_strides(chunk.shape, "C");
+      copySubRegion(src, srcStrides, dst, actualChunkShape);
+      return {
+        data: dst as typeof chunk.data,
+        shape: actualChunkShape,
+        stride: get_strides(actualChunkShape, "C"),
+      };
+    }
   }
   return chunk;
+}
+
+/**
+ * Copy a sub-region from a padded C-order buffer into a compact destination.
+ *
+ * For each dimension, copies only the first `subShape[d]` elements along
+ * that axis from the source (which has strides `srcStrides`).
+ */
+function copySubRegion(
+  src: { readonly [i: number]: unknown; readonly length: number },
+  srcStrides: number[],
+  dst: { [i: number]: unknown; length: number },
+  subShape: number[],
+  srcOffset = 0,
+  dstOffset = 0,
+  dim = 0,
+): void {
+  if (dim === subShape.length - 1) {
+    // Innermost dimension — copy contiguous run
+    for (let i = 0; i < subShape[dim]; i++) {
+      dst[dstOffset + i] = src[srcOffset + i];
+    }
+    return;
+  }
+  const dstStride = subShape.slice(dim + 1).reduce((a, b) => a * b, 1);
+  for (let i = 0; i < subShape[dim]; i++) {
+    copySubRegion(
+      src,
+      srcStrides,
+      dst,
+      subShape,
+      srcOffset + i * srcStrides[dim],
+      dstOffset + i * dstStride,
+      dim + 1,
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -85,9 +136,7 @@ const pipelineByKey = new Map<
   ReturnType<typeof create_codec_pipeline>
 >();
 
-function getPipeline(
-  metaId: number,
-): ReturnType<typeof create_codec_pipeline> {
+function getPipeline(metaId: number): ReturnType<typeof create_codec_pipeline> {
   const pipeline = pipelineByMetaId.get(metaId);
   if (!pipeline) {
     throw new Error(
@@ -170,201 +219,191 @@ type WorkerMessage =
     cIndex: number;
   };
 
-ctx.addEventListener(
-  "message",
-  async (event: MessageEvent<WorkerMessage>) => {
-    const msg = event.data;
+ctx.addEventListener("message", async (event: MessageEvent<WorkerMessage>) => {
+  const msg = event.data;
 
-    try {
-      if (msg.type === "init") {
-        metaByMetaId.set(msg.metaId, msg.meta);
-        const pipeline = create_codec_pipeline({
-          data_type: msg.meta.data_type,
-          shape: msg.meta.chunk_shape,
-          codecs: msg.meta.codecs,
-        });
-        pipelineByMetaId.set(msg.metaId, pipeline);
-        ctx.postMessage({ type: "init_ok", id: msg.id });
-        return;
+  try {
+    if (msg.type === "init") {
+      metaByMetaId.set(msg.metaId, msg.meta);
+      const pipeline = create_codec_pipeline({
+        data_type: msg.meta.data_type,
+        shape: msg.meta.chunk_shape,
+        codecs: msg.meta.codecs,
+      });
+      pipelineByMetaId.set(msg.metaId, pipeline);
+      ctx.postMessage({ type: "init_ok", id: msg.id });
+      return;
+    }
+
+    if (msg.type === "decode") {
+      const pipeline =
+        msg.metaId !== undefined && pipelineByMetaId.has(msg.metaId)
+          ? getPipeline(msg.metaId)
+          : getOrCreatePipelineLegacy(msg.meta!);
+
+      const bytes = new Uint8Array(msg.bytes);
+      let chunk = (await pipeline.decode(bytes)) as Chunk<DataType>;
+      chunk = fixEdgeChunkShapeStride(chunk, msg.actualChunkShape);
+
+      const dataView = chunk.data as unknown as {
+        buffer: ArrayBuffer;
+        byteOffset: number;
+        byteLength: number;
+      };
+      const buffer = dataView.buffer;
+      const byteOffset = dataView.byteOffset;
+      const byteLength = dataView.byteLength;
+
+      let transferBuffer: ArrayBuffer;
+      if (byteOffset === 0 && byteLength === buffer.byteLength) {
+        transferBuffer = buffer;
+      } else {
+        transferBuffer = buffer.slice(byteOffset, byteOffset + byteLength);
       }
 
-      if (msg.type === "decode") {
-        const pipeline =
-          msg.metaId !== undefined && pipelineByMetaId.has(msg.metaId)
-            ? getPipeline(msg.metaId)
-            : getOrCreatePipelineLegacy(msg.meta!);
+      ctx.postMessage(
+        {
+          type: "decoded" as const,
+          id: msg.id,
+          data: transferBuffer,
+          shape: chunk.shape,
+          stride: chunk.stride,
+        },
+        [transferBuffer],
+      );
+    } else if (msg.type === "decode_into") {
+      const pipeline = getPipeline(msg.metaId);
+      const bytes = new Uint8Array(msg.bytes);
+      let chunk = (await pipeline.decode(bytes)) as Chunk<DataType>;
+      chunk = fixEdgeChunkShapeStride(chunk, msg.actualChunkShape);
 
-        const bytes = new Uint8Array(msg.bytes);
-        let chunk = (await pipeline.decode(bytes)) as Chunk<DataType>;
-        chunk = fixEdgeChunkShapeStride(chunk, msg.actualChunkShape);
+      const destView = new Uint8Array(msg.output, 0, msg.outputByteLength);
+      // deno-lint-ignore no-explicit-any
+      const src = compat_chunk(chunk as any);
 
-        const dataView = chunk.data as unknown as {
-          buffer: ArrayBuffer;
-          byteOffset: number;
-          byteLength: number;
-        };
-        const buffer = dataView.buffer;
-        const byteOffset = dataView.byteOffset;
-        const byteLength = dataView.byteLength;
+      set_from_chunk_binary(
+        { data: destView, stride: msg.outputStride },
+        src,
+        msg.bytesPerElement,
+        msg.projections,
+      );
 
-        let transferBuffer: ArrayBuffer;
-        if (byteOffset === 0 && byteLength === buffer.byteLength) {
-          transferBuffer = buffer;
-        } else {
-          transferBuffer = buffer.slice(byteOffset, byteOffset + byteLength);
-        }
+      ctx.postMessage({ type: "decode_into_ok", id: msg.id });
+    } else if (msg.type === "encode") {
+      let pipeline: ReturnType<typeof create_codec_pipeline>;
+      let meta: CodecChunkMeta;
+      if (msg.metaId !== undefined && pipelineByMetaId.has(msg.metaId)) {
+        pipeline = getPipeline(msg.metaId);
+        meta = metaByMetaId.get(msg.metaId)!;
+      } else {
+        meta = msg.meta!;
+        pipeline = getOrCreatePipelineLegacy(meta);
+      }
 
-        ctx.postMessage(
-          {
-            type: "decoded" as const,
-            id: msg.id,
-            data: transferBuffer,
-            shape: chunk.shape,
-            stride: chunk.stride,
-          },
-          [transferBuffer],
+      const Ctr = get_ctr(meta.data_type) as unknown as {
+        new (buf: ArrayBuffer, off: number, len: number): unknown;
+        BYTES_PER_ELEMENT: number;
+      };
+      const data = new Ctr(
+        msg.data,
+        0,
+        msg.data.byteLength / Ctr.BYTES_PER_ELEMENT,
+      );
+      const shape = meta.chunk_shape;
+      const stride = get_strides(shape, "C");
+
+      const chunk = { data, shape, stride } as Chunk<DataType>;
+      // deno-lint-ignore no-explicit-any
+      const encoded = await pipeline.encode(chunk as any);
+
+      const transferBuffer = encoded.byteOffset === 0 &&
+          encoded.byteLength === encoded.buffer.byteLength
+        ? (encoded.buffer as ArrayBuffer)
+        : encoded.buffer.slice(
+          encoded.byteOffset,
+          encoded.byteOffset + encoded.byteLength,
         );
-      } else if (msg.type === "decode_into") {
-        const pipeline = getPipeline(msg.metaId);
-        const bytes = new Uint8Array(msg.bytes);
-        let chunk = (await pipeline.decode(bytes)) as Chunk<DataType>;
-        chunk = fixEdgeChunkShapeStride(chunk, msg.actualChunkShape);
 
-        const destView = new Uint8Array(msg.output, 0, msg.outputByteLength);
-        // deno-lint-ignore no-explicit-any
-        const src = compat_chunk(chunk as any);
+      ctx.postMessage(
+        {
+          type: "encoded" as const,
+          id: msg.id,
+          bytes: transferBuffer,
+        },
+        [transferBuffer],
+      );
+    } else if (msg.type === "decode_and_stats") {
+      // NEW: Decode chunk AND compute per-channel statistics in one pass
+      const pipeline = getPipeline(msg.metaId);
+      const bytes = new Uint8Array(msg.bytes);
+      let chunk = (await pipeline.decode(bytes)) as Chunk<DataType>;
+      chunk = fixEdgeChunkShapeStride(chunk, msg.actualChunkShape);
 
-        set_from_chunk_binary(
-          { data: destView, stride: msg.outputStride },
-          src,
-          msg.bytesPerElement,
-          msg.projections,
-        );
+      const chunkData = chunk.data as unknown as ArrayLike<number>;
+      const chunkShape = chunk.shape;
+      const { nChannels, cIndex } = msg;
 
-        ctx.postMessage({ type: "decode_into_ok", id: msg.id });
-      } else if (msg.type === "encode") {
-        let pipeline: ReturnType<typeof create_codec_pipeline>;
-        let meta: CodecChunkMeta;
-        if (
-          msg.metaId !== undefined && pipelineByMetaId.has(msg.metaId)
-        ) {
-          pipeline = getPipeline(msg.metaId);
-          meta = metaByMetaId.get(msg.metaId)!;
-        } else {
-          meta = msg.meta!;
-          pipeline = getOrCreatePipelineLegacy(meta);
-        }
-
-        const Ctr = get_ctr(meta.data_type) as unknown as {
-          new (buf: ArrayBuffer, off: number, len: number): unknown;
-          BYTES_PER_ELEMENT: number;
-        };
-        const data = new Ctr(
-          msg.data,
-          0,
-          msg.data.byteLength / Ctr.BYTES_PER_ELEMENT,
-        );
-        const shape = meta.chunk_shape;
-        const stride = get_strides(shape, "C");
-
-        const chunk = { data, shape, stride } as Chunk<DataType>;
-        // deno-lint-ignore no-explicit-any
-        const encoded = await pipeline.encode(chunk as any);
-
-        const transferBuffer = encoded.byteOffset === 0 &&
-            encoded.byteLength === encoded.buffer.byteLength
-          ? (encoded.buffer as ArrayBuffer)
-          : encoded.buffer.slice(
-            encoded.byteOffset,
-            encoded.byteOffset + encoded.byteLength,
-          );
-
-        ctx.postMessage(
-          {
-            type: "encoded" as const,
-            id: msg.id,
-            bytes: transferBuffer,
-          },
-          [transferBuffer],
-        );
-      } else if (msg.type === "decode_and_stats") {
-        // NEW: Decode chunk AND compute per-channel statistics in one pass
-        const pipeline = getPipeline(msg.metaId);
-        const bytes = new Uint8Array(msg.bytes);
-        let chunk = (await pipeline.decode(bytes)) as Chunk<DataType>;
-        chunk = fixEdgeChunkShapeStride(chunk, msg.actualChunkShape);
-
-        const chunkData = chunk.data as unknown as ArrayLike<number>;
-        const chunkShape = chunk.shape;
-        const { nChannels, cIndex } = msg;
-
-        // Compute per-channel statistics
-        const accumulators: SerializedAccumulator[] = [];
-        if (cIndex >= 0) {
-          // Multi-channel: extract each channel and compute stats
-          for (let ch = 0; ch < nChannels; ch++) {
-            const channelData = extractChannel(
-              chunkData,
-              chunkShape,
-              ch,
-              cIndex,
-            );
-            const acc = createAccumulator();
-            updateAccumulator(acc, channelData);
-            accumulators.push(acc);
-          }
-        } else {
-          // Single channel: compute stats on full chunk data
+      // Compute per-channel statistics
+      const accumulators: SerializedAccumulator[] = [];
+      if (cIndex >= 0) {
+        // Multi-channel: extract each channel and compute stats
+        for (let ch = 0; ch < nChannels; ch++) {
+          const channelData = extractChannel(chunkData, chunkShape, ch, cIndex);
           const acc = createAccumulator();
-          updateAccumulator(acc, chunkData);
+          updateAccumulator(acc, channelData);
           accumulators.push(acc);
         }
-
-        // Transfer the decoded data buffer back for caching
-        const dataView = chunk.data as unknown as {
-          buffer: ArrayBuffer;
-          byteOffset: number;
-          byteLength: number;
-        };
-        const buffer = dataView.buffer;
-        const byteOffset = dataView.byteOffset;
-        const byteLength = dataView.byteLength;
-
-        let transferBuffer: ArrayBuffer;
-        if (byteOffset === 0 && byteLength === buffer.byteLength) {
-          transferBuffer = buffer;
-        } else {
-          transferBuffer = buffer.slice(byteOffset, byteOffset + byteLength);
-        }
-
-        ctx.postMessage(
-          {
-            type: "decoded_and_stats" as const,
-            id: msg.id,
-            data: transferBuffer,
-            shape: chunk.shape,
-            stride: chunk.stride,
-            accumulators,
-          },
-          [transferBuffer],
-        );
+      } else {
+        // Single channel: compute stats on full chunk data
+        const acc = createAccumulator();
+        updateAccumulator(acc, chunkData);
+        accumulators.push(acc);
       }
-    } catch (error) {
-      // Send error back to main thread
-      const errorType = msg.type === "decode"
-        ? "decoded"
-        : msg.type === "encode"
-        ? "encoded"
-        : msg.type === "decode_into"
-        ? "decode_into_ok"
-        : msg.type === "decode_and_stats"
-        ? "decoded_and_stats"
-        : "init_ok";
-      ctx.postMessage({
-        type: errorType,
-        id: msg.id,
-        error: error instanceof Error ? error.message : String(error),
-      });
+
+      // Transfer the decoded data buffer back for caching
+      const dataView = chunk.data as unknown as {
+        buffer: ArrayBuffer;
+        byteOffset: number;
+        byteLength: number;
+      };
+      const buffer = dataView.buffer;
+      const byteOffset = dataView.byteOffset;
+      const byteLength = dataView.byteLength;
+
+      let transferBuffer: ArrayBuffer;
+      if (byteOffset === 0 && byteLength === buffer.byteLength) {
+        transferBuffer = buffer;
+      } else {
+        transferBuffer = buffer.slice(byteOffset, byteOffset + byteLength);
+      }
+
+      ctx.postMessage(
+        {
+          type: "decoded_and_stats" as const,
+          id: msg.id,
+          data: transferBuffer,
+          shape: chunk.shape,
+          stride: chunk.stride,
+          accumulators,
+        },
+        [transferBuffer],
+      );
     }
-  },
-);
+  } catch (error) {
+    // Send error back to main thread
+    const errorType = msg.type === "decode"
+      ? "decoded"
+      : msg.type === "encode"
+      ? "encoded"
+      : msg.type === "decode_into"
+      ? "decode_into_ok"
+      : msg.type === "decode_and_stats"
+      ? "decoded_and_stats"
+      : "init_ok";
+    ctx.postMessage({
+      type: errorType,
+      id: msg.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+});

--- a/ts/test/merge_accumulators_test.ts
+++ b/ts/test/merge_accumulators_test.ts
@@ -1,0 +1,491 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * Tests for mergeAccumulators in compute_omero-shared.ts.
+ * Focuses on proportional sampling and unbiased reservoir merging.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import {
+  createAccumulator,
+  finalizeStatistics,
+  mergeAccumulators,
+  updateAccumulator,
+} from "../src/utils/compute_omero-shared.ts";
+
+// ============================================================================
+// Basic merging tests
+// ============================================================================
+
+Deno.test("mergeAccumulators: two empty accumulators", () => {
+  const a = createAccumulator();
+  const b = createAccumulator();
+
+  const merged = mergeAccumulators(a, b);
+
+  assertEquals(merged.count, 0);
+  assertEquals(merged.sample.length, 0);
+  assertEquals(merged.min, Math.min(a.min, b.min));
+  assertEquals(merged.max, Math.max(a.max, b.max));
+});
+
+Deno.test("mergeAccumulators: one empty, one with data", () => {
+  const empty = createAccumulator();
+  const withData = createAccumulator();
+  const data = [1, 2, 3, 4, 5];
+  updateAccumulator(withData, data);
+
+  const merged = mergeAccumulators(empty, withData);
+
+  assertEquals(merged.count, 5);
+  assertEquals(merged.min, 1);
+  assertEquals(merged.max, 5);
+  // Should have all samples from withData since empty contributes nothing
+  assertEquals(merged.sample.length, 5);
+});
+
+Deno.test("mergeAccumulators: preserves min/max from both", () => {
+  const a = createAccumulator();
+  const b = createAccumulator();
+  updateAccumulator(a, [5, 10, 15]);
+  updateAccumulator(b, [1, 20, 25]);
+
+  const merged = mergeAccumulators(a, b);
+
+  assertEquals(merged.min, 1); // From b
+  assertEquals(merged.max, 25); // From b
+});
+
+// ============================================================================
+// Proportional sampling tests
+// ============================================================================
+
+Deno.test("mergeAccumulators: equal-sized populations get equal representation", () => {
+  const a = createAccumulator();
+  const b = createAccumulator();
+
+  // Both have 100 elements
+  updateAccumulator(a, Array(100).fill(1));
+  updateAccumulator(b, Array(100).fill(2));
+
+  const merged = mergeAccumulators(a, b);
+
+  assertEquals(merged.count, 200);
+
+  // Each accumulator should contribute roughly half of the samples
+  // Count how many 1s vs 2s in the merged sample
+  const count1s = merged.sample.filter((x) => x === 1).length;
+  const count2s = merged.sample.filter((x) => x === 2).length;
+
+  // With equal populations, expect roughly 50/50 split
+  // Allow some variance due to random sampling
+  const ratio = count1s / (count1s + count2s);
+  assertEquals(ratio > 0.4 && ratio < 0.6, true, `ratio=${ratio}`);
+});
+
+Deno.test("mergeAccumulators: 10:1 population ratio", () => {
+  const large = createAccumulator();
+  const small = createAccumulator();
+
+  // Large chunk: 1000 elements
+  updateAccumulator(large, Array(1000).fill(100));
+  // Small chunk: 100 elements
+  updateAccumulator(small, Array(100).fill(200));
+
+  const merged = mergeAccumulators(large, small);
+
+  assertEquals(merged.count, 1100);
+
+  // Count representation in sample
+  const countLarge = merged.sample.filter((x) => x === 100).length;
+  const countSmall = merged.sample.filter((x) => x === 200).length;
+
+  // Large should have ~10x more samples than small
+  // Expected ratio: 1000/1100 ≈ 0.909
+  const ratio = countLarge / (countLarge + countSmall);
+  assertEquals(
+    ratio > 0.85 && ratio < 0.95,
+    true,
+    `ratio=${ratio}, should be ~0.909`,
+  );
+});
+
+Deno.test("mergeAccumulators: 100:1 population ratio (edge chunk scenario)", () => {
+  const fullChunk = createAccumulator();
+  const edgeChunk = createAccumulator();
+
+  // Full chunk: 10000 voxels
+  updateAccumulator(fullChunk, Array(10000).fill(50));
+  // Edge chunk: 100 voxels
+  updateAccumulator(edgeChunk, Array(100).fill(150));
+
+  const merged = mergeAccumulators(fullChunk, edgeChunk);
+
+  assertEquals(merged.count, 10100);
+
+  const countFull = merged.sample.filter((x) => x === 50).length;
+  const countEdge = merged.sample.filter((x) => x === 150).length;
+
+  // Expected ratio: 10000/10100 ≈ 0.99
+  const ratio = countFull / (countFull + countEdge);
+  assertEquals(
+    ratio > 0.97 && ratio < 1.0,
+    true,
+    `ratio=${ratio}, should be ~0.99`,
+  );
+});
+
+// ============================================================================
+// Tests for correct quantile estimation after merging
+// ============================================================================
+
+Deno.test("mergeAccumulators: quantiles remain accurate after merge", () => {
+  const a = createAccumulator();
+  const b = createAccumulator();
+
+  // a: values 0-499
+  updateAccumulator(a, Array.from({ length: 500 }, (_, i) => i));
+  // b: values 500-999
+  updateAccumulator(b, Array.from({ length: 500 }, (_, i) => i + 500));
+
+  const merged = mergeAccumulators(a, b);
+
+  // Finalize with 2% and 98% quantiles
+  const stats = finalizeStatistics(merged, [0.02, 0.98]);
+
+  assertEquals(merged.count, 1000);
+  assertEquals(stats.min, 0);
+  assertEquals(stats.max, 999);
+
+  // 2% of 1000 = 20, 98% = 980
+  // Allow some sampling error
+  assertEquals(
+    stats.qLow >= 0 && stats.qLow <= 40,
+    true,
+    `qLow=${stats.qLow}`,
+  );
+  assertEquals(
+    stats.qHigh >= 960 && stats.qHigh <= 999,
+    true,
+    `qHigh=${stats.qHigh}`,
+  );
+});
+
+Deno.test("mergeAccumulators: bimodal distribution", () => {
+  const a = createAccumulator();
+  const b = createAccumulator();
+
+  // a: all zeros (background)
+  updateAccumulator(a, Array(1000).fill(0));
+  // b: all 255s (foreground)
+  updateAccumulator(b, Array(1000).fill(255));
+
+  const merged = mergeAccumulators(a, b);
+  const stats = finalizeStatistics(merged, [0.02, 0.98]);
+
+  assertEquals(merged.count, 2000);
+  assertEquals(stats.min, 0);
+  assertEquals(stats.max, 255);
+
+  // With equal populations, both values should be well represented
+  const count0s = merged.sample.filter((x) => x === 0).length;
+  const count255s = merged.sample.filter((x) => x === 255).length;
+
+  // Expect roughly 50/50 split
+  const ratio = count0s / (count0s + count255s);
+  assertEquals(ratio > 0.4 && ratio < 0.6, true, `ratio=${ratio}`);
+});
+
+// ============================================================================
+// Tests for multiple sequential merges
+// ============================================================================
+
+Deno.test("mergeAccumulators: chaining multiple merges", () => {
+  const acc1 = createAccumulator();
+  const acc2 = createAccumulator();
+  const acc3 = createAccumulator();
+  const acc4 = createAccumulator();
+
+  // Each chunk has different size and values
+  updateAccumulator(acc1, Array(100).fill(10)); // Small
+  updateAccumulator(acc2, Array(1000).fill(20)); // Large
+  updateAccumulator(acc3, Array(100).fill(30)); // Small
+  updateAccumulator(acc4, Array(1000).fill(40)); // Large
+
+  // Merge in sequence (simulating parallel reduction)
+  const merged12 = mergeAccumulators(acc1, acc2);
+  const merged34 = mergeAccumulators(acc3, acc4);
+  const final = mergeAccumulators(merged12, merged34);
+
+  assertEquals(final.count, 2200);
+  assertEquals(final.min, 10);
+  assertEquals(final.max, 40);
+
+  // Count representation
+  const counts = {
+    10: final.sample.filter((x) => x === 10).length,
+    20: final.sample.filter((x) => x === 20).length,
+    30: final.sample.filter((x) => x === 30).length,
+    40: final.sample.filter((x) => x === 40).length,
+  };
+
+  // Large chunks (20, 40) should dominate with ~1000/2200 ≈ 0.45 each
+  // Small chunks (10, 30) should each have ~100/2200 ≈ 0.045
+  const total = counts[10] + counts[20] + counts[30] + counts[40];
+  const ratio20 = counts[20] / total;
+  const ratio40 = counts[40] / total;
+  const ratio10 = counts[10] / total;
+  const ratio30 = counts[30] / total;
+
+  // Large chunks: expect ~0.45 each (allow 0.35-0.55)
+  assertEquals(
+    ratio20 > 0.35 && ratio20 < 0.55,
+    true,
+    `ratio20=${ratio20}`,
+  );
+  assertEquals(
+    ratio40 > 0.35 && ratio40 < 0.55,
+    true,
+    `ratio40=${ratio40}`,
+  );
+
+  // Small chunks: expect ~0.045 each (allow 0.01-0.15)
+  assertEquals(
+    ratio10 > 0.01 && ratio10 < 0.15,
+    true,
+    `ratio10=${ratio10}`,
+  );
+  assertEquals(
+    ratio30 > 0.01 && ratio30 < 0.15,
+    true,
+    `ratio30=${ratio30}`,
+  );
+});
+
+// ============================================================================
+// Tests for Fisher-Yates partial shuffle
+// ============================================================================
+
+Deno.test("mergeAccumulators: randomness in subsampling", () => {
+  // Verify that Fisher-Yates shuffle produces different samples
+  // Use different data in each accumulator to guarantee different possible outcomes
+  const acc1 = createAccumulator();
+  const acc2 = createAccumulator();
+
+  // acc1 has values 0-9999, acc2 has values 10000-19999
+  updateAccumulator(acc1, Array.from({ length: 10000 }, (_, i) => i));
+  updateAccumulator(acc2, Array.from({ length: 10000 }, (_, i) => i + 10000));
+
+  // Merge multiple times - samples should differ due to random subsampling
+  let allIdentical = true;
+  const firstMerge = mergeAccumulators(acc1, acc2);
+
+  // Try 10 more merges - at least one should differ
+  for (let i = 0; i < 10; i++) {
+    // Create fresh accumulators with same data
+    const a = createAccumulator();
+    const b = createAccumulator();
+    updateAccumulator(a, Array.from({ length: 10000 }, (_, i) => i));
+    updateAccumulator(b, Array.from({ length: 10000 }, (_, i) => i + 10000));
+
+    const merged = mergeAccumulators(a, b);
+
+    const samplesEqual = JSON.stringify(merged.sample.sort()) ===
+      JSON.stringify(firstMerge.sample.sort());
+
+    if (!samplesEqual) {
+      allIdentical = false;
+      break;
+    }
+  }
+
+  assertEquals(
+    allIdentical,
+    false,
+    "at least one sample should differ due to randomness",
+  );
+});
+
+// ============================================================================
+// Tests for reservoir size limits
+// ============================================================================
+
+Deno.test("mergeAccumulators: respects QUANTILE_SAMPLE_SIZE limit", () => {
+  const a = createAccumulator();
+  const b = createAccumulator();
+
+  // Each accumulator has large sample (will be at QUANTILE_SAMPLE_SIZE=10000)
+  updateAccumulator(a, Array.from({ length: 20000 }, (_, i) => i));
+  updateAccumulator(b, Array.from({ length: 20000 }, (_, i) => i + 20000));
+
+  const merged = mergeAccumulators(a, b);
+
+  // Merged sample should not exceed 10000
+  assertEquals(
+    merged.sample.length <= 10000,
+    true,
+    `sample.length=${merged.sample.length}`,
+  );
+  // Should be exactly 10000 (sum of proportional targets)
+  assertEquals(merged.sample.length, 10000);
+});
+
+Deno.test("mergeAccumulators: small accumulators preserve all samples", () => {
+  const a = createAccumulator();
+  const b = createAccumulator();
+
+  updateAccumulator(a, [1, 2, 3]);
+  updateAccumulator(b, [4, 5, 6]);
+
+  const merged = mergeAccumulators(a, b);
+
+  // With only 6 total samples, all should be preserved
+  assertEquals(merged.sample.length, 6);
+  assertEquals(merged.count, 6);
+
+  // Verify all values present
+  const sortedSample = merged.sample.sort((x, y) => x - y);
+  assertEquals(sortedSample, [1, 2, 3, 4, 5, 6]);
+});
+
+// ============================================================================
+// Tests for edge cases
+// ============================================================================
+
+Deno.test("mergeAccumulators: one accumulator has full reservoir", () => {
+  const full = createAccumulator();
+  const small = createAccumulator();
+
+  // Fill one accumulator to reservoir limit
+  updateAccumulator(full, Array.from({ length: 15000 }, () => 100));
+  // Other has few samples
+  updateAccumulator(small, Array(100).fill(200));
+
+  const merged = mergeAccumulators(full, small);
+
+  assertEquals(merged.count, 15100);
+  assertEquals(merged.sample.length, 10000);
+
+  // The large accumulator should dominate (~99% of samples)
+  const countFull = merged.sample.filter((x) => x === 100).length;
+  const countSmall = merged.sample.filter((x) => x === 200).length;
+
+  const ratio = countFull / (countFull + countSmall);
+  assertEquals(
+    ratio > 0.98,
+    true,
+    `ratio=${ratio}, should be ~0.993`,
+  );
+});
+
+Deno.test("mergeAccumulators: handles NaN gracefully", () => {
+  const a = createAccumulator();
+  const b = createAccumulator();
+
+  // Accumulators with valid data (NaN should have been filtered in updateAccumulator)
+  updateAccumulator(a, [1, 2, 3]);
+  updateAccumulator(b, [4, 5, 6]);
+
+  const merged = mergeAccumulators(a, b);
+
+  // Verify no NaN in results
+  const hasNaN = merged.sample.some((x) => Number.isNaN(x));
+  assertEquals(hasNaN, false);
+  assertEquals(Number.isNaN(merged.min), false);
+  assertEquals(Number.isNaN(merged.max), false);
+});
+
+Deno.test("mergeAccumulators: commutative property", () => {
+  const a1 = createAccumulator();
+  const b1 = createAccumulator();
+  const a2 = createAccumulator();
+  const b2 = createAccumulator();
+
+  const data_a = Array.from({ length: 100 }, (_, i) => i);
+  const data_b = Array.from({ length: 200 }, (_, i) => i + 100);
+
+  updateAccumulator(a1, data_a);
+  updateAccumulator(b1, data_b);
+  updateAccumulator(a2, data_a);
+  updateAccumulator(b2, data_b);
+
+  const merged1 = mergeAccumulators(a1, b1);
+  const merged2 = mergeAccumulators(b2, a2); // Swapped order
+
+  // Basic properties should be identical
+  assertEquals(merged1.count, merged2.count);
+  assertEquals(merged1.min, merged2.min);
+  assertEquals(merged1.max, merged2.max);
+  assertEquals(merged1.sample.length, merged2.sample.length);
+
+  // Samples may differ due to randomness, but statistics should be similar
+  const stats1 = finalizeStatistics(merged1, [0.02, 0.98]);
+  const stats2 = finalizeStatistics(merged2, [0.02, 0.98]);
+
+  // Allow small differences due to sampling
+  assertEquals(
+    Math.abs(stats1.qLow - stats2.qLow) < 20,
+    true,
+    `qLow diff=${Math.abs(stats1.qLow - stats2.qLow)}`,
+  );
+  assertEquals(
+    Math.abs(stats1.qHigh - stats2.qHigh) < 20,
+    true,
+    `qHigh diff=${Math.abs(stats1.qHigh - stats2.qHigh)}`,
+  );
+});
+
+// ============================================================================
+// Real-world scenario tests
+// ============================================================================
+
+Deno.test("mergeAccumulators: typical OME-Zarr chunk scenario", () => {
+  // Simulate real-world OME-Zarr chunking scenario:
+  // - Most chunks are full size (256x256 = 65536 voxels)
+  // - Edge chunks are smaller (e.g., 128x256 = 32768 voxels)
+
+  const fullChunks = [];
+  const edgeChunks = [];
+
+  // Create 8 full chunks
+  for (let i = 0; i < 8; i++) {
+    const acc = createAccumulator();
+    // Full chunk with values around 100
+    updateAccumulator(acc, Array(65536).fill(100 + i * 10));
+    fullChunks.push(acc);
+  }
+
+  // Create 2 edge chunks
+  for (let i = 0; i < 2; i++) {
+    const acc = createAccumulator();
+    // Edge chunk with values around 200
+    updateAccumulator(acc, Array(32768).fill(200 + i * 10));
+    edgeChunks.push(acc);
+  }
+
+  // Merge all chunks
+  let merged = fullChunks[0];
+  for (let i = 1; i < fullChunks.length; i++) {
+    merged = mergeAccumulators(merged, fullChunks[i]);
+  }
+  for (const edge of edgeChunks) {
+    merged = mergeAccumulators(merged, edge);
+  }
+
+  // Total voxels: 8*65536 + 2*32768 = 524288 + 65536 = 589824
+  assertEquals(merged.count, 589824);
+  assertExists(merged.sample);
+  assertEquals(merged.sample.length, 10000);
+
+  // Full chunks should dominate: 524288/589824 ≈ 0.889
+  const countFull = merged.sample.filter((x) => x >= 100 && x < 200).length;
+  const countEdge = merged.sample.filter((x) => x >= 200).length;
+
+  const ratio = countFull / (countFull + countEdge);
+  assertEquals(
+    ratio > 0.85 && ratio < 0.92,
+    true,
+    `ratio=${ratio}, expected ~0.889`,
+  );
+});

--- a/ts/test/omero_codec_worker_test.ts
+++ b/ts/test/omero_codec_worker_test.ts
@@ -1,0 +1,419 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * Tests for omero_codec_worker utilities, specifically copySubRegion.
+ */
+
+import { assertEquals } from "@std/assert";
+
+/**
+ * Copy a sub-region from a padded C-order buffer into a compact destination.
+ *
+ * For each dimension, copies only the first `subShape[d]` elements along
+ * that axis from the source (which has strides `srcStrides`).
+ */
+function copySubRegion(
+  src: { readonly [i: number]: unknown; readonly length: number },
+  srcStrides: number[],
+  dst: { [i: number]: unknown; length: number },
+  subShape: number[],
+  srcOffset = 0,
+  dstOffset = 0,
+  dim = 0,
+): void {
+  if (dim === subShape.length - 1) {
+    // Innermost dimension — copy contiguous run
+    for (let i = 0; i < subShape[dim]; i++) {
+      dst[dstOffset + i] = src[srcOffset + i];
+    }
+    return;
+  }
+  const dstStride = subShape.slice(dim + 1).reduce((a, b) => a * b, 1);
+  for (let i = 0; i < subShape[dim]; i++) {
+    copySubRegion(
+      src,
+      srcStrides,
+      dst,
+      subShape,
+      srcOffset + i * srcStrides[dim],
+      dstOffset + i * dstStride,
+      dim + 1,
+    );
+  }
+}
+
+/**
+ * Compute C-order strides from shape.
+ */
+function getStrides(shape: number[]): number[] {
+  const strides: number[] = new Array(shape.length);
+  let stride = 1;
+  for (let i = shape.length - 1; i >= 0; i--) {
+    strides[i] = stride;
+    stride *= shape[i];
+  }
+  return strides;
+}
+
+// ============================================================================
+// Tests for 1D arrays
+// ============================================================================
+
+Deno.test("copySubRegion: 1D array - full copy", () => {
+  const src = [1, 2, 3, 4, 5];
+  const dst = new Array(5).fill(0);
+  const srcStrides = getStrides([5]);
+  const subShape = [5];
+
+  copySubRegion(src, srcStrides, dst, subShape);
+
+  assertEquals(dst, [1, 2, 3, 4, 5]);
+});
+
+Deno.test("copySubRegion: 1D array - partial copy", () => {
+  const src = [1, 2, 3, 4, 5];
+  const dst = new Array(3).fill(0);
+  const srcStrides = getStrides([5]);
+  const subShape = [3];
+
+  copySubRegion(src, srcStrides, dst, subShape);
+
+  assertEquals(dst, [1, 2, 3]);
+});
+
+Deno.test("copySubRegion: 1D array - single element", () => {
+  const src = [1, 2, 3];
+  const dst = new Array(1).fill(0);
+  const srcStrides = getStrides([3]);
+  const subShape = [1];
+
+  copySubRegion(src, srcStrides, dst, subShape);
+
+  assertEquals(dst, [1]);
+});
+
+// ============================================================================
+// Tests for 2D arrays
+// ============================================================================
+
+Deno.test("copySubRegion: 2D array - full copy", () => {
+  // 3x4 array in C-order
+  const src = [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+  ];
+  const dst = new Array(12).fill(0);
+  const srcStrides = getStrides([3, 4]);
+  const subShape = [3, 4];
+
+  copySubRegion(src, srcStrides, dst, subShape);
+
+  assertEquals(dst, src);
+});
+
+Deno.test("copySubRegion: 2D array - extract sub-region", () => {
+  // 3x4 padded array, extract 2x3 region
+  const src = [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+  ];
+  const dst = new Array(6).fill(0);
+  const srcStrides = getStrides([3, 4]);
+  const subShape = [2, 3];
+
+  copySubRegion(src, srcStrides, dst, subShape);
+
+  assertEquals(dst, [1, 2, 3, 5, 6, 7]);
+});
+
+Deno.test("copySubRegion: 2D array - extract single row", () => {
+  const src = [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+  ];
+  const dst = new Array(3).fill(0);
+  const srcStrides = getStrides([3, 3]);
+  const subShape = [1, 3];
+
+  copySubRegion(src, srcStrides, dst, subShape);
+
+  assertEquals(dst, [1, 2, 3]);
+});
+
+Deno.test("copySubRegion: 2D array - extract single column", () => {
+  const src = [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+  ];
+  const dst = new Array(3).fill(0);
+  const srcStrides = getStrides([3, 3]);
+  const subShape = [3, 1];
+
+  copySubRegion(src, srcStrides, dst, subShape);
+
+  assertEquals(dst, [1, 4, 7]);
+});
+
+Deno.test("copySubRegion: 2D array - extract single element", () => {
+  const src = [1, 2, 3, 4];
+  const dst = new Array(1).fill(0);
+  const srcStrides = getStrides([2, 2]);
+  const subShape = [1, 1];
+
+  copySubRegion(src, srcStrides, dst, subShape);
+
+  assertEquals(dst, [1]);
+});
+
+// ============================================================================
+// Tests for 3D arrays
+// ============================================================================
+
+Deno.test("copySubRegion: 3D array - full copy", () => {
+  // 2x3x4 array
+  const src = Array.from({ length: 24 }, (_, i) => i);
+  const dst = new Array(24).fill(-1);
+  const srcStrides = getStrides([2, 3, 4]);
+  const subShape = [2, 3, 4];
+
+  copySubRegion(src, srcStrides, dst, subShape);
+
+  assertEquals(dst, src);
+});
+
+Deno.test("copySubRegion: 3D array - extract sub-region", () => {
+  // 2x3x4 padded array, extract 2x2x3 region
+  // Shape: [z, y, x] = [2, 3, 4]
+  const src = [
+    // z=0
+    0,
+    1,
+    2,
+    3, // y=0
+    4,
+    5,
+    6,
+    7, // y=1
+    8,
+    9,
+    10,
+    11, // y=2
+    // z=1
+    12,
+    13,
+    14,
+    15, // y=0
+    16,
+    17,
+    18,
+    19, // y=1
+    20,
+    21,
+    22,
+    23, // y=2
+  ];
+  const dst = new Array(12).fill(-1);
+  const srcStrides = getStrides([2, 3, 4]);
+  const subShape = [2, 2, 3]; // Extract first 2x2x3
+
+  copySubRegion(src, srcStrides, dst, subShape);
+
+  // Expected: z=0: [0,1,2], [4,5,6]  z=1: [12,13,14], [16,17,18]
+  assertEquals(dst, [0, 1, 2, 4, 5, 6, 12, 13, 14, 16, 17, 18]);
+});
+
+Deno.test("copySubRegion: 3D array - extract single plane", () => {
+  // 3x2x2 array, extract first plane (1x2x2)
+  const src = [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+  ];
+  const dst = new Array(4).fill(-1);
+  const srcStrides = getStrides([3, 2, 2]);
+  const subShape = [1, 2, 2];
+
+  copySubRegion(src, srcStrides, dst, subShape);
+
+  assertEquals(dst, [1, 2, 3, 4]);
+});
+
+// ============================================================================
+// Tests for edge chunk scenarios
+// ============================================================================
+
+Deno.test("copySubRegion: padded edge chunk - 2D example", () => {
+  // Simulate a padded edge chunk: chunk_shape=[3,3], actual_shape=[2,2]
+  // The padded region is filled with zeros
+  const src = [
+    1,
+    2,
+    0, // y=0: valid data, then padding
+    3,
+    4,
+    0, // y=1: valid data, then padding
+    0,
+    0,
+    0, // y=2: all padding
+  ];
+  const dst = new Array(4).fill(-1);
+  const srcStrides = getStrides([3, 3]);
+  const subShape = [2, 2]; // Extract only valid region
+
+  copySubRegion(src, srcStrides, dst, subShape);
+
+  assertEquals(dst, [1, 2, 3, 4]);
+});
+
+Deno.test("copySubRegion: padded edge chunk - 3D example", () => {
+  // chunk_shape=[2,2,2], actual_shape=[1,2,1]
+  const src = [
+    10,
+    0, // z=0, y=0: one valid, one pad
+    20,
+    0, // z=0, y=1: one valid, one pad
+    0,
+    0, // z=1, y=0: all padding
+    0,
+    0, // z=1, y=1: all padding
+  ];
+  const dst = new Array(2).fill(-1);
+  const srcStrides = getStrides([2, 2, 2]);
+  const subShape = [1, 2, 1]; // Extract only valid region
+
+  copySubRegion(src, srcStrides, dst, subShape);
+
+  assertEquals(dst, [10, 20]);
+});
+
+// ============================================================================
+// Tests with typed arrays
+// ============================================================================
+
+Deno.test("copySubRegion: Float32Array", () => {
+  const src = new Float32Array([1.5, 2.5, 3.5, 4.5]);
+  const dst = new Float32Array(2);
+  const srcStrides = getStrides([2, 2]);
+  const subShape = [1, 2];
+
+  copySubRegion(src, srcStrides, dst, subShape);
+
+  assertEquals(Array.from(dst), [1.5, 2.5]);
+});
+
+Deno.test("copySubRegion: Uint8Array", () => {
+  const src = new Uint8Array([255, 128, 64, 32, 16, 8, 4, 2]);
+  const dst = new Uint8Array(4);
+  const srcStrides = getStrides([2, 2, 2]);
+  const subShape = [1, 2, 2];
+
+  copySubRegion(src, srcStrides, dst, subShape);
+
+  assertEquals(Array.from(dst), [255, 128, 64, 32]);
+});
+
+// ============================================================================
+// Tests for different dimension orderings
+// ============================================================================
+
+Deno.test("copySubRegion: 4D array (c, z, y, x)", () => {
+  // Shape: [c=2, z=2, y=2, x=2] = 16 elements
+  const src = Array.from({ length: 16 }, (_, i) => i);
+  const dst = new Array(4).fill(-1);
+  const srcStrides = getStrides([2, 2, 2, 2]);
+  const subShape = [1, 1, 2, 2]; // Extract c=0, z=0, all y,x
+
+  copySubRegion(src, srcStrides, dst, subShape);
+
+  // c=0, z=0: indices 0,1,2,3
+  assertEquals(dst, [0, 1, 2, 3]);
+});
+
+Deno.test("copySubRegion: 5D array", () => {
+  // Shape: [t=2, c=2, z=2, y=2, x=2] = 32 elements
+  const src = Array.from({ length: 32 }, (_, i) => i);
+  const dst = new Array(8).fill(-1);
+  const srcStrides = getStrides([2, 2, 2, 2, 2]);
+  const subShape = [1, 1, 2, 2, 2]; // Extract t=0, c=0, all z,y,x
+
+  copySubRegion(src, srcStrides, dst, subShape);
+
+  // t=0, c=0: indices 0-7
+  assertEquals(dst, [0, 1, 2, 3, 4, 5, 6, 7]);
+});
+
+// ============================================================================
+// Tests with offset parameters
+// ============================================================================
+
+Deno.test("copySubRegion: with srcOffset", () => {
+  // 2x3 array: [[1,2,3], [4,5,6]]
+  const src = [1, 2, 3, 4, 5, 6];
+  const dst = new Array(4).fill(-1);
+  const srcStrides = getStrides([2, 3]); // srcStrides = [3, 1] for shape [2,3]
+  const subShape = [2, 2];
+
+  // Start copy from index 1 (offset by 1 in source)
+  // With srcStrides=[3,1], subShape=[2,2], srcOffset=1:
+  // First row (i=0): srcOffset=1, copies src[1], src[2] -> 2, 3
+  // Second row (i=1): srcOffset=1+3=4, copies src[4], src[5] -> 5, 6
+  copySubRegion(src, srcStrides, dst, subShape, 1, 0, 0);
+
+  assertEquals(dst, [2, 3, 5, 6]);
+});
+
+Deno.test("copySubRegion: with dstOffset", () => {
+  const src = [1, 2, 3, 4];
+  const dst = new Array(6).fill(0);
+  const srcStrides = getStrides([2, 2]);
+  const subShape = [1, 2];
+
+  // Write to destination starting at offset 2
+  copySubRegion(src, srcStrides, dst, subShape, 0, 2, 0);
+
+  assertEquals(dst, [0, 0, 1, 2, 0, 0]);
+});


### PR DESCRIPTION
Two fixes for chunk-size-dependent OMERO statistics errors:

1. omero_codec_worker: Add copySubRegion to fixEdgeChunkShapeStride so that
   padded edge chunks (written by setWorker with fill-value zeros beyond the
   valid region) have the valid sub-region extracted before statistics are
   computed.

2. mergeAccumulators: Fix biased reservoir sampling when merging accumulators
   from chunks of different sizes. Previously, each chunk contributed an equal
   number of samples (10,000) regardless of its actual voxel count, causing
   small edge chunks (with many background zeros) to be overrepresented.
   Now samples from each chunk proportionally to its population count using
   Fisher-Yates partial shuffle, producing unbiased quantile estimates.
