### PR TITLE
fix(ci): avoid duplicate pixi binary install in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,13 +144,10 @@ jobs:
           pixi-version: v0.62.2
           frozen: true
 
-      - name: Setup pixi (for TypeScript build)
+      - name: Install pixi environment (for TypeScript build)
         if: steps.identify.outputs.project == 'ts'
-        uses: prefix-dev/setup-pixi@v0.9.3
-        with:
-          manifest-path: ./ts/pixi.toml
-          pixi-version: v0.62.2
-          frozen: true
+        run: pixi install --frozen
+        working-directory: ts
 
       - name: Install deno (for TypeScript package)
         if: steps.identify.outputs.project == 'ts'


### PR DESCRIPTION
## Summary

Fixes the TypeScript release workflow failing with `Destination file path /home/runner/.pixi/bin/pixi already exists` when the `prefix-dev/setup-pixi` action is invoked twice in the same job.

**Failing run:** https://github.com/fideus-labs/ngff-zarr/actions/runs/22370662451/job/64748417143

## Problem

The `release` job in `.github/workflows/release.yml` had two consecutive `prefix-dev/setup-pixi` action calls:

1. **"Setup pixi (for Python test data)"** — runs unconditionally, installs the pixi binary to `~/.pixi/bin/pixi` and sets up the `py/` environment.
2. **"Setup pixi (for TypeScript build)"** — runs only for `ts-v*` tags, attempts to install the same pixi binary to the same path for the `ts/` environment.

The `setup-pixi` action re-downloads and writes the pixi binary on every invocation. When the second call runs (during TypeScript releases), it fails because the binary already exists at the destination path. After retrying twice with backoff, it errors out.

## Fix

Replace the second `setup-pixi` action call with a direct `pixi install --frozen` command in the `ts/` working directory. Since the pixi binary is already installed and on `PATH` from the first step, this sets up the TypeScript pixi environment without attempting to re-download the binary.

```diff
-      - name: Setup pixi (for TypeScript build)
+      - name: Install pixi environment (for TypeScript build)
         if: steps.identify.outputs.project == 'ts'
-        uses: prefix-dev/setup-pixi@v0.9.3
-        with:
-          manifest-path: ./ts/pixi.toml
-          pixi-version: v0.62.2
-          frozen: true
+        run: pixi install --frozen
+        working-directory: ts
```

This is consistent with how pixi resolves its manifest — when run from the `ts/` directory, it automatically picks up `ts/pixi.toml`.