### PR TITLE
ci(py,mcp,ts): add environment for trusted publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-24.04
+    environment:
+      name: publish
+      url: https://pypi.org/p/ngff-zarr
     permissions:
       contents: write  # Required to create releases
       id-token: write  # Required for PyPI trusted publishing (OIDC)


### PR DESCRIPTION
Add environment configuration for trusted publishing release job.