### PR TITLE
ci: specify tls version for curl fetch

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install pip if missing
         shell: bash
         run: |
-          curl https://bootstrap.pypa.io/get-pip.py -o "$RUNNER_TEMP/get-pip.py"
+          curl --retry-all-errors --retry 3 --tlsv1.2 https://bootstrap.pypa.io/get-pip.py -o "$RUNNER_TEMP/get-pip.py"
           python -m ensurepip --upgrade || python "$RUNNER_TEMP/get-pip.py"
 
       - name: Install dependencies


### PR DESCRIPTION
Attempt to address macos-15-intel build failure.

  curl https://bootstrap.pypa.io/get-pip.py -o "$RUNNER_TEMP/get-pip.py"
3
  python -m ensurepip --upgrade || python "$RUNNER_TEMP/get-pip.py"
4
  shell: /bin/bash --noprofile --norc -e -o pipefail {0}
5
  env:
6
    pythonLocation: /Users/runner/hostedtoolcache/Python/3.13.12/x64
7
    PKG_CONFIG_PATH: /Users/runner/hostedtoolcache/Python/3.13.12/x64/lib/pkgconfig
8
    Python_ROOT_DIR: /Users/runner/hostedtoolcache/Python/3.13.12/x64
9
    Python2_ROOT_DIR: /Users/runner/hostedtoolcache/Python/3.13.12/x64
10
    Python3_ROOT_DIR: /Users/runner/hostedtoolcache/Python/3.13.12/x64
11
  % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
12
                                 Dload  Upload  Total   Spent   Left   Speed
13

14
  0      0   0      0   0      0      0      0                              0
15
curl: (56) OpenSSL SSL_read: OpenSSL/3.6.1: error:0A000119:SSL routines::decryption failed or bad record mac, errno 0
