### PR TITLE
fix(py): correctly calculate regions in to_ngff_zarr

### DIFF
--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -935,8 +935,8 @@ def _compute_write_regions(
             else:
                 region = [slice(arr.shape[i]) for i in range(arr.ndim)]
                 region[z_index] = slice(
-                    slab_index * z_chunks,
-                    min((slab_index + 1) * z_chunks, arr.shape[z_index]),
+                    slab_index * slab_slices,
+                    min((slab_index + 1) * slab_slices, arr.shape[z_index]),
                 )
                 regions.append(tuple(region))
     else:


### PR DESCRIPTION
Create correct slice number to write all Z planes in _compute_write_regions. Multiply slab_index with z_chunk previusly doesn't write all planeson image without slice_planes variable and with larger z_index that slab_slice. write Z with slab_slice always create regions according to Z dimension.