### PR TITLE
ci(ts): add trusted publishing for JSR and NPM via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       url: https://pypi.org/p/ngff-zarr
     permissions:
       contents: write  # Required to create releases
-      id-token: write  # Required for PyPI trusted publishing (OIDC)
+      id-token: write  # Required for trusted publishing (PyPI, NPM, JSR via OIDC)
 
     steps:
       - name: Checkout repository
@@ -285,23 +285,19 @@ jobs:
           skip-existing: true
           verbose: true
 
-      # --- TypeScript Package Publishing (NPM) ---
+      # --- TypeScript Package Publishing (NPM - Trusted Publishing / OIDC) ---
 
-      # - name: Publish to NPM
-      #   if: steps.identify.outputs.project == 'ts'
-      #   working-directory: ts/npm
-      #   run: |
-      #     echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-      #     npm publish --access public
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to NPM
+        if: steps.identify.outputs.project == 'ts'
+        working-directory: ts/npm
+        run: |
+          npm install -g npm@latest
+          npm publish --provenance --access public
 
-      # --- TypeScript Package Publishing (JSR - Optional) ---
+      # --- TypeScript Package Publishing (JSR - OIDC) ---
 
-      # - name: Publish to JSR
-      #   if: steps.identify.outputs.project == 'ts'
-      #   working-directory: ts
-      #   run: |
-      #     deno publish --allow-dirty
-      #   env:
-      #     DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
+      - name: Publish to JSR
+        if: steps.identify.outputs.project == 'ts'
+        working-directory: ts
+        run: |
+          deno publish --allow-dirty


### PR DESCRIPTION
## Summary

- Replace commented-out, secret-based NPM and JSR publishing steps with OIDC trusted publishing in the release workflow
- Eliminate the need for long-lived `NPM_TOKEN` and `DENO_DEPLOY_TOKEN` secrets

## Changes

### NPM Trusted Publishing
- Replaced the old `NPM_TOKEN`-based publish block with `npm publish --provenance --access public`
- Added `npm install -g npm@latest` to ensure npm >=11.5.1 (required for OIDC token exchange)
- No secrets or environment variables needed — the npm CLI auto-detects the GitHub Actions OIDC environment

### JSR Trusted Publishing
- Replaced the old `DENO_DEPLOY_TOKEN`-based publish block with a plain `deno publish --allow-dirty`
- JSR has native GitHub Actions OIDC support — just needs the `id-token: write` permission (already configured)
- `--allow-dirty` is required because build artifacts are present in the working directory at publish time

### Shared Infrastructure
- The existing `id-token: write` permission (originally added for PyPI) is reused by both NPM and JSR — no new permissions needed
- Updated the `id-token` comment to document that it now covers all three registries (PyPI, NPM, JSR)
- The existing build steps (`pixi run build` + `pixi run build-npm`) remain unchanged

## Manual Setup (already completed)

The following registry-side configuration was done prior to this PR:

1. **NPM**: Trusted publisher configured at `npmjs.com` for `@fideus-labs/ngff-zarr` → workflow `release.yml`
2. **JSR**: Package linked to the `fideus-labs/ngff-zarr` GitHub repository at `jsr.io`