### PR TITLE
docs: add `CLAUDE.md` shim that delegates to `AGENTS.md`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Context
+
+This project's primary agent spec is in `AGENTS.md` at the repo root.
+
+@AGENTS.md


### PR DESCRIPTION
Claude Code expects a `CLAUDE.md` entrypoint, but this repo already
standardizes on a single root‐level `AGENTS.md` for all agent
instructions. Note that the new `CLAUDE.md` is intentionally minimal and
just forwards Claude to `AGENTS.md` (via an explicit reference) so that:

- `AGENTS.md` remains the canonical, editor‑agnostic source of truth
- Claude Code and other CLAUDE.md‑aware tools still "just work"
- We avoid fragile symlink hacks and keep behavior consistent across platforms and CLIs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added reference documentation to guide users toward the repository's agent specification resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->