### PR TITLE
feat(py): add support for bioformats2raw container layout

### DIFF
--- a/py/ngff_zarr/from_ngff_zarr.py
+++ b/py/ngff_zarr/from_ngff_zarr.py
@@ -36,6 +36,11 @@ def from_ngff_zarr(
         for well A1, field 0). To load the entire plate structure, use
         from_hcs_zarr() instead.
 
+        For bioformats2raw containers with a single image, the function
+        will automatically navigate into the image subgroup. For containers
+        with multiple images, provide the path to a specific image
+        (e.g., 'container.ome.zarr/0').
+
     validate : bool
         If True, validate the NGFF metadata against the schema.
 
@@ -57,6 +62,8 @@ def from_ngff_zarr(
     from .parse_metadata import (
         _detect_version,
         _extract_method_metadata,
+        _get_bioformats2raw_series,
+        _is_bioformats2raw,
         _is_hcs_plate,
         _parse_hcs_path,
     )
@@ -150,9 +157,33 @@ def from_ngff_zarr(
                 "For programmatic access to the full plate, use from_hcs_zarr() instead of from_ngff_zarr()."
             ) from None
 
-    # Navigate to sub-path if provided (for HCS well/image access)
-    # We get metadata from the subpath but pass the subpath to _from_zarr_attrs
-    # so it can correctly construct data paths
+    # Check if this is a bioformats2raw container layout
+    if _is_bioformats2raw(root_attrs_initial) and not subpath:
+        image_paths = _get_bioformats2raw_series(root)
+
+        if not image_paths:
+            raise ValueError(
+                "The input is a bioformats2raw container but no image subgroups were found. "
+                "The container may be empty or malformed."
+            )
+        if len(image_paths) == 1:
+            # Single image: navigate into it silently
+            subpath = image_paths[0]
+        else:
+            # Multiple images: require user to specify which one
+            display_store = str(original_store).replace("\\", "/")
+            examples = [f"'{display_store}/{p}'" for p in image_paths[:5]]
+            examples_str = ", ".join(examples)
+            more = f" (and {len(image_paths) - 5} more)" if len(image_paths) > 5 else ""
+            raise ValueError(
+                f"The input is a bioformats2raw container with {len(image_paths)} images. "
+                f"To load a specific image, provide the full path including the image index:\n"
+                f"  Available images: {examples_str}{more}\n"
+                f"For example: ngff-zarr -i {display_store}/{image_paths[0]}"
+            )
+
+    # Navigate to sub-path if provided (for HCS well/image access,
+    # or bioformats2raw image navigation)
     if subpath:
         try:
             root = root[subpath]

--- a/py/ngff_zarr/parse_metadata.py
+++ b/py/ngff_zarr/parse_metadata.py
@@ -168,6 +168,89 @@ def _is_hcs_plate(root_attrs: dict) -> bool:
     return False
 
 
+def _is_bioformats2raw(root_attrs: dict) -> bool:
+    """Check if root attributes indicate a bioformats2raw container layout.
+
+    bioformats2raw produces OME-Zarr containers where the root level has a
+    ``bioformats2raw.layout`` key (v0.4) or an ``ome`` key containing
+    ``bioformats2raw.layout`` (v0.5), with the actual image data stored in
+    numbered subdirectories (0/, 1/, ...).
+
+    Returns True if the root is a bioformats2raw container (not a regular
+    image group).
+    """
+    # v0.4: bioformats2raw.layout at root level
+    if "bioformats2raw.layout" in root_attrs:
+        return True
+
+    # v0.5: bioformats2raw.layout under ome key, but without multiscales
+    # (if multiscales is present under ome, it's a regular v0.5 image)
+    if (
+        "ome" in root_attrs
+        and isinstance(root_attrs["ome"], dict)
+        and "bioformats2raw.layout" in root_attrs["ome"]
+        and "multiscales" not in root_attrs["ome"]
+    ):
+        return True
+
+    return False
+
+
+def _get_bioformats2raw_series(root) -> list:
+    """Get the list of image paths from a bioformats2raw container.
+
+    Reads the ``series`` array from the ``OME`` subgroup if available,
+    otherwise falls back to enumerating subgroups in the root.
+
+    Parameters
+    ----------
+    root : zarr.Group
+        The root zarr group of the bioformats2raw container.
+
+    Returns
+    -------
+    list of str
+        Sorted list of image path strings (e.g., ``["0", "1", "2"]``).
+    """
+    import zarr
+
+    # Try reading the OME subgroup's series metadata
+    try:
+        ome_group = root["OME"]
+        ome_attrs = ome_group.attrs.asdict()
+        # v0.5: series under "ome" key
+        if "ome" in ome_attrs and isinstance(ome_attrs["ome"], dict):
+            series = ome_attrs["ome"].get("series")
+            if isinstance(series, list) and series:
+                return list(series)
+        # v0.4: series at root of OME group
+        series = ome_attrs.get("series")
+        if isinstance(series, list) and series:
+            return list(series)
+    except (KeyError, AttributeError):
+        pass
+
+    # Fallback: enumerate subgroups that are not the OME metadata group
+    image_paths = []
+    for key in root.keys():
+        if key == "OME":
+            continue
+        try:
+            child = root[key]
+            if isinstance(child, zarr.Group):
+                image_paths.append(key)
+        except (KeyError, TypeError):
+            continue
+
+    # Sort numerically if all paths are numeric, otherwise alphabetically
+    try:
+        image_paths.sort(key=int)
+    except ValueError:
+        image_paths.sort()
+
+    return image_paths
+
+
 def _detect_version(root_attrs: dict) -> NgffVersion:
     """Detect NGFF version from root attributes.
 

--- a/py/pixi.lock
+++ b/py/pixi.lock
@@ -7742,8 +7742,8 @@ packages:
   timestamp: 1738196177597
 - pypi: ./
   name: ngff-zarr
-  version: 0.29.0
-  sha256: eaefc08b05057164a8dc94477ea8bf6e3d713f070a71ab46c2b676bcf7e05795
+  version: 0.30.0
+  sha256: 2917c65d981798ffb2463238a6337bcee9a7073a26f9bddd85e21ce42ea246b5
   requires_dist:
   - dask[array]!=2025.12.0,!=2026.1.0,!=2026.1.1
   - importlib-resources

--- a/py/test/test_version_detection.py
+++ b/py/test/test_version_detection.py
@@ -8,7 +8,11 @@ import pytest
 import zarr
 from ngff_zarr import from_ngff_zarr, to_multiscales, to_ngff_image, to_ngff_zarr
 from ngff_zarr._supported_versions import NgffVersion
-from ngff_zarr.parse_metadata import _detect_version
+from ngff_zarr.parse_metadata import (
+    _detect_version,
+    _get_bioformats2raw_series,
+    _is_bioformats2raw,
+)
 from zarr.storage import MemoryStore
 
 zarr_version = packaging.version.parse(zarr.__version__)
@@ -364,3 +368,333 @@ def test_from_ngff_zarr_v05_ome_key_without_multiscales():
     error_msg = str(exc_info.value)
     assert "Available keys under 'ome'" in error_msg
     assert "corrupted" in error_msg.lower() or "incomplete" in error_msg.lower()
+
+
+# ---- bioformats2raw tests ----
+
+
+def _create_bf2raw_v04_image_subgroup(parent, name, data):
+    """Create a v0.4-style image subgroup inside a bioformats2raw container.
+
+    Sets up a numbered subgroup (e.g., "0") with standard multiscales metadata
+    and array data, mimicking what bioformats2raw produces.
+
+    Parameters
+    ----------
+    parent :
+        Parent Zarr group or container under which the image subgroup will be
+        created.
+    name : str
+        Name of the image subgroup to create (for example, ``"0"``).
+    data : numpy.ndarray
+        Array data to store in the subgroup at path ``"0"``.
+
+    Returns
+    -------
+    image_group
+        The created image subgroup containing the array data and multiscales
+        metadata.
+    """
+    if zarr_version_major >= 3:
+        image_group = parent.create_group(name)
+        image_group.create_array("0", data=data, chunks=(32, 32))
+    else:
+        image_group = parent.create_group(name)
+        image_group.create_dataset("0", data=data, chunks=(32, 32))
+
+    image_group.attrs["multiscales"] = [
+        {
+            "version": "0.4",
+            "axes": [
+                {"name": "y", "type": "space"},
+                {"name": "x", "type": "space"},
+            ],
+            "datasets": [{"path": "0"}],
+        }
+    ]
+    return image_group
+
+
+def test_is_bioformats2raw_v04():
+    """Test detection of v0.4 bioformats2raw container layout."""
+    root_attrs = {"bioformats2raw.layout": 3}
+    assert _is_bioformats2raw(root_attrs) is True
+
+
+def test_is_bioformats2raw_v05():
+    """Test detection of v0.5 bioformats2raw container layout."""
+    root_attrs = {
+        "ome": {
+            "bioformats2raw.layout": 3,
+            "version": "0.5",
+        }
+    }
+    assert _is_bioformats2raw(root_attrs) is True
+
+
+def test_is_bioformats2raw_false_for_regular_v04():
+    """Test that regular v0.4 image is not detected as bioformats2raw."""
+    root_attrs = {
+        "multiscales": [
+            {
+                "version": "0.4",
+                "axes": [
+                    {"name": "y", "type": "space"},
+                    {"name": "x", "type": "space"},
+                ],
+                "datasets": [{"path": "0"}],
+            }
+        ]
+    }
+    assert _is_bioformats2raw(root_attrs) is False
+
+
+def test_is_bioformats2raw_false_for_regular_v05():
+    """Test that regular v0.5 image is not detected as bioformats2raw."""
+    root_attrs = {
+        "ome": {
+            "version": "0.5",
+            "multiscales": [
+                {
+                    "axes": [
+                        {"name": "y", "type": "space"},
+                        {"name": "x", "type": "space"},
+                    ],
+                    "datasets": [{"path": "0"}],
+                }
+            ],
+        }
+    }
+    assert _is_bioformats2raw(root_attrs) is False
+
+
+def test_is_bioformats2raw_false_for_v05_with_multiscales_and_bf2raw():
+    """Test that v0.5 with both multiscales and bioformats2raw.layout is not bf2raw.
+
+    If multiscales metadata is present under 'ome', the file is a regular
+    v0.5 image even if bioformats2raw.layout is also present.
+    """
+    root_attrs = {
+        "ome": {
+            "version": "0.5",
+            "bioformats2raw.layout": 3,
+            "multiscales": [
+                {
+                    "axes": [
+                        {"name": "y", "type": "space"},
+                        {"name": "x", "type": "space"},
+                    ],
+                    "datasets": [{"path": "0"}],
+                }
+            ],
+        }
+    }
+    assert _is_bioformats2raw(root_attrs) is False
+
+
+def test_from_ngff_zarr_bioformats2raw_single_image():
+    """Test loading a bioformats2raw container with a single image.
+
+    When there is only one image subgroup, from_ngff_zarr should
+    silently navigate into it and read the image data.
+    """
+    store = MemoryStore()
+    if zarr_version_major >= 3:
+        root = zarr.open_group(store, mode="w", zarr_format=2)
+    else:
+        root = zarr.open_group(store, mode="w")
+
+    # Set bioformats2raw root attributes
+    root.attrs["bioformats2raw.layout"] = 3
+
+    # Create a single image subgroup with standard multiscales metadata
+    data = np.random.randint(0, 255, size=(64, 64), dtype=np.uint8)
+    _create_bf2raw_v04_image_subgroup(root, "0", data)
+
+    # Should transparently navigate into subgroup "0" and load
+    loaded = from_ngff_zarr(store)
+    assert loaded is not None
+    assert len(loaded.images) > 0
+    assert loaded.images[0].data.shape == (64, 64)
+
+
+def test_from_ngff_zarr_bioformats2raw_multi_image_error():
+    """Test that a bioformats2raw container with multiple images gives helpful error."""
+    store = MemoryStore()
+    if zarr_version_major >= 3:
+        root = zarr.open_group(store, mode="w", zarr_format=2)
+    else:
+        root = zarr.open_group(store, mode="w")
+
+    root.attrs["bioformats2raw.layout"] = 3
+
+    # Create multiple image subgroups
+    data = np.random.randint(0, 255, size=(64, 64), dtype=np.uint8)
+    _create_bf2raw_v04_image_subgroup(root, "0", data)
+    _create_bf2raw_v04_image_subgroup(root, "1", data)
+    _create_bf2raw_v04_image_subgroup(root, "2", data)
+
+    with pytest.raises(ValueError, match="bioformats2raw container with 3 images"):
+        from_ngff_zarr(store)
+
+
+def test_from_ngff_zarr_bioformats2raw_with_explicit_subpath(tmp_path):
+    """Test loading a specific image from a multi-image bioformats2raw container.
+
+    When the user provides an explicit subpath (e.g., 'container.ome.zarr/1'),
+    it should load that specific image without error.
+    """
+    store_path = tmp_path / "container.ome.zarr"
+    if zarr_version_major >= 3:
+        root = zarr.open_group(str(store_path), mode="w", zarr_format=2)
+    else:
+        root = zarr.open_group(str(store_path), mode="w")
+
+    root.attrs["bioformats2raw.layout"] = 3
+
+    # Create multiple image subgroups with different data
+    data0 = np.random.randint(0, 255, size=(64, 64), dtype=np.uint8)
+    data1 = np.random.randint(0, 255, size=(32, 32), dtype=np.uint8)
+    _create_bf2raw_v04_image_subgroup(root, "0", data0)
+    img1 = _create_bf2raw_v04_image_subgroup(root, "1", data1)
+    # Update metadata for image 1 to reflect its actual shape
+    img1.attrs["multiscales"] = [
+        {
+            "version": "0.4",
+            "axes": [
+                {"name": "y", "type": "space"},
+                {"name": "x", "type": "space"},
+            ],
+            "datasets": [{"path": "0"}],
+        }
+    ]
+
+    # Load with explicit subpath: path/1
+    loaded = from_ngff_zarr(f"{store_path}/1")
+    assert loaded is not None
+    assert len(loaded.images) > 0
+    # Shape must match data1 (32x32), not data0 (64x64), proving correct image was loaded
+    assert loaded.images[0].data.shape == (32, 32)
+    # Value-level check: loaded data must match data1, not data0
+    np.testing.assert_array_equal(loaded.images[0].data.compute(), data1)
+
+
+def test_from_ngff_zarr_bioformats2raw_with_ome_series():
+    """Test that OME subgroup series metadata is used for image enumeration.
+
+    bioformats2raw stores image paths in OME/.zattrs under the 'series' key.
+    This should be preferred over fallback enumeration.
+    """
+    store = MemoryStore()
+    if zarr_version_major >= 3:
+        root = zarr.open_group(store, mode="w", zarr_format=2)
+    else:
+        root = zarr.open_group(store, mode="w")
+
+    root.attrs["bioformats2raw.layout"] = 3
+
+    # Create image subgroups
+    data = np.random.randint(0, 255, size=(64, 64), dtype=np.uint8)
+    _create_bf2raw_v04_image_subgroup(root, "0", data)
+    _create_bf2raw_v04_image_subgroup(root, "1", data)
+
+    # Create OME subgroup with series metadata
+    ome_group = root.create_group("OME")
+    ome_group.attrs["series"] = ["0", "1"]
+
+    # Verify _get_bioformats2raw_series reads from OME/series
+    series = _get_bioformats2raw_series(root)
+    assert series == ["0", "1"]
+
+    # With two images and no subpath, should error
+    with pytest.raises(ValueError, match="bioformats2raw container with 2 images"):
+        from_ngff_zarr(store)
+
+
+def test_from_ngff_zarr_bioformats2raw_with_ome_series_single():
+    """Test single-image bioformats2raw container with OME series metadata.
+
+    When the OME series metadata lists a single image path, from_ngff_zarr
+    should silently navigate into it.
+    """
+    store = MemoryStore()
+    if zarr_version_major >= 3:
+        root = zarr.open_group(store, mode="w", zarr_format=2)
+    else:
+        root = zarr.open_group(store, mode="w")
+
+    root.attrs["bioformats2raw.layout"] = 3
+
+    # Create single image subgroup
+    data = np.random.randint(0, 255, size=(64, 64), dtype=np.uint8)
+    _create_bf2raw_v04_image_subgroup(root, "0", data)
+
+    # Create OME subgroup with series metadata pointing to image "0"
+    ome_group = root.create_group("OME")
+    ome_group.attrs["series"] = ["0"]
+
+    loaded = from_ngff_zarr(store)
+    assert loaded is not None
+    assert len(loaded.images) > 0
+    assert loaded.images[0].data.shape == (64, 64)
+
+
+def test_from_ngff_zarr_bioformats2raw_empty_container():
+    """Test that a bioformats2raw container with no images gives helpful error."""
+    store = MemoryStore()
+    if zarr_version_major >= 3:
+        root = zarr.open_group(store, mode="w", zarr_format=2)
+    else:
+        root = zarr.open_group(store, mode="w")
+
+    root.attrs["bioformats2raw.layout"] = 3
+
+    # Only create OME group (no image subgroups)
+    root.create_group("OME")
+
+    with pytest.raises(ValueError, match="no image subgroups were found"):
+        from_ngff_zarr(store)
+
+
+def test_get_bioformats2raw_series_fallback_enumeration():
+    """Test that _get_bioformats2raw_series falls back to subgroup enumeration.
+
+    When no OME subgroup or series metadata exists, the function should
+    enumerate all non-OME subgroups and sort them.
+    """
+    store = MemoryStore()
+    if zarr_version_major >= 3:
+        root = zarr.open_group(store, mode="w", zarr_format=2)
+    else:
+        root = zarr.open_group(store, mode="w")
+
+    root.attrs["bioformats2raw.layout"] = 3
+
+    # Create numbered subgroups (out of order to test sorting)
+    data = np.random.randint(0, 255, size=(64, 64), dtype=np.uint8)
+    _create_bf2raw_v04_image_subgroup(root, "2", data)
+    _create_bf2raw_v04_image_subgroup(root, "0", data)
+    _create_bf2raw_v04_image_subgroup(root, "1", data)
+
+    series = _get_bioformats2raw_series(root)
+    # Should be sorted numerically
+    assert series == ["0", "1", "2"]
+
+
+def test_get_bioformats2raw_series_ome_v05_format():
+    """Test reading series from OME subgroup in v0.5 format.
+
+    In v0.5 format, the series is nested under the 'ome' key in OME/.zattrs.
+    """
+    store = MemoryStore()
+    if zarr_version_major >= 3:
+        root = zarr.open_group(store, mode="w", zarr_format=2)
+    else:
+        root = zarr.open_group(store, mode="w")
+
+    # Create OME subgroup with v0.5-style series metadata
+    ome_group = root.create_group("OME")
+    ome_group.attrs["ome"] = {"series": ["0", "1", "2"], "version": "0.5"}
+
+    series = _get_bioformats2raw_series(root)
+    assert series == ["0", "1", "2"]


### PR DESCRIPTION
## Summary

Adds support for reading OME-Zarr files produced by [bioformats2raw](https://github.com/glencoesoftware/bioformats2raw), which use a container layout that stores `bioformats2raw.layout` at the root level instead of the expected `multiscales` metadata. Previously, `from_ngff_zarr()` would crash with `ValueError: Could not detect NGFF version from root attributes` when encountering these files.

## Problem

bioformats2raw-produced `.ome.zarr` files have a different structure from standard OME-Zarr:

```
root/
├── .zattrs              → {"bioformats2raw.layout": 3}   # no multiscales here
├── OME/
│   ├── .zattrs          → {"series": ["0", "1", ...]}    # image path listing
│   └── METADATA.ome.xml
├── 0/                   # actual image with multiscales metadata
│   ├── .zattrs          → {"multiscales": [...]}
│   └── 0/, 1/, ...      # resolution levels
├── 1/
│   └── ...
└── ...
```

Since `_detect_version()` only checked for `ome`, `multiscales`, or `plate` keys at the root, these files were rejected entirely.

## Solution

Follows the same pattern already used for HCS plate detection:

1. **`_is_bioformats2raw(root_attrs)`** — Detects bioformats2raw containers by checking for the `bioformats2raw.layout` key at root (v0.4) or under the `ome` key (v0.5 format).

2. **`_get_bioformats2raw_series(root)`** — Reads image paths from the `OME` subgroup's `series` metadata array when available, with fallback to enumerating non-OME subgroups.

3. **Transparent navigation in `from_ngff_zarr()`**:
   - **Single image** (most common case): silently navigates into the sole image subgroup — the user experience is seamless.
   - **Multiple images**: raises a helpful `ValueError` listing available images and how to select one (e.g., `path.ome.zarr/0`).
   - **Explicit subpath** (e.g., `path.ome.zarr/0`): works via the existing `_parse_hcs_path` infrastructure with no additional changes needed.
   - **Empty container**: raises a clear error about missing image subgroups.

## Files changed

- **`py/ngff_zarr/parse_metadata.py`** — Added `_is_bioformats2raw()` and `_get_bioformats2raw_series()` functions
- **`py/ngff_zarr/from_ngff_zarr.py`** — Added bioformats2raw detection block after the existing HCS plate check, updated docstring
- **`py/test/test_version_detection.py`** — 13 new test cases covering detection, single/multi-image navigation, OME series metadata, fallback enumeration, and error cases

## Test results

All 388 tests pass (including 13 new), 0 failures. All lint/format checks pass.