### PR TITLE
ci: prevent duplicate push and pull_request CI builds

### DIFF
--- a/.github/workflows/mcp-ci.yml
+++ b/.github/workflows/mcp-ci.yml
@@ -2,9 +2,8 @@ name: MCP Server
 
 on:
   push:
-    branches: [main, develop]
-  pull_request:
     branches: [main]
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/python-pixi.yml
+++ b/.github/workflows/python-pixi.yml
@@ -1,6 +1,9 @@
 name: Python Pixi
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,6 +1,9 @@
 name: Python
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/python_dask.yaml
+++ b/.github/workflows/python_dask.yaml
@@ -1,5 +1,8 @@
 name: Python Dask pre-sharding
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,6 +1,9 @@
 name: TypeScript
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Restrict `push` triggers to the `main` branch across all 5 CI workflows to eliminate duplicate builds when branches with open pull requests are pushed to the main repository.

## Problem

Four workflows (`python.yml`, `python-pixi.yml`, `python_dask.yaml`, `typescript.yml`) used `on: [push, pull_request]` with no branch filters, and `mcp-ci.yml` had partial filters. This caused **two identical CI runs** for the same commit SHA whenever a push was made to a branch with an open PR — one from the `push` event and one from the `pull_request` (synchronize) event.

## Changes

All 5 CI workflows now use the same trigger pattern:

```yaml
on:
  push:
    branches: [main]
  pull_request:
```

### Workflows updated

| Workflow | Before | After |
|----------|--------|-------|
| `python.yml` | `on: [push, pull_request]` | push: `main` only, PR: all |
| `python-pixi.yml` | `on: [push, pull_request]` | push: `main` only, PR: all |
| `python_dask.yaml` | `on: [push, pull_request]` | push: `main` only, PR: all |
| `typescript.yml` | `on: [push, pull_request]` | push: `main` only, PR: all |
| `mcp-ci.yml` | push: `main`/`develop`, PR: `main` only | push: `main` only, PR: all |

### Unaffected workflows (no changes needed)

- `release.yml` — tag-only trigger
- `daily-repo-status.lock.yml` — schedule/dispatch trigger

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Push to feature branch with open PR | 2 runs (push + PR) | 1 run (PR only) |
| Direct push to `main` | 1-2 runs | 1 run (push only) |
| PR from external fork | 1 run (PR) | 1 run (PR) |
| Push to feature branch without PR | 1 run (push) | 0 runs |

The last case (push without PR) is intentional — CI will run as soon as a PR is opened for that branch.