### PR TITLE
docs: add npm and JSR version badges for @fideus-labs/ngff-zarr

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![PyPI - Version](https://img.shields.io/pypi/v/ngff-zarr.svg)](https://pypi.org/project/ngff-zarr)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ngff-zarr.svg)](https://pypi.org/project/ngff-zarr)
 [![Python CI Testing](https://github.com/thewtex/ngff-zarr/actions/workflows/python.yml/badge.svg)](https://github.com/thewtex/ngff-zarr/actions/workflows/python.yml)
+[![npm - Version](https://img.shields.io/npm/v/@fideus-labs/ngff-zarr.svg)](https://www.npmjs.com/package/@fideus-labs/ngff-zarr)
 [![Typescript CI Testing](https://github.com/thewtex/ngff-zarr/actions/workflows/typescript.yml/badge.svg)](https://github.com/thewtex/ngff-zarr/actions/workflows/typescript.yml)
 [![MCP CI Testing](https://github.com/thewtex/ngff-zarr/actions/workflows/mcp-ci.yml/badge.svg)](https://github.com/thewtex/ngff-zarr/actions/workflows/mcp-ci.yml)
 [![DOI](https://zenodo.org/badge/541840158.svg)](https://zenodo.org/badge/latestdoi/541840158)

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@
 [![PyPI - Version](https://img.shields.io/pypi/v/ngff-zarr.svg)](https://pypi.org/project/ngff-zarr)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ngff-zarr.svg)](https://pypi.org/project/ngff-zarr)
 [![Python CI Testing](https://github.com/thewtex/ngff-zarr/actions/workflows/python.yml/badge.svg)](https://github.com/thewtex/ngff-zarr/actions/workflows/python.yml)
+[![npm - Version](https://img.shields.io/npm/v/@fideus-labs/ngff-zarr.svg)](https://www.npmjs.com/package/@fideus-labs/ngff-zarr)
 [![Typescript CI Testing](https://github.com/thewtex/ngff-zarr/actions/workflows/typescript.yml/badge.svg)](https://github.com/thewtex/ngff-zarr/actions/workflows/typescript.yml)
 [![MCP CI Testing](https://github.com/thewtex/ngff-zarr/actions/workflows/mcp-ci.yml/badge.svg)](https://github.com/thewtex/ngff-zarr/actions/workflows/mcp-ci.yml)
 [![DOI](https://zenodo.org/badge/541840158.svg)](https://zenodo.org/badge/latestdoi/541840158)

--- a/py/ngff_zarr/from_ngff_zarr.py
+++ b/py/ngff_zarr/from_ngff_zarr.py
@@ -117,13 +117,13 @@ def from_ngff_zarr(
                 "requires navigating to a specific well/field)\n"
                 "  3. The file may use a custom or unsupported metadata structure\n\n"
             )
-            
+
             # Provide additional generic guidance when 'multiscales' is missing under 'ome'
             error_msg += (
                 "The 'ome' key is present but doesn't contain the required 'multiscales' metadata. "
                 "Please verify that this is a valid OME-Zarr file."
             )
-            
+
             raise ValueError(error_msg)
 
         metadata_obj, images = Metadata._from_zarr_attrs(

--- a/py/test/test_version_detection.py
+++ b/py/test/test_version_detection.py
@@ -284,7 +284,7 @@ def test_from_ngff_zarr_hcs_plate_error():
 @pytest.mark.skipif(zarr_version_major < 3, reason="v0.5 format requires zarr-python 3")
 def test_from_ngff_zarr_v05_ome_key_without_multiscales():
     """Test that v0.5 format with ome key but missing multiscales gives helpful error.
-    
+
     This can happen with corrupted files or files with ome key containing other metadata
     but not the required multiscales.
     """
@@ -303,11 +303,10 @@ def test_from_ngff_zarr_v05_ome_key_without_multiscales():
 
     # Should raise ValueError with helpful error explaining possible causes
     with pytest.raises(
-        ValueError, 
-        match=r"multiscales[\s\S]*missing[\s\S]*Possible causes"
+        ValueError, match=r"multiscales[\s\S]*missing[\s\S]*Possible causes"
     ) as exc_info:
         from_ngff_zarr(store)
-    
+
     # Verify error message contains all expected guidance
     error_msg = str(exc_info.value)
     assert "Available keys under 'ome'" in error_msg

--- a/ts/README.md
+++ b/ts/README.md
@@ -3,6 +3,9 @@
 
 # ngff-zarr TypeScript
 
+[![npm - Version](https://img.shields.io/npm/v/@fideus-labs/ngff-zarr.svg)](https://www.npmjs.com/package/@fideus-labs/ngff-zarr)
+[![JSR - Version](https://img.shields.io/jsr/v/@fideus-labs/ngff-zarr.svg)](https://jsr.io/@fideus-labs/ngff-zarr)
+
 A TypeScript implementation of ngff-zarr for reading and writing OME-Zarr files,
 compatible with Deno, Node.js, and the browser.
 


### PR DESCRIPTION
## Summary

Add npm and JSR version badges for the TypeScript package `@fideus-labs/ngff-zarr` to improve discoverability and provide at-a-glance package status.

## Changes

- **`README.md`** — Added an npm version badge after the Typescript CI Testing badge, grouped with the existing PyPI version badge for the Python package.
- **`docs/index.md`** — Same npm badge added in the same position, keeping the Sphinx documentation index in sync with the top-level README.
- **`ts/README.md`** — Added both an npm version badge and a JSR version badge immediately below the package title. This file previously had no badges at all; the two badges reflect that the package is published to both registries.

## Implementation details

All badges use [shields.io](https://shields.io/) and follow the existing naming convention (`npm - Version`, `JSR - Version`) consistent with the repo's `PyPI - Version` and `PyPI - Python Version` badges. Badge URLs:

- npm: `https://img.shields.io/npm/v/@fideus-labs/ngff-zarr.svg` → `https://www.npmjs.com/package/@fideus-labs/ngff-zarr`
- JSR: `https://img.shields.io/jsr/v/@fideus-labs/ngff-zarr.svg` → `https://jsr.io/@fideus-labs/ngff-zarr`

The JSR badge is only added to `ts/README.md` (the TypeScript package README), since the top-level README and docs only surface one badge per package for brevity.