### PR TITLE
feat(py,ts): preserve ITK direction matrix through anatomical orientation round-trips

### DIFF
--- a/py/ngff_zarr/__init__.py
+++ b/py/ngff_zarr/__init__.py
@@ -44,7 +44,9 @@ from .rfc4 import (
     AnatomicalOrientation,
     AnatomicalOrientationValues,
     add_anatomical_orientation_to_axis,
+    anatomical_orientation_to_itk_direction,
     is_rfc4_enabled,
+    itk_direction_to_anatomical_orientation,
     itk_lps_to_anatomical_orientation,
     remove_anatomical_orientation_from_axis,
 )
@@ -154,6 +156,8 @@ __all__ = [
     "LPS",
     "RAS",
     "itk_lps_to_anatomical_orientation",
+    "itk_direction_to_anatomical_orientation",
+    "anatomical_orientation_to_itk_direction",
     "is_rfc4_enabled",
     "add_anatomical_orientation_to_axis",
     "remove_anatomical_orientation_from_axis",

--- a/py/ngff_zarr/itk_image_to_ngff_image.py
+++ b/py/ngff_zarr/itk_image_to_ngff_image.py
@@ -5,7 +5,10 @@ from dataclasses import asdict
 import dask.array
 
 from .ngff_image import NgffImage
-from .rfc4 import itk_lps_to_anatomical_orientation
+from .rfc4 import (
+    itk_direction_to_anatomical_orientation,
+    itk_lps_to_anatomical_orientation,
+)
 
 
 def itk_image_to_ngff_image(
@@ -71,11 +74,41 @@ def itk_image_to_ngff_image(
     # Add anatomical orientation if requested
     axes_orientations = None
     if add_anatomical_orientation:
+        import numpy as np
+
+        direction = image_dict.get("direction")
+        n_spatial = len(spatial_dims)
+
+        # Check whether the direction matrix is available and non-identity
+        has_direction = direction is not None and len(direction) > 0
+        has_non_identity = False
+        if has_direction:
+            dir_array = np.asarray(direction).reshape(n_spatial, n_spatial)
+            has_non_identity = not np.array_equal(dir_array, np.eye(n_spatial))
+
         axes_orientations = {}
-        for dim in spatial_dims:
-            orientation = itk_lps_to_anatomical_orientation(dim)
-            if orientation is not None:
-                axes_orientations[dim] = orientation
+        if has_non_identity:
+            # Use the direction cosine matrix to determine each axis'
+            # anatomical orientation. The direction matrix is stored
+            # row-major: direction[row * n_spatial + col].
+            #
+            # spatial_dims is in array order (e.g. ["z", "y", "x"]) and
+            # maps to reversed ITK axis indices:
+            #   spatial_dims[0] = "z" -> ITK axis 2 -> direction column 2
+            #   spatial_dims[1] = "y" -> ITK axis 1 -> direction column 1
+            #   spatial_dims[2] = "x" -> ITK axis 0 -> direction column 0
+            for i, dim in enumerate(spatial_dims):
+                itk_axis_index = n_spatial - 1 - i
+                col = [
+                    float(dir_array[row, itk_axis_index]) for row in range(n_spatial)
+                ]
+                axes_orientations[dim] = itk_direction_to_anatomical_orientation(col)
+        else:
+            # Identity direction or no direction: fall back to LPS labels
+            for dim in spatial_dims:
+                orientation = itk_lps_to_anatomical_orientation(dim)
+                if orientation is not None:
+                    axes_orientations[dim] = orientation
 
     return NgffImage(
         data, dims, scale, translation, axes_orientations=axes_orientations

--- a/py/ngff_zarr/ngff_image_to_itk_image.py
+++ b/py/ngff_zarr/ngff_image_to_itk_image.py
@@ -6,6 +6,7 @@ from dask.array.core import Array as DaskArray
 
 from .methods._support import _channel_dim_last
 from .ngff_image import NgffImage
+from .rfc4 import anatomical_orientation_to_itk_direction
 
 
 def _dtype_to_component_type(dtype):
@@ -135,12 +136,40 @@ def ngff_image_to_itk_image(
 
     data = np.asarray(ngff_image.data)
 
+    # Build direction matrix from anatomical orientations when available.
+    # itk_dims is in ITK physical-space order [x, y, z (, t)].
+    # Column j of the direction matrix corresponds to itk_dims[j].
+    direction = np.eye(dimension)
+    orientations = ngff_image.axes_orientations
+    if orientations:
+        # Only spatial dims (not "t") contribute to the direction matrix.
+        spatial_itk_dims = [d for d in itk_dims if d != "t"]
+        columns: list[list[float]] = []
+        use_orientations = True
+        for dim in spatial_itk_dims:
+            ori = orientations.get(dim)
+            if ori is None:
+                use_orientations = False
+                break
+            col = anatomical_orientation_to_itk_direction(ori.value)
+            if col is None:
+                # Non-LPS orientation: fall back to identity
+                use_orientations = False
+                break
+            columns.append(col)
+
+        if use_orientations and columns:
+            n_spatial = len(spatial_itk_dims)
+            for col_idx in range(n_spatial):
+                for row in range(n_spatial):
+                    direction[row, col_idx] = columns[col_idx][row]
+
     image_dict = {
         "imageType": imageType,
         "name": ngff_image.name,
         "origin": origin,
         "spacing": spacing,
-        "direction": np.eye(dimension),
+        "direction": direction,
         "size": size,
         "metadata": {},
         "data": data,

--- a/py/ngff_zarr/rfc4.py
+++ b/py/ngff_zarr/rfc4.py
@@ -152,6 +152,133 @@ def itk_lps_to_anatomical_orientation(
     return LPS.get(axis_name)
 
 
+_LPS_ORIENTATION_PAIRS = [
+    (
+        AnatomicalOrientationValues.right_to_left,
+        AnatomicalOrientationValues.left_to_right,
+    ),
+    (
+        AnatomicalOrientationValues.anterior_to_posterior,
+        AnatomicalOrientationValues.posterior_to_anterior,
+    ),
+    (
+        AnatomicalOrientationValues.inferior_to_superior,
+        AnatomicalOrientationValues.superior_to_inferior,
+    ),
+]
+"""LPS orientation pairs: positive and negative orientations for each
+physical axis in the LPS coordinate system.
+
+Each row is ``(positive_orientation, negative_orientation)`` where
+*positive* means the direction cosine value is >= 0 and *negative* means
+it is < 0.
+
+- Row 0 (L/R): positive -> RightToLeft, negative -> LeftToRight
+- Row 1 (A/P): positive -> AnteriorToPosterior, negative -> PosteriorToAnterior
+- Row 2 (I/S): positive -> InferiorToSuperior, negative -> SuperiorToInferior
+"""
+
+
+_MAX_SPATIAL_DIMENSIONS = 3
+
+
+def itk_direction_to_anatomical_orientation(
+    direction_column: list[float] | tuple[float, ...],
+) -> AnatomicalOrientation:
+    """Determine the anatomical orientation from a direction cosine vector.
+
+    The direction vector is a column of the ITK direction matrix. Its
+    dominant component (largest absolute value) determines which physical
+    axis (L/R, A/P, or S/I) this image axis aligns with, and the sign
+    of that component determines the direction.
+
+    In LPS physical space:
+    - Component 0: L/R axis (positive = Right->Left, negative = Left->Right)
+    - Component 1: A/P axis (positive = Anterior->Posterior, negative = Posterior->Anterior)
+    - Component 2: I/S axis (positive = Inferior->Superior, negative = Superior->Inferior)
+
+    For 2D images, the direction column will have only 2 components, with the
+    third component implicitly zero.
+
+    Parameters
+    ----------
+    direction_column : list[float] | tuple[float, ...]
+        Direction cosine vector for the image axis.
+        Can be 2-element (for 2D images) or 3-element (for 3D images).
+        Must have at least 2 elements.
+
+    Returns
+    -------
+    AnatomicalOrientation
+        The anatomical orientation corresponding to the dominant direction
+        of this axis.
+
+    Raises
+    ------
+    ValueError
+        If direction_column has fewer than 2 elements.
+    """
+    if len(direction_column) < 2:
+        msg = (
+            f"Direction column must have at least 2 elements for 2D/3D images, "
+            f"got {len(direction_column)}"
+        )
+        raise ValueError(msg)
+
+    # Find the dominant physical axis (largest absolute component)
+    n = min(len(direction_column), _MAX_SPATIAL_DIMENSIONS)
+    dominant_axis = 0
+    max_abs = abs(direction_column[0])
+    for i in range(1, n):
+        abs_val = abs(direction_column[i])
+        if abs_val > max_abs:
+            max_abs = abs_val
+            dominant_axis = i
+
+    # Positive component -> positive LPS direction, negative -> opposite
+    pos, neg = _LPS_ORIENTATION_PAIRS[dominant_axis]
+    value = pos if direction_column[dominant_axis] >= 0 else neg
+    return AnatomicalOrientation(value=value)
+
+
+def anatomical_orientation_to_itk_direction(
+    orientation: AnatomicalOrientationValues,
+) -> list[float] | None:
+    """Convert an anatomical orientation to an ITK direction cosine vector.
+
+    This is the reverse of :func:`itk_direction_to_anatomical_orientation`.
+    Given an anatomical orientation value, it returns the unit direction
+    column vector in ITK LPS physical space.
+
+    Only the six LPS-compatible orientations are supported.  For any other
+    orientation (e.g. dorsal, palmar, rostral, etc.) the function returns
+    ``None``, signalling that the caller should fall back to an identity
+    direction matrix.
+
+    Parameters
+    ----------
+    orientation : AnatomicalOrientationValues
+        The anatomical orientation value.
+
+    Returns
+    -------
+    list[float] | None
+        A 3-element unit direction column vector ``[lps_x, lps_y, lps_z]``,
+        or ``None`` if the orientation is not one of the six LPS-compatible
+        values.
+    """
+    for axis_index, (pos, neg) in enumerate(_LPS_ORIENTATION_PAIRS):
+        if orientation == pos:
+            col = [0.0, 0.0, 0.0]
+            col[axis_index] = 1.0
+            return col
+        if orientation == neg:
+            col = [0.0, 0.0, 0.0]
+            col[axis_index] = -1.0
+            return col
+    return None
+
+
 def is_rfc4_enabled(enabled_rfcs: list[int] | None) -> bool:
     """Check if RFC 4 is enabled in the list of enabled RFCs."""
     return enabled_rfcs is not None and 4 in enabled_rfcs

--- a/py/pixi.lock
+++ b/py/pixi.lock
@@ -33,7 +33,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
@@ -71,7 +71,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.1-h546c87b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.13.12-h4c0d347_100_cp313.conda
@@ -93,7 +93,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.0-h19cb2f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.1-h19cb2f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.4-h991f03e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.2-h11316ed_0.conda
@@ -103,7 +103,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.1-hb6871ef_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.3-h4f44bb5_101_cp314.conda
@@ -126,7 +126,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.2-hef89b57_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.0-h55c6f16_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.1-h55c6f16_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.4-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
@@ -136,7 +136,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.3-h4c637c5_101_cp314.conda
@@ -166,7 +166,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.1-hf411b9b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.3-h4b44e0e_101_cp314.conda
@@ -212,7 +212,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonttools-4.62.0-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.2-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.3.2-h6083320_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.1.0-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py314h97ea11e_0.conda
@@ -283,7 +283,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py314h8ec4b1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.10.2-py314hf36963e_0.conda
@@ -372,7 +372,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fonttools-4.62.0-py313hd3a54cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.2-h8af1aa0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.14-hfae3067_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-12.3.2-h1134a53_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-13.1.0-h1134a53_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.2-hcab7f73_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/kiwisolver-1.5.0-py313h314c631_0.conda
@@ -443,7 +443,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.1.1-py313h20c1486_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyside6-6.10.2-py313h871b3e4_0.conda
@@ -526,7 +526,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h8616949_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h8616949_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.11.0-5_h9b27e0a_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.0-h19cb2f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.1-h19cb2f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.25-h517ebb2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.4-h991f03e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
@@ -556,7 +556,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.1-hb6871ef_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-12.1.1-py314hf9dbaa9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.3-h4f44bb5_101_cp314.conda
@@ -618,7 +618,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-5_hb0561ab_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.0-h55c6f16_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.1-h55c6f16_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.25-hc11a715_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.4-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
@@ -648,7 +648,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.1.1-py314hab283cf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.3-h4c637c5_101_cp314.conda
@@ -712,7 +712,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonttools-4.62.0-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.14.2-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.14-hac47afa_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-12.3.2-h5a1b470_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-13.1.0-h5a1b470_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/icu-78.2-h637d24d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.5.0-py314hf309875_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.22.2-h0ea6238_0.conda
@@ -762,7 +762,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.47-hd2b5f0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-12.1.1-py314h61b30b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.46.4-h5112557_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.10.2-py314h2c9462b_0.conda
@@ -984,7 +984,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.0-h19cb2f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.1-h19cb2f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.4-h991f03e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.2-h11316ed_0.conda
@@ -1055,7 +1055,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.2-hef89b57_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.0-h55c6f16_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.1-h55c6f16_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.4-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
@@ -1227,7 +1227,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.51-hd8ed1ab_0.conda
@@ -1287,7 +1287,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.1-h546c87b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.51-hd8ed1ab_0.conda
@@ -1328,7 +1328,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.17-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.0-h19cb2f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.1-h19cb2f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.4-h991f03e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.2-h11316ed_0.conda
@@ -1341,7 +1341,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.1-hb6871ef_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.51-hd8ed1ab_0.conda
@@ -1383,7 +1383,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.17-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.0-h55c6f16_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.1-h55c6f16_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.4-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
@@ -1396,7 +1396,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.51-hd8ed1ab_0.conda
@@ -1448,7 +1448,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.1-hf411b9b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.51-hd8ed1ab_0.conda
@@ -1512,7 +1512,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.2-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.3.2-h6083320_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.1.0-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
@@ -1588,7 +1588,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py314h8ec4b1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
@@ -1666,7 +1666,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c6/bb/82c7dcf38070b46172a517e2334e665c5bf374a262f99a283ea454bece7c/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/61/20/a655b1ee047c27cff1b63a714136b78580ee0e048e1e04769f13d2e61bbf/nibabel-5.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/d7/601b6396b33536811668935faa790112266c70661be94555999be431f86f/nibabel-5.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6d/30/16a57fc4d9fb0ba06c600408bd6634f2f1753c54a7a351c99c5e09b51ee2/numcodecs-0.16.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/55/77/6ea82043db22cb0f2bbfe7198da3544000ddaadb12d26be36e19b03a2dc5/pandas-3.0.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
@@ -1720,7 +1720,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.2-h8af1aa0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.14-hfae3067_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-12.3.2-h1134a53_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-13.1.0-h1134a53_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.2-hcab7f73_0.conda
@@ -1796,7 +1796,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.1.1-py313h20c1486_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
@@ -1873,7 +1873,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/b7/dff378afc2b0d5a7d6cd9d3209b60474d9819d1189d347521e1688a60a53/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/61/20/a655b1ee047c27cff1b63a714136b78580ee0e048e1e04769f13d2e61bbf/nibabel-5.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/d7/601b6396b33536811668935faa790112266c70661be94555999be431f86f/nibabel-5.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/00/787ea5f237b8ea7bc67140c99155f9c00b5baf11c49afc5f3bfefa298f95/numcodecs-0.16.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/80/f01ff54664b6d70fed71475543d108a9b7c888e923ad210795bef04ffb7d/pandas-3.0.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
@@ -1926,7 +1926,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h8616949_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h8616949_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.11.0-5_h9b27e0a_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.0-h19cb2f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.1-h19cb2f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.25-h517ebb2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.4-h991f03e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
@@ -1957,7 +1957,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.1-hb6871ef_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-12.1.1-py314hf9dbaa9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
@@ -2012,7 +2012,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/61/20/a655b1ee047c27cff1b63a714136b78580ee0e048e1e04769f13d2e61bbf/nibabel-5.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/d7/601b6396b33536811668935faa790112266c70661be94555999be431f86f/nibabel-5.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3c/9e/38e7ca8184c958b51f45d56a4aeceb1134ecde2d8bd157efadc98502cc42/numcodecs-0.16.5-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/8b/4bb774a998b97e6c2fd62a9e6cfdaae133b636fd1c468f92afb4ae9a447a/pandas-3.0.1-cp314-cp314-macosx_10_15_x86_64.whl
@@ -2066,7 +2066,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-5_hb0561ab_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.0-h55c6f16_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.1-h55c6f16_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.25-hc11a715_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.4-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
@@ -2097,7 +2097,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.1.1-py314hab283cf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
@@ -2152,7 +2152,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/61/20/a655b1ee047c27cff1b63a714136b78580ee0e048e1e04769f13d2e61bbf/nibabel-5.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/d7/601b6396b33536811668935faa790112266c70661be94555999be431f86f/nibabel-5.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/37/260fa42e7b2b08e6e00ad632f8dd620961a60a459426c26cea390f8c68d0/numcodecs-0.16.5-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/72/3a/5b39b51c64159f470f1ca3b1c2a87da290657ca022f7cd11442606f607d1/pandas-3.0.1-cp314-cp314-macosx_11_0_arm64.whl
@@ -2204,7 +2204,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.14.2-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.14-hac47afa_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-12.3.2-h5a1b470_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-13.1.0-h5a1b470_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/icu-78.2-h637d24d_0.conda
@@ -2259,7 +2259,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.47-hd2b5f0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-12.1.1-py314h61b30b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.46.4-h5112557_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
@@ -2321,7 +2321,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e9/93/2bfed22d2498c468f6bcd0d9f56b033eaa19f33320389314c19ef6766413/ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/61/20/a655b1ee047c27cff1b63a714136b78580ee0e048e1e04769f13d2e61bbf/nibabel-5.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/d7/601b6396b33536811668935faa790112266c70661be94555999be431f86f/nibabel-5.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/a5/a0425af36c20d55a3ea884db4b4efca25a43bea9214ba69ca7932dd997b4/numcodecs-0.16.5-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/09/f8/8ce132104074f977f907442790eaae24e27bce3b3b454e82faa3237ff098/pandas-3.0.1-cp314-cp314-win_amd64.whl
@@ -3884,56 +3884,56 @@ packages:
   - pkg:pypi/h2?source=hash-mapping
   size: 95967
   timestamp: 1756364871835
-- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.3.2-h6083320_0.conda
-  sha256: 92015faf283f9c0a8109e2761042cd47ae7a4505e24af42a53bc3767cb249912
-  md5: d170a70fc1d5c605fcebdf16851bd54a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.1.0-h6083320_0.conda
+  sha256: 08dc098dcc5c3445331a834f46602b927cb65d2768189f3f032a6e4643f15cd9
+  md5: 5baf48da05855be929c5a50f4377794d
   depends:
   - __glibc >=2.17,<3.0.a0
   - cairo >=1.18.4,<2.0a0
   - graphite2 >=1.3.14,<2.0a0
   - icu >=78.2,<79.0a0
-  - libexpat >=2.7.3,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
+  - libexpat >=2.7.4,<3.0a0
+  - libfreetype >=2.14.2
+  - libfreetype6 >=2.14.2
   - libgcc >=14
-  - libglib >=2.86.3,<3.0a0
+  - libglib >=2.86.4,<3.0a0
   - libstdcxx >=14
   - libzlib >=1.3.1,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 2035859
-  timestamp: 1769445400168
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-12.3.2-h1134a53_0.conda
-  sha256: 2256234188df4651a202f5bd1428b6b11ce1442a4a2fc6baf403c293c1ff752e
-  md5: f8ab08bc3716972b7bd47e48a6884260
+  size: 2615630
+  timestamp: 1773217509651
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-13.1.0-h1134a53_0.conda
+  sha256: 49074457bdc624c0c0f39bb4b9b7689ec6334127ed7d5312484908f48e9a8e20
+  md5: 811bb5384d92870a3492fab4de4ff3f6
   depends:
   - cairo >=1.18.4,<2.0a0
   - graphite2 >=1.3.14,<2.0a0
   - icu >=78.2,<79.0a0
-  - libexpat >=2.7.3,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
+  - libexpat >=2.7.4,<3.0a0
+  - libfreetype >=2.14.2
+  - libfreetype6 >=2.14.2
   - libgcc >=14
-  - libglib >=2.86.3,<3.0a0
+  - libglib >=2.86.4,<3.0a0
   - libstdcxx >=14
   - libzlib >=1.3.1,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 2046698
-  timestamp: 1769449788963
-- conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-12.3.2-h5a1b470_0.conda
-  sha256: f55c689dfb49a3778c2e3369a9103393f6cbd8efc9105753b8e081909dae74dd
-  md5: fb5d7b9527b418f83e3316f3e6daa8a2
+  size: 2346492
+  timestamp: 1773222371375
+- conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-13.1.0-h5a1b470_0.conda
+  sha256: 27acd845926048481a831b7321674b3f92accde49869fb95438f0a35ea89419b
+  md5: b3a4ff5d1e21d58090cd87060eb54c2d
   depends:
   - cairo >=1.18.4,<2.0a0
   - graphite2 >=1.3.14,<2.0a0
   - icu >=78.2,<79.0a0
-  - libexpat >=2.7.3,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libglib >=2.86.3,<3.0a0
+  - libexpat >=2.7.4,<3.0a0
+  - libfreetype >=2.14.2
+  - libfreetype6 >=2.14.2
+  - libglib >=2.86.4,<3.0a0
   - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -3941,8 +3941,8 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 1127522
-  timestamp: 1769445644521
+  size: 1285640
+  timestamp: 1773217788574
 - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
   sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
   md5: 0a802cb9888dd14eeefc611f05c40b6e
@@ -5215,26 +5215,26 @@ packages:
   purls: []
   size: 4553739
   timestamp: 1770903929794
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.0-h19cb2f5_1.conda
-  sha256: fa002b43752fe5860e588435525195324fe250287105ebd472ac138e97de45e6
-  md5: 836389b6b9ae58f3fbcf7cafebd5c7f2
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.1-h19cb2f5_0.conda
+  sha256: db3adcb33eaca02311d3ba17e06c60ceaedda20240414f7b1df6e7f9ec902bfa
+  md5: 799141ac68a99265f04bcee196b2df51
   depends:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 570141
-  timestamp: 1772001147762
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.0-h55c6f16_1.conda
-  sha256: ce1049fa6fda9cf08ff1c50fb39573b5b0ea6958375d8ea7ccd8456ab81a0bcb
-  md5: e9c56daea841013e7774b5cd46f41564
+  size: 564942
+  timestamp: 1773203656390
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.1-h55c6f16_0.conda
+  sha256: 3c8142cdd3109c250a926c492ec45bc954697b288e5d1154ada95272ffa21be8
+  md5: 7a290d944bc0c481a55baf33fa289deb
   depends:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 568910
-  timestamp: 1772001095642
+  size: 570281
+  timestamp: 1773203613980
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
   sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
   md5: 6c77a605a7a689d17d4819c0f8ac9a00
@@ -7732,10 +7732,10 @@ packages:
   - pytest>=6 ; extra == 'test'
   - jsonschema ; extra == 'validate'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/61/20/a655b1ee047c27cff1b63a714136b78580ee0e048e1e04769f13d2e61bbf/nibabel-5.4.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/3b/d7/601b6396b33536811668935faa790112266c70661be94555999be431f86f/nibabel-5.4.2-py3-none-any.whl
   name: nibabel
-  version: 5.4.0
-  sha256: 1a386d27343952b980be0415d2629ebba41b50ac40abfc457a17f2fed79edfbe
+  version: 5.4.2
+  sha256: 553482c5f1e1034fc312edf6fb7f32236c0056439845d1c29293b7e8c98d4854
   requires_dist:
   - importlib-resources>=5.12 ; python_full_version < '3.12'
   - numpy>=1.25
@@ -7750,11 +7750,6 @@ packages:
   - pydicom>=2.3 ; extra == 'dicom'
   - pillow>=8.4 ; extra == 'dicomfs'
   - pydicom>=2.3 ; extra == 'dicomfs'
-  - matplotlib>=3.5 ; extra == 'doc'
-  - numpydoc>=1.9 ; extra == 'doc'
-  - sphinx>=7.4 ; extra == 'doc'
-  - texext>=0.6.8 ; extra == 'doc'
-  - tomli>=2.3 ; python_full_version < '3.11' and extra == 'doc'
   - indexed-gzip>=1.6 ; extra == 'indexed-gzip'
   - h5py>=3.8 ; extra == 'minc2'
   - scipy>=1.11 ; extra == 'spm'
@@ -8858,9 +8853,9 @@ packages:
   purls: []
   size: 542795
   timestamp: 1754665193489
-- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
-  sha256: 7f263219cecf0ba6d74c751efa60c4676ce823157ca90aa43ebba5ac615ca0fa
-  md5: 4fefefb892ce9cc1539405bec2f1a6cd
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+  sha256: 0289f0a38337ee201d984f8f31f11f6ef076cfbbfd0ab9181d12d9d1d099bf46
+  md5: 82c1787f2a65c0155ef9652466ee98d6
   depends:
   - python >=3.10
   - python
@@ -8868,8 +8863,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/platformdirs?source=compressed-mapping
-  size: 25643
-  timestamp: 1771233827084
+  size: 25646
+  timestamp: 1773199142345
 - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
   name: pluggy
   version: 1.6.0
@@ -9534,6 +9529,7 @@ packages:
   - platformdirs <5,>=4.3.6
   - python
   license: MIT
+  license_family: MIT
   purls:
   - pkg:pypi/python-discovery?source=compressed-mapping
   size: 33996

--- a/py/test/test_bin_shrink_map_blocks_fast_path.py
+++ b/py/test/test_bin_shrink_map_blocks_fast_path.py
@@ -11,11 +11,9 @@ produces a much smaller dask task graph.
 
 import dask.array as da
 import numpy as np
-from zarr.storage import MemoryStore
-
 from ngff_zarr import Methods, to_multiscales, to_ngff_image, to_ngff_zarr
 from ngff_zarr.methods._support import _can_use_map_blocks_fast_path
-
+from zarr.storage import MemoryStore
 
 # ---------------------------------------------------------------------------
 # Unit tests for the helper

--- a/py/test/test_ngff_image_to_itk_image.py
+++ b/py/test/test_ngff_image_to_itk_image.py
@@ -252,3 +252,208 @@ def test_c_index_with_empty_axes_units():
     assert itk_image.imageType.components == 1
     assert len(itk_image.size) == 3
     assert itk_image.data.shape == (4, 8, 8)  # (z, y, x) after removing c
+
+
+# --- Tests for direction matrix from anatomical orientation ---
+
+
+def test_direction_matrix_without_orientation():
+    """NgffImage without axes_orientations produces identity direction."""
+    import dask.array as da
+    from ngff_zarr import NgffImage
+
+    data = da.zeros((4, 8, 8), dtype=np.uint8)
+    ngff_image = NgffImage(
+        data=data,
+        dims=("z", "y", "x"),
+        scale={"z": 1.0, "y": 1.0, "x": 1.0},
+        translation={"z": 0.0, "y": 0.0, "x": 0.0},
+    )
+
+    itk_image = ngff_image_to_itk_image(ngff_image)
+
+    assert np.array_equal(np.asarray(itk_image.direction).reshape(3, 3), np.eye(3))
+
+
+def test_direction_matrix_from_lps_orientation():
+    """NgffImage with LPS orientations produces identity direction."""
+    import dask.array as da
+    from ngff_zarr import LPS, NgffImage
+
+    data = da.zeros((4, 8, 8), dtype=np.uint8)
+    ngff_image = NgffImage(
+        data=data,
+        dims=("z", "y", "x"),
+        scale={"z": 1.0, "y": 1.0, "x": 1.0},
+        translation={"z": 0.0, "y": 0.0, "x": 0.0},
+        axes_orientations=LPS,
+    )
+
+    itk_image = ngff_image_to_itk_image(ngff_image)
+
+    assert np.array_equal(np.asarray(itk_image.direction).reshape(3, 3), np.eye(3))
+
+
+def test_direction_matrix_from_ras_orientation():
+    """NgffImage with RAS orientations produces flipped X/Y direction."""
+    import dask.array as da
+    from ngff_zarr import RAS, NgffImage
+
+    data = da.zeros((4, 8, 8), dtype=np.uint8)
+    ngff_image = NgffImage(
+        data=data,
+        dims=("z", "y", "x"),
+        scale={"z": 1.0, "y": 1.0, "x": 1.0},
+        translation={"z": 0.0, "y": 0.0, "x": 0.0},
+        axes_orientations=RAS,
+    )
+
+    itk_image = ngff_image_to_itk_image(ngff_image)
+
+    # RAS: X is left-to-right (-1), Y is posterior-to-anterior (-1),
+    # Z is inferior-to-superior (+1)
+    expected = np.diag([-1.0, -1.0, 1.0])
+    assert np.array_equal(np.asarray(itk_image.direction).reshape(3, 3), expected)
+
+
+def test_direction_matrix_from_permuted_orientation():
+    """NgffImage with permuted orientations produces non-identity direction."""
+    import dask.array as da
+    from ngff_zarr import AnatomicalOrientation, AnatomicalOrientationValues, NgffImage
+
+    data = da.zeros((4, 8, 8), dtype=np.uint8)
+    # x maps to A/P (Y physical), y maps to I/S (Z physical),
+    # z maps to R/L (X physical)
+    axes_orientations = {
+        "x": AnatomicalOrientation(
+            value=AnatomicalOrientationValues.anterior_to_posterior
+        ),
+        "y": AnatomicalOrientation(
+            value=AnatomicalOrientationValues.inferior_to_superior
+        ),
+        "z": AnatomicalOrientation(value=AnatomicalOrientationValues.right_to_left),
+    }
+    ngff_image = NgffImage(
+        data=data,
+        dims=("z", "y", "x"),
+        scale={"z": 1.0, "y": 1.0, "x": 1.0},
+        translation={"z": 0.0, "y": 0.0, "x": 0.0},
+        axes_orientations=axes_orientations,
+    )
+
+    itk_image = ngff_image_to_itk_image(ngff_image)
+
+    direction = np.asarray(itk_image.direction).reshape(3, 3)
+    # itk_dims sorted = [x, y, z]
+    # col 0 (x) -> A/P -> [0, 1, 0]
+    # col 1 (y) -> I/S -> [0, 0, 1]
+    # col 2 (z) -> R/L -> [1, 0, 0]
+    expected = np.array(
+        [
+            [0.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+        ]
+    )
+    assert np.array_equal(direction, expected)
+
+
+def test_direction_matrix_non_lps_fallback():
+    """NgffImage with non-LPS orientation falls back to identity."""
+    import dask.array as da
+    from ngff_zarr import AnatomicalOrientation, AnatomicalOrientationValues, NgffImage
+
+    data = da.zeros((4, 8, 8), dtype=np.uint8)
+    axes_orientations = {
+        "x": AnatomicalOrientation(value=AnatomicalOrientationValues.right_to_left),
+        "y": AnatomicalOrientation(value=AnatomicalOrientationValues.dorsal_to_ventral),
+        "z": AnatomicalOrientation(
+            value=AnatomicalOrientationValues.inferior_to_superior
+        ),
+    }
+    ngff_image = NgffImage(
+        data=data,
+        dims=("z", "y", "x"),
+        scale={"z": 1.0, "y": 1.0, "x": 1.0},
+        translation={"z": 0.0, "y": 0.0, "x": 0.0},
+        axes_orientations=axes_orientations,
+    )
+
+    itk_image = ngff_image_to_itk_image(ngff_image)
+
+    # Should fall back to identity since dorsal_to_ventral is not LPS
+    assert np.array_equal(np.asarray(itk_image.direction).reshape(3, 3), np.eye(3))
+
+
+def test_direction_matrix_2d():
+    """2D NgffImage with orientations produces correct 2x2 direction."""
+    import dask.array as da
+    from ngff_zarr import RAS, NgffImage
+
+    data = da.zeros((8, 8), dtype=np.uint8)
+    # Use RAS x and y only
+    axes_orientations = {
+        "x": RAS["x"],
+        "y": RAS["y"],
+    }
+    ngff_image = NgffImage(
+        data=data,
+        dims=("y", "x"),
+        scale={"y": 1.0, "x": 1.0},
+        translation={"y": 0.0, "x": 0.0},
+        axes_orientations=axes_orientations,
+    )
+
+    itk_image = ngff_image_to_itk_image(ngff_image)
+
+    expected = np.diag([-1.0, -1.0])
+    assert np.array_equal(np.asarray(itk_image.direction).reshape(2, 2), expected)
+
+
+def test_direction_round_trip_identity():
+    """Round-trip ITK -> NgffImage -> ITK preserves identity direction."""
+    img = itkwasm.Image(
+        imageType=itkwasm.ImageType(
+            dimension=3,
+            componentType="uint8",
+            pixelType="Scalar",
+            components=1,
+        ),
+        name="test",
+        origin=[0.0, 0.0, 0.0],
+        spacing=[1.0, 1.0, 1.0],
+        direction=np.eye(3, dtype=np.float64).flatten(),
+        size=[4, 8, 8],
+        data=np.zeros((8, 8, 4), dtype=np.uint8),
+    )
+
+    ngff = itk_image_to_ngff_image(img)
+    itk_back = ngff_image_to_itk_image(ngff)
+
+    assert np.array_equal(np.asarray(itk_back.direction).reshape(3, 3), np.eye(3))
+
+
+def test_direction_round_trip_flipped_y():
+    """Round-trip ITK -> NgffImage -> ITK preserves flipped-Y direction."""
+    original_direction = np.diag([1.0, -1.0, 1.0])
+    img = itkwasm.Image(
+        imageType=itkwasm.ImageType(
+            dimension=3,
+            componentType="uint8",
+            pixelType="Scalar",
+            components=1,
+        ),
+        name="test",
+        origin=[0.0, 0.0, 0.0],
+        spacing=[1.0, 1.0, 1.0],
+        direction=original_direction.flatten(),
+        size=[4, 8, 8],
+        data=np.zeros((8, 8, 4), dtype=np.uint8),
+    )
+
+    ngff = itk_image_to_ngff_image(img)
+    itk_back = ngff_image_to_itk_image(ngff)
+
+    assert np.array_equal(
+        np.asarray(itk_back.direction).reshape(3, 3), original_direction
+    )

--- a/py/test/test_rfc4.py
+++ b/py/test/test_rfc4.py
@@ -2,11 +2,14 @@
 # SPDX-License-Identifier: MIT
 """Test RFC 4 anatomical orientation implementation."""
 
+import pytest
 from ngff_zarr.rfc4 import (
     AnatomicalOrientation,
     AnatomicalOrientationValues,
     add_anatomical_orientation_to_axis,
+    anatomical_orientation_to_itk_direction,
     is_rfc4_enabled,
+    itk_direction_to_anatomical_orientation,
     itk_lps_to_anatomical_orientation,
     remove_anatomical_orientation_from_axis,
 )
@@ -109,3 +112,122 @@ def test_anatomical_orientation_values_enum():
     assert (
         AnatomicalOrientationValues.superior_to_inferior.value == "superior-to-inferior"
     )
+
+
+# --- Tests for anatomical_orientation_to_itk_direction ---
+
+
+class TestAnatomicalOrientationToItkDirection:
+    """Unit tests for anatomical_orientation_to_itk_direction."""
+
+    def test_right_to_left(self):
+        col = anatomical_orientation_to_itk_direction(
+            AnatomicalOrientationValues.right_to_left
+        )
+        assert col == [1.0, 0.0, 0.0]
+
+    def test_left_to_right(self):
+        col = anatomical_orientation_to_itk_direction(
+            AnatomicalOrientationValues.left_to_right
+        )
+        assert col == [-1.0, 0.0, 0.0]
+
+    def test_anterior_to_posterior(self):
+        col = anatomical_orientation_to_itk_direction(
+            AnatomicalOrientationValues.anterior_to_posterior
+        )
+        assert col == [0.0, 1.0, 0.0]
+
+    def test_posterior_to_anterior(self):
+        col = anatomical_orientation_to_itk_direction(
+            AnatomicalOrientationValues.posterior_to_anterior
+        )
+        assert col == [0.0, -1.0, 0.0]
+
+    def test_inferior_to_superior(self):
+        col = anatomical_orientation_to_itk_direction(
+            AnatomicalOrientationValues.inferior_to_superior
+        )
+        assert col == [0.0, 0.0, 1.0]
+
+    def test_superior_to_inferior(self):
+        col = anatomical_orientation_to_itk_direction(
+            AnatomicalOrientationValues.superior_to_inferior
+        )
+        assert col == [0.0, 0.0, -1.0]
+
+    def test_non_lps_returns_none(self):
+        assert (
+            anatomical_orientation_to_itk_direction(
+                AnatomicalOrientationValues.dorsal_to_ventral
+            )
+            is None
+        )
+        assert (
+            anatomical_orientation_to_itk_direction(
+                AnatomicalOrientationValues.rostral_to_caudal
+            )
+            is None
+        )
+        assert (
+            anatomical_orientation_to_itk_direction(
+                AnatomicalOrientationValues.proximal_to_distal
+            )
+            is None
+        )
+
+
+# --- Tests for itk_direction_to_anatomical_orientation ---
+
+
+class TestItkDirectionToAnatomicalOrientation:
+    """Unit tests for itk_direction_to_anatomical_orientation."""
+
+    def test_positive_x(self):
+        ori = itk_direction_to_anatomical_orientation([1.0, 0.0, 0.0])
+        assert ori.value == AnatomicalOrientationValues.right_to_left
+
+    def test_negative_x(self):
+        ori = itk_direction_to_anatomical_orientation([-1.0, 0.0, 0.0])
+        assert ori.value == AnatomicalOrientationValues.left_to_right
+
+    def test_positive_y(self):
+        ori = itk_direction_to_anatomical_orientation([0.0, 1.0, 0.0])
+        assert ori.value == AnatomicalOrientationValues.anterior_to_posterior
+
+    def test_negative_y(self):
+        ori = itk_direction_to_anatomical_orientation([0.0, -1.0, 0.0])
+        assert ori.value == AnatomicalOrientationValues.posterior_to_anterior
+
+    def test_positive_z(self):
+        ori = itk_direction_to_anatomical_orientation([0.0, 0.0, 1.0])
+        assert ori.value == AnatomicalOrientationValues.inferior_to_superior
+
+    def test_negative_z(self):
+        ori = itk_direction_to_anatomical_orientation([0.0, 0.0, -1.0])
+        assert ori.value == AnatomicalOrientationValues.superior_to_inferior
+
+    def test_oblique_dominant_x(self):
+        """Oblique direction with dominant +X component."""
+        ori = itk_direction_to_anatomical_orientation([0.9, 0.3, 0.2])
+        assert ori.value == AnatomicalOrientationValues.right_to_left
+
+    def test_oblique_dominant_negative_y(self):
+        """Oblique direction with dominant -Y component."""
+        ori = itk_direction_to_anatomical_orientation([0.1, -0.9, 0.2])
+        assert ori.value == AnatomicalOrientationValues.posterior_to_anterior
+
+    def test_2d_positive_x(self):
+        """2D direction: positive X."""
+        ori = itk_direction_to_anatomical_orientation([1.0, 0.0])
+        assert ori.value == AnatomicalOrientationValues.right_to_left
+
+    def test_2d_negative_y(self):
+        """2D direction: negative Y."""
+        ori = itk_direction_to_anatomical_orientation([0.0, -1.0])
+        assert ori.value == AnatomicalOrientationValues.posterior_to_anterior
+
+    def test_too_short_raises(self):
+        """Direction column with <2 elements raises ValueError."""
+        with pytest.raises(ValueError, match="at least 2 elements"):
+            itk_direction_to_anatomical_orientation([1.0])

--- a/ts/src/io/ngff_image_to_itk_image.ts
+++ b/ts/src/io/ngff_image_to_itk_image.ts
@@ -15,6 +15,7 @@ import type {
 import * as zarr from "zarrita";
 import { defaultCodecs } from "../utils/codecs.ts";
 import { NgffImage } from "../types/ngff_image.ts";
+import { anatomicalOrientationToItkDirection } from "../types/rfc4.ts";
 import { zarrGet, zarrSet } from "../utils/worker_pool.ts";
 
 export interface NgffImageToItkImageOptions {
@@ -291,10 +292,44 @@ export async function ngffImageToItkImage(
   const selection = new Array(data.shape.length).fill(null);
   const dataChunk = await zarrGet(data, selection);
 
-  // Create direction matrix (identity for now)
+  // Build direction matrix from anatomical orientations when available.
+  // sortedItkDims is in ITK physical-space order [x, y, z (, t)].
+  // Column j of the direction matrix corresponds to sortedItkDims[j].
   const direction = new Float64Array(dimension * dimension);
   for (let i = 0; i < dimension; i++) {
-    direction[i * dimension + i] = 1.0;
+    direction[i * dimension + i] = 1.0; // Start with identity
+  }
+
+  const orientations = workingImage.axesOrientations;
+  if (orientations) {
+    // Only spatial dims (not "t") contribute to the direction matrix.
+    const spatialItkDims = sortedItkDims.filter((d) => d !== "t");
+    const nSpatial = spatialItkDims.length;
+    const columns: number[][] = [];
+    let useOrientations = true;
+
+    for (const dim of spatialItkDims) {
+      const ori = orientations[dim];
+      if (ori === undefined) {
+        useOrientations = false;
+        break;
+      }
+      const col = anatomicalOrientationToItkDirection(ori.value);
+      if (col === undefined) {
+        // Non-LPS orientation: fall back to identity
+        useOrientations = false;
+        break;
+      }
+      columns.push(col);
+    }
+
+    if (useOrientations && columns.length > 0) {
+      for (let colIdx = 0; colIdx < nSpatial; colIdx++) {
+        for (let row = 0; row < nSpatial; row++) {
+          direction[row * dimension + colIdx] = columns[colIdx][row];
+        }
+      }
+    }
   }
 
   // Create ITK-Wasm Image

--- a/ts/src/types/rfc4.ts
+++ b/ts/src/types/rfc4.ts
@@ -222,6 +222,46 @@ export function itkDirectionToAnatomicalOrientation(
 }
 
 /**
+ * Convert an anatomical orientation to an ITK direction cosine vector.
+ *
+ * This is the reverse of {@link itkDirectionToAnatomicalOrientation}.
+ * Given an anatomical orientation value, it returns the unit direction
+ * column vector in ITK LPS physical space.
+ *
+ * Only the six LPS-compatible orientations are supported.  For any other
+ * orientation (e.g. dorsal, palmar, rostral, etc.) the function returns
+ * `undefined`, signalling that the caller should fall back to an identity
+ * direction matrix.
+ *
+ * @param orientation - The anatomical orientation value.
+ * @returns A 3-element unit direction column vector `[lps_x, lps_y, lps_z]`,
+ *   or `undefined` if the orientation is not one of the six LPS-compatible
+ *   values.
+ */
+export function anatomicalOrientationToItkDirection(
+  orientation: AnatomicalOrientationValues,
+): number[] | undefined {
+  for (
+    let axisIndex = 0;
+    axisIndex < LPS_ORIENTATION_PAIRS.length;
+    axisIndex++
+  ) {
+    const [pos, neg] = LPS_ORIENTATION_PAIRS[axisIndex];
+    if (orientation === pos) {
+      const col = [0, 0, 0];
+      col[axisIndex] = 1;
+      return col;
+    }
+    if (orientation === neg) {
+      const col = [0, 0, 0];
+      col[axisIndex] = -1;
+      return col;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Check if RFC 4 is enabled in the list of enabled RFCs.
  */
 export function isRfc4Enabled(enabledRfcs?: number[]): boolean {

--- a/ts/test/ngff_image_to_itk_image_test.ts
+++ b/ts/test/ngff_image_to_itk_image_test.ts
@@ -10,6 +10,17 @@ import {
 } from "itk-wasm";
 import { ngffImageToItkImage } from "../src/io/ngff_image_to_itk_image.ts";
 import { itkImageToNgffImage } from "../src/io/itk_image_to_ngff_image.ts";
+import {
+  AnatomicalOrientationValues,
+  createAnatomicalOrientation,
+  LPS,
+  RAS,
+} from "../src/types/rfc4.ts";
+import { NgffImage } from "../src/types/ngff_image.ts";
+import * as zarr from "zarrita";
+import { defaultCodecs } from "../src/utils/codecs.ts";
+import { zarrSet } from "../src/utils/worker_pool.ts";
+import { _zarrita_internal_get_strides as getStrides } from "zarrita";
 
 // Basic test to verify function is exportable
 Deno.test("ngffImageToItkImage function exports", async () => {
@@ -374,5 +385,225 @@ Deno.test("ngffImageToItkImage metadata preservation", async () => {
   const expectedDirection = new Float64Array([1, 0, 0, 1]);
   for (let i = 0; i < expectedDirection.length; i++) {
     assertEquals(reconvertedItkImage.direction[i], expectedDirection[i]);
+  }
+});
+
+// --- Tests for direction matrix from anatomical orientation ---
+
+/**
+ * Helper to create a simple 3D NgffImage backed by a zarr array.
+ */
+async function createTestNgffImage(
+  shape: number[],
+  dims: string[],
+  axesOrientations?: Record<
+    string,
+    { readonly type: "anatomical"; readonly value: AnatomicalOrientationValues }
+  >,
+): Promise<NgffImage> {
+  const store = new Map<string, Uint8Array>();
+  const root = zarr.root(store);
+  const chunkShape = shape.map((s) => Math.min(s, 256));
+
+  const zarrArray = await zarr.create(root.resolve("test"), {
+    shape,
+    chunk_shape: chunkShape,
+    data_type: "uint8",
+    fill_value: 0,
+    codecs: defaultCodecs("uint8"),
+  });
+
+  const totalSize = shape.reduce((a, b) => a * b, 1);
+  const data = new Uint8Array(totalSize);
+  const selection = new Array(shape.length).fill(null);
+  const chunk = {
+    data,
+    shape,
+    stride: getStrides(shape, "C"),
+  };
+  await zarrSet(zarrArray, selection, chunk);
+
+  const scale: Record<string, number> = {};
+  const translation: Record<string, number> = {};
+  for (const d of dims) {
+    scale[d] = 1.0;
+    translation[d] = 0.0;
+  }
+
+  return new NgffImage({
+    data: zarrArray,
+    dims,
+    scale,
+    translation,
+    name: "test",
+    axesUnits: undefined,
+    axesOrientations,
+    computedCallbacks: undefined,
+  });
+}
+
+Deno.test("direction matrix - without orientation → identity", async () => {
+  const ngff = await createTestNgffImage([4, 8, 8], ["z", "y", "x"]);
+  const itk = await ngffImageToItkImage(ngff);
+
+  const expected = new Float64Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+  for (let i = 0; i < expected.length; i++) {
+    assertEquals(itk.direction[i], expected[i]);
+  }
+});
+
+Deno.test("direction matrix - LPS orientation → identity", async () => {
+  const ngff = await createTestNgffImage(
+    [4, 8, 8],
+    ["z", "y", "x"],
+    LPS,
+  );
+  const itk = await ngffImageToItkImage(ngff);
+
+  const expected = new Float64Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+  for (let i = 0; i < expected.length; i++) {
+    assertEquals(itk.direction[i], expected[i]);
+  }
+});
+
+Deno.test("direction matrix - RAS orientation → flipped X/Y", async () => {
+  const ngff = await createTestNgffImage(
+    [4, 8, 8],
+    ["z", "y", "x"],
+    RAS,
+  );
+  const itk = await ngffImageToItkImage(ngff);
+
+  // RAS: X=-1, Y=-1, Z=+1
+  const expected = new Float64Array([-1, 0, 0, 0, -1, 0, 0, 0, 1]);
+  for (let i = 0; i < expected.length; i++) {
+    assertEquals(itk.direction[i], expected[i]);
+  }
+});
+
+Deno.test("direction matrix - permuted orientations", async () => {
+  const axesOrientations = {
+    x: createAnatomicalOrientation(
+      AnatomicalOrientationValues.AnteriorToPosterior,
+    ),
+    y: createAnatomicalOrientation(
+      AnatomicalOrientationValues.InferiorToSuperior,
+    ),
+    z: createAnatomicalOrientation(
+      AnatomicalOrientationValues.RightToLeft,
+    ),
+  };
+
+  const ngff = await createTestNgffImage(
+    [4, 8, 8],
+    ["z", "y", "x"],
+    axesOrientations,
+  );
+  const itk = await ngffImageToItkImage(ngff);
+
+  // itk_dims sorted = [x, y, z]
+  // col 0 (x) -> A/P -> [0, 1, 0]
+  // col 1 (y) -> I/S -> [0, 0, 1]
+  // col 2 (z) -> R/L -> [1, 0, 0]
+  const expected = new Float64Array([0, 0, 1, 1, 0, 0, 0, 1, 0]);
+  for (let i = 0; i < expected.length; i++) {
+    assertEquals(itk.direction[i], expected[i]);
+  }
+});
+
+Deno.test("direction matrix - non-LPS fallback → identity", async () => {
+  const axesOrientations = {
+    x: createAnatomicalOrientation(
+      AnatomicalOrientationValues.RightToLeft,
+    ),
+    y: createAnatomicalOrientation(
+      AnatomicalOrientationValues.DorsalToVentral,
+    ),
+    z: createAnatomicalOrientation(
+      AnatomicalOrientationValues.InferiorToSuperior,
+    ),
+  };
+
+  const ngff = await createTestNgffImage(
+    [4, 8, 8],
+    ["z", "y", "x"],
+    axesOrientations,
+  );
+  const itk = await ngffImageToItkImage(ngff);
+
+  const expected = new Float64Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+  for (let i = 0; i < expected.length; i++) {
+    assertEquals(itk.direction[i], expected[i]);
+  }
+});
+
+Deno.test("direction matrix - 2D RAS orientation", async () => {
+  const axesOrientations = {
+    x: RAS.x,
+    y: RAS.y,
+  };
+
+  const ngff = await createTestNgffImage(
+    [8, 8],
+    ["y", "x"],
+    axesOrientations,
+  );
+  const itk = await ngffImageToItkImage(ngff);
+
+  const expected = new Float64Array([-1, 0, 0, -1]);
+  for (let i = 0; i < expected.length; i++) {
+    assertEquals(itk.direction[i], expected[i]);
+  }
+});
+
+Deno.test("direction round-trip - identity preserved", async () => {
+  const originalDirection = new Float64Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+  const originalImage: ITKImage = {
+    imageType: {
+      dimension: 3,
+      componentType: "uint8" as typeof IntTypes.UInt8,
+      pixelType: "Scalar" as typeof PixelTypes.Scalar,
+      components: 1,
+    },
+    name: "test",
+    origin: [0, 0, 0],
+    spacing: [1, 1, 1],
+    direction: originalDirection,
+    size: [4, 8, 8],
+    metadata: new Map(),
+    data: new Uint8Array(4 * 8 * 8),
+  };
+
+  const ngff = await itkImageToNgffImage(originalImage);
+  const itkBack = await ngffImageToItkImage(ngff);
+
+  for (let i = 0; i < originalDirection.length; i++) {
+    assertEquals(itkBack.direction[i], originalDirection[i]);
+  }
+});
+
+Deno.test("direction round-trip - flipped Y preserved", async () => {
+  const originalDirection = new Float64Array([1, 0, 0, 0, -1, 0, 0, 0, 1]);
+  const originalImage: ITKImage = {
+    imageType: {
+      dimension: 3,
+      componentType: "uint8" as typeof IntTypes.UInt8,
+      pixelType: "Scalar" as typeof PixelTypes.Scalar,
+      components: 1,
+    },
+    name: "test",
+    origin: [0, 0, 0],
+    spacing: [1, 1, 1],
+    direction: originalDirection,
+    size: [4, 8, 8],
+    metadata: new Map(),
+    data: new Uint8Array(4 * 8 * 8),
+  };
+
+  const ngff = await itkImageToNgffImage(originalImage);
+  const itkBack = await ngffImageToItkImage(ngff);
+
+  for (let i = 0; i < originalDirection.length; i++) {
+    assertEquals(itkBack.direction[i], originalDirection[i]);
   }
 });

--- a/ts/test/rfc4_test.ts
+++ b/ts/test/rfc4_test.ts
@@ -8,6 +8,7 @@
 import { assertEquals } from "@std/assert";
 import {
   addAnatomicalOrientationToAxis,
+  anatomicalOrientationToItkDirection,
   AnatomicalOrientationValues,
   createAnatomicalOrientation,
   isRfc4Enabled,
@@ -160,4 +161,81 @@ Deno.test("RAS coordinate system - correct orientations", () => {
 
   assertEquals(RAS.z.type, "anatomical");
   assertEquals(RAS.z.value, AnatomicalOrientationValues.InferiorToSuperior);
+});
+
+// --- Tests for anatomicalOrientationToItkDirection ---
+
+Deno.test("anatomicalOrientationToItkDirection - RightToLeft → [1,0,0]", () => {
+  assertEquals(
+    anatomicalOrientationToItkDirection(
+      AnatomicalOrientationValues.RightToLeft,
+    ),
+    [1, 0, 0],
+  );
+});
+
+Deno.test("anatomicalOrientationToItkDirection - LeftToRight → [-1,0,0]", () => {
+  assertEquals(
+    anatomicalOrientationToItkDirection(
+      AnatomicalOrientationValues.LeftToRight,
+    ),
+    [-1, 0, 0],
+  );
+});
+
+Deno.test("anatomicalOrientationToItkDirection - A→P → [0,1,0]", () => {
+  assertEquals(
+    anatomicalOrientationToItkDirection(
+      AnatomicalOrientationValues.AnteriorToPosterior,
+    ),
+    [0, 1, 0],
+  );
+});
+
+Deno.test("anatomicalOrientationToItkDirection - P→A → [0,-1,0]", () => {
+  assertEquals(
+    anatomicalOrientationToItkDirection(
+      AnatomicalOrientationValues.PosteriorToAnterior,
+    ),
+    [0, -1, 0],
+  );
+});
+
+Deno.test("anatomicalOrientationToItkDirection - I→S → [0,0,1]", () => {
+  assertEquals(
+    anatomicalOrientationToItkDirection(
+      AnatomicalOrientationValues.InferiorToSuperior,
+    ),
+    [0, 0, 1],
+  );
+});
+
+Deno.test("anatomicalOrientationToItkDirection - S→I → [0,0,-1]", () => {
+  assertEquals(
+    anatomicalOrientationToItkDirection(
+      AnatomicalOrientationValues.SuperiorToInferior,
+    ),
+    [0, 0, -1],
+  );
+});
+
+Deno.test("anatomicalOrientationToItkDirection - non-LPS returns undefined", () => {
+  assertEquals(
+    anatomicalOrientationToItkDirection(
+      AnatomicalOrientationValues.DorsalToVentral,
+    ),
+    undefined,
+  );
+  assertEquals(
+    anatomicalOrientationToItkDirection(
+      AnatomicalOrientationValues.RostralToCaudal,
+    ),
+    undefined,
+  );
+  assertEquals(
+    anatomicalOrientationToItkDirection(
+      AnatomicalOrientationValues.ProximalToDistal,
+    ),
+    undefined,
+  );
 });


### PR DESCRIPTION
## Summary

When converting between ITK images and NgffImages, the direction cosine matrix was previously lost — `ngffImageToItkImage` always produced an identity direction, and the Python `itk_image_to_ngff_image` ignored the direction matrix entirely. This PR adds bidirectional conversion between ITK direction matrices and RFC-4 anatomical orientations in both Python and TypeScript, so that cardinal axis-aligned directions survive a full ITK → NgffImage → ITK round-trip.

## Changes

### New functions in `rfc4` (both packages)

- **`anatomicalOrientationToItkDirection`** / **`anatomical_orientation_to_itk_direction`** — converts an anatomical orientation enum value back to a 3-element unit direction cosine vector in ITK LPS space. Returns `None`/`undefined` for non-LPS orientations (dorsal, palmar, rostral, etc.), signalling the caller should fall back to identity.

- **`itk_direction_to_anatomical_orientation`** (Python only, new) — determines the anatomical orientation from a direction cosine column vector by finding the dominant component. The TypeScript equivalent (`itkDirectionToAnatomicalOrientation`) already existed.

### Updated conversions

- **`ngffImageToItkImage`** (both packages) — now reads `axesOrientations` from the NgffImage and constructs the direction matrix from orientation metadata. Falls back to identity when orientations are absent, incomplete, or non-LPS.

- **`itk_image_to_ngff_image`** (Python) — now extracts the ITK direction matrix and converts each column to an anatomical orientation using `itk_direction_to_anatomical_orientation`. Previously it unconditionally assigned LPS defaults regardless of the actual direction. Falls back to LPS labels for identity directions.

### Tests

- **Python `test_rfc4.py`** — 11 new tests for `itk_direction_to_anatomical_orientation` (6 cardinal axes, 2 oblique, 2 for 2D, 1 error case) and 7 tests for `anatomical_orientation_to_itk_direction` (6 LPS + non-LPS returns None).
- **Python `test_ngff_image_to_itk_image.py`** — 8 new integration tests: identity, LPS, RAS, permuted axes, non-LPS fallback, 2D, and two round-trip tests (identity and flipped-Y).
- **TypeScript `rfc4_test.ts`** — 8 new unit tests for `anatomicalOrientationToItkDirection`.
- **TypeScript `ngff_image_to_itk_image_test.ts`** — 8 new integration tests mirroring the Python ones.

## Implementation details

- The reverse mapping is inherently lossy for oblique directions (which are approximated to the nearest cardinal axis by the forward mapping), but round-trips perfectly for all axis-aligned directions.
- Only the 6 LPS-compatible orientations map to direction vectors. Non-LPS orientations cause a graceful fallback to identity for the entire image.
- Both packages share the same `_LPS_ORIENTATION_PAIRS` / `LPS_ORIENTATION_PAIRS` data structure for forward and reverse mapping.
- `itk_dims` / `sortedItkDims` are in ITK physical-space order `[x, y, z]`; column *j* of the direction matrix corresponds to axis *j*.