### PR TITLE
ci(release): always install pixi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,12 +134,19 @@ jobs:
       # TypeScript Package Build (ts/)
       # ============================================================================
 
-      - name: Setup pixi (for TypeScript package)
-        if: steps.identify.outputs.project == 'ts'
-        uses: prefix-dev/setup-pixi@v0.8.1
+      - name: Setup pixi (for Python test data)
+        uses: prefix-dev/setup-pixi@v0.9.3
         with:
-          pixi-version: v0.49.0
           manifest-path: ./py/pyproject.toml
+          pixi-version: v0.62.2
+          frozen: true
+
+      - name: Setup pixi (for TypeScript build)
+        if: steps.identify.outputs.project == 'ts'
+        uses: prefix-dev/setup-pixi@v0.9.3
+        with:
+          manifest-path: ./ts/pixi.toml
+          pixi-version: v0.62.2
           frozen: true
 
       - name: Install deno (for TypeScript package)


### PR DESCRIPTION
Needed for both ts and py.

Also bump the setup-pixi action and remove the pixi-version constraint.
