### PR TITLE
feat(py,ts): rename public API to use ome_zarr naming convention

### DIFF
--- a/mcp/ngff_zarr_mcp/tools.py
+++ b/mcp/ngff_zarr_mcp/tools.py
@@ -10,7 +10,7 @@ from ngff_zarr import (  # type: ignore[import-untyped]
     Methods,
     cli_input_to_ngff_image,
     detect_cli_io_backend,
-    from_ngff_zarr,
+    from_ome_zarr,
     to_multiscales,
     to_ome_zarr,
 )
@@ -79,7 +79,7 @@ async def convert_to_ome_zarr(
                 # Check if it's a zarr store URL by trying to load it
                 try:
                     # Try to read as zarr store first
-                    multiscales = from_ngff_zarr(input_path)
+                    multiscales = from_ome_zarr(input_path)
 
                     # If successful, we have a zarr store input
                     # We'll work with the multiscales directly and apply transformations
@@ -269,7 +269,7 @@ async def read_ngff_zarr(
     """
     try:
         # Read the multiscales
-        multiscales = from_ngff_zarr(store_path, validate=validate)
+        multiscales = from_ome_zarr(store_path, validate=validate)
 
         # Analyze the store
         store_info = analyze_zarr_store(store_path)
@@ -342,8 +342,8 @@ async def validate_ome_zarr(store_path: str) -> ValidationResult:
 
         # Try to load as NGFF
         try:
-            # Use store_path directly - from_ngff_zarr can handle strings
-            multiscales = from_ngff_zarr(store_path)
+            # Use store_path directly - from_ome_zarr can handle strings
+            multiscales = from_ome_zarr(store_path)
 
             # Basic validation checks
             if len(multiscales.images) == 0:
@@ -407,7 +407,7 @@ async def optimize_zarr_store(options: OptimizationOptions) -> ConversionResult:
             )
 
         # Load multiscales
-        multiscales = from_ngff_zarr(str(input_path))
+        multiscales = from_ome_zarr(str(input_path))
 
         # Setup output store
         output_path = Path(options.output_path)

--- a/mcp/ngff_zarr_mcp/tools.py
+++ b/mcp/ngff_zarr_mcp/tools.py
@@ -12,7 +12,7 @@ from ngff_zarr import (  # type: ignore[import-untyped]
     detect_cli_io_backend,
     from_ngff_zarr,
     to_multiscales,
-    to_ngff_zarr,
+    to_ome_zarr,
 )
 
 # Import validation function if available
@@ -215,7 +215,7 @@ async def convert_to_ome_zarr(
             #     # Remove duplicates
             #     enabled_rfcs = list(set(enabled_rfcs))
 
-            to_ngff_zarr(
+            to_ome_zarr(
                 output_store,
                 multiscales_obj,
                 version=options.ome_zarr_version,
@@ -442,7 +442,7 @@ async def optimize_zarr_store(options: OptimizationOptions) -> ConversionResult:
             optimized_images.append(optimized_image)
 
         # Create new multiscales object with optimized images
-        # For now, use the original multiscales and rely on to_ngff_zarr to handle optimization
+        # For now, use the original multiscales and rely on to_ome_zarr to handle optimization
         # This preserves metadata and compatibility
         optimized_multiscales = multiscales  # type: ignore[assignment]
 
@@ -455,7 +455,7 @@ async def optimize_zarr_store(options: OptimizationOptions) -> ConversionResult:
                 chunks_per_shard = tuple(chunks_per_shard)
 
         # Save optimized store
-        to_ngff_zarr(
+        to_ome_zarr(
             output_store,
             optimized_multiscales,
             chunks_per_shard=chunks_per_shard,

--- a/mcp/ngff_zarr_mcp/utils.py
+++ b/mcp/ngff_zarr_mcp/utils.py
@@ -12,7 +12,7 @@ import httpx
 import zarr
 from ngff_zarr import (  # type: ignore[import-untyped]
     config,
-    from_ngff_zarr,
+    from_ome_zarr,
 )
 
 # Import unit validation function
@@ -116,7 +116,7 @@ def analyze_zarr_store(store_path: str) -> StoreInfo:
 
         # Load multiscales
         try:
-            multiscales = from_ngff_zarr(store)
+            multiscales = from_ome_zarr(store)
         except ValueError as e:
             if "path" in str(e) and "FSMap" in str(e):
                 # Handle zarr v3 FSMap issue by using zarr v2 for remote stores
@@ -125,7 +125,7 @@ def analyze_zarr_store(store_path: str) -> StoreInfo:
                 if store_path.startswith(("http://", "https://")):
                     try:
                         store_v2 = zarr.open(store, mode="r")
-                        multiscales = from_ngff_zarr(store_v2.store)
+                        multiscales = from_ome_zarr(store_v2.store)
                     except KeyError as ke:
                         if str(ke) == "'start'":
                             # Handle OMERO metadata compatibility issue for remote stores

--- a/py/ngff_zarr/__init__.py
+++ b/py/ngff_zarr/__init__.py
@@ -63,7 +63,7 @@ from .tiff_to_ngff_image import (
 )
 from .to_multiscales import to_multiscales
 from .to_ngff_image import to_ngff_image
-from .to_ngff_zarr import ScaleStrategy, to_ngff_zarr
+from .to_ngff_zarr import ScaleStrategy, to_ngff_zarr, to_ome_zarr
 from .v04.zarr_metadata import (
     AxesType,
     Axis,
@@ -112,6 +112,7 @@ __all__ = [
     "task_count",
     "to_multiscales",
     "Methods",
+    "to_ome_zarr",
     "to_ngff_zarr",
     "ScaleStrategy",
     "from_ngff_zarr",

--- a/py/ngff_zarr/__init__.py
+++ b/py/ngff_zarr/__init__.py
@@ -14,7 +14,7 @@ from .compute_omero import (
 )
 from .config import config
 from .detect_cli_io_backend import ConversionBackend, detect_cli_io_backend
-from .from_ngff_zarr import from_ngff_zarr
+from .from_ngff_zarr import from_ngff_zarr, from_ome_zarr
 from .hcs import (
     HCSPlate,
     HCSPlateWriter,
@@ -115,6 +115,7 @@ __all__ = [
     "to_ome_zarr",
     "to_ngff_zarr",
     "ScaleStrategy",
+    "from_ome_zarr",
     "from_ngff_zarr",
     "detect_cli_io_backend",
     "ConversionBackend",

--- a/py/ngff_zarr/cli.py
+++ b/py/ngff_zarr/cli.py
@@ -43,7 +43,7 @@ from .detect_cli_io_backend import (
     conversion_backends_values,
     detect_cli_io_backend,
 )
-from .from_ngff_zarr import from_ngff_zarr
+from .from_ngff_zarr import from_ome_zarr
 from .methods import Methods, methods_values
 from .ngff_image_to_itk_image import ngff_image_to_itk_image
 from .rich_dask_progress import NgffProgress, NgffProgressCallback
@@ -780,8 +780,8 @@ def main():
             sys.exit(1)
 
         if input_backend is ConversionBackend.NGFF_ZARR:
-            # Pass the path directly to from_ngff_zarr to let it handle .ozx files
-            multiscales = from_ngff_zarr(args.input[0])
+            # Pass the path directly to from_ome_zarr to let it handle .ozx files
+            multiscales = from_ome_zarr(args.input[0])
             _multiscales_to_ngff_zarr(
                 live,
                 args,

--- a/py/ngff_zarr/cli.py
+++ b/py/ngff_zarr/cli.py
@@ -48,7 +48,7 @@ from .methods import Methods, methods_values
 from .ngff_image_to_itk_image import ngff_image_to_itk_image
 from .rich_dask_progress import NgffProgress, NgffProgressCallback
 from .to_multiscales import to_multiscales
-from .to_ngff_zarr import to_ngff_zarr
+from .to_ngff_zarr import to_ome_zarr
 from .v04.zarr_metadata import Omero, OmeroChannel, OmeroWindow, is_unit_supported
 
 
@@ -201,7 +201,7 @@ def _multiscales_to_ngff_zarr(
 
         codec_kwargs["compressor"] = codec_from_name(args.codec, args.compression_level)
 
-    to_ngff_zarr(
+    to_ome_zarr(
         output_store,
         multiscales,
         chunks_per_shard=chunks_per_shard,

--- a/py/ngff_zarr/cli_input_to_ngff_image.py
+++ b/py/ngff_zarr/cli_input_to_ngff_image.py
@@ -8,7 +8,7 @@ from dask.array.image import imread as daimread
 from rich import print
 
 from .detect_cli_io_backend import ConversionBackend
-from .from_ngff_zarr import from_ngff_zarr
+from .from_ngff_zarr import from_ome_zarr
 from .itk_image_to_ngff_image import itk_image_to_ngff_image
 from .ngff_image import NgffImage
 from .nibabel_image_to_ngff_image import nibabel_image_to_ngff_image
@@ -19,7 +19,7 @@ def cli_input_to_ngff_image(
     backend: ConversionBackend, input, output_scale: int = 0
 ) -> NgffImage:
     if backend is ConversionBackend.NGFF_ZARR:
-        multiscales = from_ngff_zarr(input[0])
+        multiscales = from_ome_zarr(input[0])
         return multiscales.images[output_scale]
     if backend is ConversionBackend.ZARR_ARRAY:
         arr = zarr.open_array(input[0], mode="r")

--- a/py/ngff_zarr/from_ngff_zarr.py
+++ b/py/ngff_zarr/from_ngff_zarr.py
@@ -17,7 +17,7 @@ zarr_version_major = zarr_version.major
 REMOTE_URL_SCHEMES = ("s3://", "gs://", "azure://", "http://", "https://")
 
 
-def from_ngff_zarr(
+def from_ome_zarr(
     store: StoreLike,
     validate: bool = False,
     version: str | None = None,
@@ -151,7 +151,7 @@ def from_ngff_zarr(
                 f"with {len(plate.metadata.wells)} wells. "
                 f"To convert a specific well/image, provide the full path including well and field:\n"
                 f"  Examples: {examples_str}\n"
-                f"For programmatic access to the full plate, use from_hcs_zarr() instead of from_ngff_zarr()."
+                f"For programmatic access to the full plate, use from_hcs_zarr() instead of from_ome_zarr()."
             )
         except ValueError:
             # Re-raise ValueError (from our error message above)
@@ -162,7 +162,7 @@ def from_ngff_zarr(
                 "The input appears to be an HCS (High Content Screening) plate structure, "
                 "which contains multiple wells and images. To convert a specific well/image, "
                 "provide the full path including well and field (e.g., 'plate.zarr/A/1/0' for well A1, field 0). "
-                "For programmatic access to the full plate, use from_hcs_zarr() instead of from_ngff_zarr()."
+                "For programmatic access to the full plate, use from_hcs_zarr() instead of from_ome_zarr()."
             ) from None
 
     # Check if this is a bioformats2raw container layout
@@ -258,3 +258,7 @@ def from_ngff_zarr(
     metadata_obj.metadata = method_metadata
 
     return NgffMultiscales(images, metadata_obj, method=method)
+
+
+#: Backwards-compatible alias for :func:`from_ome_zarr`.
+from_ngff_zarr = from_ome_zarr

--- a/py/ngff_zarr/hcs.py
+++ b/py/ngff_zarr/hcs.py
@@ -27,7 +27,7 @@ from packaging import version as pkg_version
 from .from_ngff_zarr import from_ngff_zarr
 from .multiscales import NgffMultiscales
 from .rfc9_zip import is_ozx_path, write_store_to_zip
-from .to_ngff_zarr import to_ngff_zarr
+from .to_ngff_zarr import to_ome_zarr
 from .v04.zarr_metadata import (
     Plate,
     PlateAcquisition,
@@ -557,7 +557,7 @@ def to_hcs_zarr(plate: HCSPlate, store) -> None:
 
     # Note: This is a basic implementation that sets up the plate structure.
     # In a full implementation, you would also write the well groups and
-    # their associated image data using the existing to_ngff_zarr functions.
+    # their associated image data using the existing to_ome_zarr functions.
     # This requires integration with the NgffMultiscales data structure.
 
     logging.info(f"HCS plate structure created at {store}")
@@ -734,7 +734,7 @@ class HCSPlateWriter:
         well_metadata : Well, optional
             Well-level metadata. If None, will be created automatically.
         **kwargs
-            Additional arguments passed to to_ngff_zarr.
+            Additional arguments passed to to_ome_zarr.
         """
         # Determine which store to write to
         working_store = self._temp_store if self.is_ozx else self.final_store
@@ -794,7 +794,7 @@ def write_hcs_well_image(
     version : str, optional
         OME-Zarr specification version (default: "0.4").
     **kwargs
-        Additional arguments passed to to_ngff_zarr.
+        Additional arguments passed to to_ome_zarr.
 
     Examples
     --------
@@ -956,7 +956,7 @@ def write_hcs_well_image(
         field_store_path.mkdir(parents=True, exist_ok=True)
 
         # Write multiscales data directly to the field path
-        to_ngff_zarr(
+        to_ome_zarr(
             store=str(field_store_path),
             multiscales=multiscales,
             version=version,
@@ -972,7 +972,7 @@ def write_hcs_well_image(
                 from zarr.storage import StorePath
 
                 store_path = StorePath(store) / field_path
-                to_ngff_zarr(
+                to_ome_zarr(
                     store=store_path,
                     multiscales=multiscales,
                     version=version,

--- a/py/ngff_zarr/hcs.py
+++ b/py/ngff_zarr/hcs.py
@@ -24,7 +24,7 @@ from typing import Optional
 import zarr
 from packaging import version as pkg_version
 
-from .from_ngff_zarr import from_ngff_zarr
+from .from_ngff_zarr import from_ome_zarr
 from .multiscales import NgffMultiscales
 from .rfc9_zip import is_ozx_path, write_store_to_zip
 from .to_ngff_zarr import to_ome_zarr
@@ -294,18 +294,18 @@ class HCSWell:
                 from zarr.storage import StorePath
 
                 store_path = StorePath(self.store, path=image_path)
-                self._images[image_path] = from_ngff_zarr(store_path)
+                self._images[image_path] = from_ome_zarr(store_path)
             elif isinstance(self.store, (str, Path)):
                 # If store is a path string, append the image path
                 full_image_path = Path(self.store) / self.path / image_meta.path
-                self._images[image_path] = from_ngff_zarr(str(full_image_path))
+                self._images[image_path] = from_ome_zarr(str(full_image_path))
             else:
                 # For other store types, try StorePath approach
                 try:
                     from zarr.storage import StorePath
 
                     store_path = StorePath(self.store, path=image_path)
-                    self._images[image_path] = from_ngff_zarr(store_path)
+                    self._images[image_path] = from_ome_zarr(store_path)
                 except (ImportError, Exception):
                     # Fallback: try to convert to path
                     if hasattr(self.store, "path"):
@@ -313,7 +313,7 @@ class HCSWell:
                     else:
                         base_path = str(self.store)
                     full_image_path = Path(base_path) / self.path / image_meta.path
-                    self._images[image_path] = from_ngff_zarr(str(full_image_path))
+                    self._images[image_path] = from_ome_zarr(str(full_image_path))
 
         return self._images[image_path]
 

--- a/py/ngff_zarr/multiscales.py
+++ b/py/ngff_zarr/multiscales.py
@@ -24,6 +24,16 @@ class NgffMultiscales:
         | None
     ) = None
 
+    def to_ome_zarr(self, store, **kwargs) -> None:
+        """Write this multiscale image to an OME-Zarr store.
+
+        Convenience method that delegates to :func:`ngff_zarr.to_ome_zarr`.
+        See that function for full parameter documentation.
+        """
+        from .to_ngff_zarr import to_ome_zarr
+
+        to_ome_zarr(store, self, **kwargs)
+
 
 # Backwards-compatible alias
 Multiscales = NgffMultiscales

--- a/py/ngff_zarr/multiscales.py
+++ b/py/ngff_zarr/multiscales.py
@@ -1,9 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
 # SPDX-License-Identifier: MIT
+from __future__ import annotations
+
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
+from ._zarr_types import StoreLike
 from .methods import Methods
 from .ngff_image import NgffImage
 from .v04.zarr_metadata import Metadata as Metadata_v04
@@ -24,7 +27,7 @@ class NgffMultiscales:
         | None
     ) = None
 
-    def to_ome_zarr(self, store, **kwargs) -> None:
+    def to_ome_zarr(self, store: StoreLike, **kwargs: Any) -> None:
         """Write this multiscale image to an OME-Zarr store.
 
         Convenience method that delegates to :func:`ngff_zarr.to_ome_zarr`.
@@ -33,6 +36,17 @@ class NgffMultiscales:
         from .to_ngff_zarr import to_ome_zarr
 
         to_ome_zarr(store, self, **kwargs)
+
+    @classmethod
+    def from_ome_zarr(cls, store: StoreLike, **kwargs: Any) -> NgffMultiscales:
+        """Read an OME-Zarr store into a NgffMultiscales object.
+
+        Convenience classmethod that delegates to :func:`ngff_zarr.from_ome_zarr`.
+        See that function for full parameter documentation.
+        """
+        from .from_ngff_zarr import from_ome_zarr
+
+        return from_ome_zarr(store, **kwargs)
 
 
 # Backwards-compatible alias

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -1320,7 +1320,7 @@ def _prepare_next_scale(
     return multiscales.images[index + 1]
 
 
-def to_ngff_zarr(
+def to_ome_zarr(
     store: StoreLike,
     multiscales: NgffMultiscales,
     version: str = "0.5",
@@ -1458,6 +1458,10 @@ def to_ngff_zarr(
         scale_strategy=scale_strategy,
         **kwargs,
     )
+
+
+#: Backwards-compatible alias for :func:`to_ome_zarr`.
+to_ngff_zarr = to_ome_zarr
 
 
 def _to_ngff_zarr_impl(

--- a/py/test/test_hcs_zarr_format.py
+++ b/py/test/test_hcs_zarr_format.py
@@ -206,7 +206,7 @@ def test_to_hcs_zarr_legacy_zarr_version(
 
 @patch("ngff_zarr.hcs.zarr.open_group")
 @patch("ngff_zarr.hcs.pkg_version.parse")
-@patch("ngff_zarr.hcs.to_ngff_zarr")
+@patch("ngff_zarr.hcs.to_ome_zarr")
 @patch("pathlib.Path.mkdir")
 def test_write_hcs_well_image_zarr_format_v04(
     mock_mkdir,
@@ -249,7 +249,7 @@ def test_write_hcs_well_image_zarr_format_v04(
 
 @patch("ngff_zarr.hcs.zarr.open_group")
 @patch("ngff_zarr.hcs.pkg_version.parse")
-@patch("ngff_zarr.hcs.to_ngff_zarr")
+@patch("ngff_zarr.hcs.to_ome_zarr")
 @patch("pathlib.Path.mkdir")
 def test_write_hcs_well_image_zarr_format_v05(
     mock_mkdir,

--- a/py/test/test_multiscales_convenience.py
+++ b/py/test/test_multiscales_convenience.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+import sys
+from unittest.mock import MagicMock, patch
+
+# In ngff_zarr/__init__.py, function names `to_ngff_zarr` and `from_ngff_zarr`
+# shadow the submodule names.  ``import ngff_zarr.to_ngff_zarr as X`` resolves
+# ``X = ngff_zarr.to_ngff_zarr`` via attribute lookup on the package, which
+# returns the *function*, not the *module*.  Use sys.modules to obtain the
+# actual module objects so that patch.object works on all Python versions.
+import ngff_zarr.from_ngff_zarr  # force module into sys.modules
+import ngff_zarr.to_ngff_zarr  # noqa: F401 - force module into sys.modules
+from ngff_zarr import Multiscales
+
+to_ngff_zarr_mod = sys.modules["ngff_zarr.to_ngff_zarr"]
+from_ngff_zarr_mod = sys.modules["ngff_zarr.from_ngff_zarr"]
+
+
+def test_to_ome_zarr_delegates(tmp_path):
+    """Test that Multiscales.to_ome_zarr delegates to ngff_zarr.to_ome_zarr."""
+    ms = MagicMock(spec=Multiscales)
+    store = str(tmp_path / "out.zarr")
+
+    with patch.object(to_ngff_zarr_mod, "to_ome_zarr") as mock_to:
+        Multiscales.to_ome_zarr(ms, store, version="0.4", overwrite=False)
+        mock_to.assert_called_once_with(store, ms, version="0.4", overwrite=False)
+
+
+def test_from_ome_zarr_delegates(tmp_path):
+    """Test that Multiscales.from_ome_zarr delegates to ngff_zarr.from_ome_zarr."""
+    store = str(tmp_path / "in.zarr")
+    sentinel = MagicMock(spec=Multiscales)
+
+    with patch.object(
+        from_ngff_zarr_mod, "from_ome_zarr", return_value=sentinel
+    ) as mock_from:
+        result = Multiscales.from_ome_zarr(store, version="0.5")
+        mock_from.assert_called_once_with(store, version="0.5")
+        assert result is sentinel

--- a/ts/src/browser-mod.ts
+++ b/ts/src/browser-mod.ts
@@ -41,6 +41,10 @@ export {
   type ToNgffZarrOptions,
   toNgffZarrOzx,
   type ToNgffZarrOzxOptions,
+  toOmeZarr,
+  type ToOmeZarrOptions,
+  toOmeZarrOzx,
+  type ToOmeZarrOzxOptions,
 } from "./io/to_ngff_zarr-browser.ts";
 // Browser-compatible processing modules
 export * from "./process/to_multiscales-browser.ts";

--- a/ts/src/browser-mod.ts
+++ b/ts/src/browser-mod.ts
@@ -14,6 +14,8 @@ export {
   type ChunkCache,
   fromNgffZarr,
   type FromNgffZarrOptions,
+  fromOmeZarr,
+  type FromOmeZarrOptions,
   type MemoryStore,
 } from "./io/from_ngff_zarr-browser.ts";
 // ITK-Wasm conversion utilities

--- a/ts/src/io/from_ngff_zarr-browser.ts
+++ b/ts/src/io/from_ngff_zarr-browser.ts
@@ -13,7 +13,7 @@ import { extractMethodMetadata } from "../utils/parse_metadata.ts";
 
 export type { ChunkCache } from "../utils/worker_pool.ts";
 
-export interface FromNgffZarrOptions {
+export interface FromOmeZarrOptions {
   /** Enable schema validation of OME-Zarr metadata. */
   validate?: boolean;
   /** Expected OME-Zarr version. */
@@ -29,17 +29,20 @@ export interface FromNgffZarrOptions {
   cache?: import("../utils/worker_pool.ts").ChunkCache;
 }
 
+/** @deprecated Use {@link FromOmeZarrOptions} instead. */
+export type FromNgffZarrOptions = FromOmeZarrOptions;
+
 export type MemoryStore = Map<string, Uint8Array>;
 
 /**
- * Browser-compatible version of fromNgffZarr.
+ * Browser-compatible version of fromOmeZarr.
  * Supports HTTP/HTTPS URLs, MemoryStore (Map), FetchStore, and any
  * zarrita-compatible Readable store (e.g. TiffStore from @fideus-labs/fiff).
  * Does NOT support local file paths (use the full version in Node.js/Deno).
  */
-export async function fromNgffZarr(
+export async function fromOmeZarr(
   store: string | MemoryStore | zarr.FetchStore | zarr.Readable,
-  options: FromNgffZarrOptions = {},
+  options: FromOmeZarrOptions = {},
 ): Promise<NgffMultiscales> {
   const validate = options.validate ?? false;
   const version = options.version;
@@ -268,3 +271,6 @@ export async function fromNgffZarr(
     );
   }
 }
+
+/** @deprecated Use {@link fromOmeZarr} instead. */
+export const fromNgffZarr = fromOmeZarr;

--- a/ts/src/io/from_ngff_zarr.ts
+++ b/ts/src/io/from_ngff_zarr.ts
@@ -16,7 +16,7 @@ import { zarrGet } from "../utils/worker_pool.ts";
 
 export type { ChunkCache } from "../utils/worker_pool.ts";
 
-export interface FromNgffZarrOptions {
+export interface FromOmeZarrOptions {
   /** Enable schema validation of OME-Zarr metadata. */
   validate?: boolean;
   /** Expected OME-Zarr version. */
@@ -32,12 +32,15 @@ export interface FromNgffZarrOptions {
   cache?: import("../utils/worker_pool.ts").ChunkCache;
 }
 
+/** @deprecated Use {@link FromOmeZarrOptions} instead. */
+export type FromNgffZarrOptions = FromOmeZarrOptions;
+
 export type MemoryStore = Map<string, Uint8Array>;
 
-export async function fromNgffZarr(
+export async function fromOmeZarr(
   // Also accepts FileSystemStore, ZipFileStore, or any zarrita Readable store
   store: string | MemoryStore | zarr.FetchStore | zarr.Readable,
-  options: FromNgffZarrOptions = {},
+  options: FromOmeZarrOptions = {},
 ): Promise<NgffMultiscales> {
   const validate = options.validate ?? false;
   const requestedVersion = options.version;
@@ -172,6 +175,9 @@ export async function fromNgffZarr(
     );
   }
 }
+
+/** @deprecated Use {@link fromOmeZarr} instead. */
+export const fromNgffZarr = fromOmeZarr;
 
 export async function readArrayData(
   storePath: string,

--- a/ts/src/io/to_ngff_zarr-browser.ts
+++ b/ts/src/io/to_ngff_zarr-browser.ts
@@ -27,7 +27,7 @@ export interface ToOmeZarrOptions {
   codecs?: ZarrCodec[];
 }
 
-/** Backwards-compatible alias for {@link ToOmeZarrOptions}. */
+/** @deprecated Use {@link ToOmeZarrOptions} instead. */
 export type ToNgffZarrOptions = ToOmeZarrOptions;
 
 /**
@@ -49,7 +49,7 @@ export interface ToOmeZarrOzxOptions {
     | undefined;
 }
 
-/** Backwards-compatible alias for {@link ToOmeZarrOzxOptions}. */
+/** @deprecated Use {@link ToOmeZarrOzxOptions} instead. */
 export type ToNgffZarrOzxOptions = ToOmeZarrOzxOptions;
 
 /**
@@ -154,7 +154,7 @@ export async function toOmeZarr(
   }
 }
 
-/** Backwards-compatible alias for {@link toOmeZarr}. */
+/** @deprecated Use {@link toOmeZarr} instead. */
 export const toNgffZarr = toOmeZarr;
 
 function _convertDtypeToZarrType(dtype: string): zarr.DataType {
@@ -542,5 +542,5 @@ export async function toOmeZarrOzx(
   return zipData;
 }
 
-/** Backwards-compatible alias for {@link toOmeZarrOzx}. */
+/** @deprecated Use {@link toOmeZarrOzx} instead. */
 export const toNgffZarrOzx = toOmeZarrOzx;

--- a/ts/src/io/to_ngff_zarr-browser.ts
+++ b/ts/src/io/to_ngff_zarr-browser.ts
@@ -15,7 +15,7 @@ import { writeNgffMultiscalesToMemoryStore } from "./to_ngff_zarr_ozx_common.ts"
 
 export { isOzxPath } from "./rfc9_zip.ts";
 
-export interface ToNgffZarrOptions {
+export interface ToOmeZarrOptions {
   overwrite?: boolean;
   version?: "0.4" | "0.5";
   chunksPerShard?: number | number[] | Record<string, number>;
@@ -27,11 +27,14 @@ export interface ToNgffZarrOptions {
   codecs?: ZarrCodec[];
 }
 
+/** Backwards-compatible alias for {@link ToOmeZarrOptions}. */
+export type ToNgffZarrOptions = ToOmeZarrOptions;
+
 /**
  * Options for writing to .ozx (RFC-9) format.
  * Note: chunksPerShard is NOT supported for .ozx files and will throw an error.
  */
-export interface ToNgffZarrOzxOptions {
+export interface ToOmeZarrOzxOptions {
   /** List of RFC numbers to enable (e.g., [4] for RFC 4 anatomical orientation) */
   enabledRfcs?: number[] | undefined;
   /**
@@ -46,15 +49,18 @@ export interface ToNgffZarrOzxOptions {
     | undefined;
 }
 
+/** Backwards-compatible alias for {@link ToOmeZarrOzxOptions}. */
+export type ToNgffZarrOzxOptions = ToOmeZarrOzxOptions;
+
 /**
- * Browser-compatible version of toNgffZarr.
+ * Browser-compatible version of toOmeZarr.
  * Only supports MemoryStore (Map) for writing.
  * Does NOT support local file paths or HTTP URLs (use the full version in Node.js/Deno).
  */
-export async function toNgffZarr(
+export async function toOmeZarr(
   store: string | MemoryStore | zarr.FetchStore,
   multiscales: NgffMultiscales,
-  options: ToNgffZarrOptions = {},
+  options: ToOmeZarrOptions = {},
 ): Promise<void> {
   const _overwrite = options.overwrite ?? true;
   const _version = options.version ?? "0.4";
@@ -147,6 +153,9 @@ export async function toNgffZarr(
     );
   }
 }
+
+/** Backwards-compatible alias for {@link toOmeZarr}. */
+export const toNgffZarr = toOmeZarr;
 
 function _convertDtypeToZarrType(dtype: string): zarr.DataType {
   // Map common numpy/LazyArray dtypes to zarrita data types
@@ -509,9 +518,9 @@ function calculateChunkStride(chunkShape: number[]): number[] {
  *
  * @see https://ngff.openmicroscopy.org/rfc/9/index.html
  */
-export async function toNgffZarrOzx(
+export async function toOmeZarrOzx(
   multiscales: NgffMultiscales,
-  _options: ToNgffZarrOzxOptions = {},
+  _options: ToOmeZarrOzxOptions = {},
 ): Promise<Uint8Array> {
   const enabledRfcs = _options.enabledRfcs;
 
@@ -532,3 +541,6 @@ export async function toNgffZarrOzx(
 
   return zipData;
 }
+
+/** Backwards-compatible alias for {@link toOmeZarrOzx}. */
+export const toNgffZarrOzx = toOmeZarrOzx;

--- a/ts/src/io/to_ngff_zarr.ts
+++ b/ts/src/io/to_ngff_zarr.ts
@@ -34,7 +34,7 @@ export interface ToOmeZarrOptions {
   codecs?: ZarrCodec[];
 }
 
-/** Backwards-compatible alias for {@link ToOmeZarrOptions}. */
+/** @deprecated Use {@link ToOmeZarrOptions} instead. */
 export type ToNgffZarrOptions = ToOmeZarrOptions;
 
 /**
@@ -56,7 +56,7 @@ export interface ToOmeZarrOzxOptions {
     | undefined;
 }
 
-/** Backwards-compatible alias for {@link ToOmeZarrOzxOptions}. */
+/** @deprecated Use {@link ToOmeZarrOzxOptions} instead. */
 export type ToNgffZarrOzxOptions = ToOmeZarrOzxOptions;
 
 /**
@@ -228,7 +228,7 @@ export async function toOmeZarr(
   }
 }
 
-/** Backwards-compatible alias for {@link toOmeZarr}. */
+/** @deprecated Use {@link toOmeZarr} instead. */
 export const toNgffZarr = toOmeZarr;
 
 function _convertDtypeToZarrType(dtype: string): zarr.DataType {
@@ -627,7 +627,7 @@ export async function toOmeZarrOzx(
   }
 }
 
-/** Backwards-compatible alias for {@link toOmeZarrOzx}. */
+/** @deprecated Use {@link toOmeZarrOzx} instead. */
 export const toNgffZarrOzx = toOmeZarrOzx;
 
 /**
@@ -668,7 +668,7 @@ export async function toOmeZarrOzxData(
   return zipData;
 }
 
-/** Backwards-compatible alias for {@link toOmeZarrOzxData}. */
+/** @deprecated Use {@link toOmeZarrOzxData} instead. */
 export const toNgffZarrOzxData = toOmeZarrOzxData;
 
 /**

--- a/ts/src/io/to_ngff_zarr.ts
+++ b/ts/src/io/to_ngff_zarr.ts
@@ -14,7 +14,7 @@ import {
   writeNgffMultiscalesToMemoryStore,
 } from "./to_ngff_zarr_ozx_common.ts";
 
-export interface ToNgffZarrOptions {
+export interface ToOmeZarrOptions {
   overwrite?: boolean;
   /**
    * OME-Zarr version to write. Defaults to "0.5" for regular Zarr files.
@@ -34,11 +34,14 @@ export interface ToNgffZarrOptions {
   codecs?: ZarrCodec[];
 }
 
+/** Backwards-compatible alias for {@link ToOmeZarrOptions}. */
+export type ToNgffZarrOptions = ToOmeZarrOptions;
+
 /**
  * Options for writing to .ozx (RFC-9) format.
  * Note: chunksPerShard is NOT supported for .ozx files and will throw an error.
  */
-export interface ToNgffZarrOzxOptions {
+export interface ToOmeZarrOzxOptions {
   /** List of RFC numbers to enable (e.g., [4] for RFC 4 anatomical orientation) */
   enabledRfcs?: number[] | undefined;
   /**
@@ -52,6 +55,9 @@ export interface ToNgffZarrOzxOptions {
     | ((completedChunks: number, totalChunks: number) => void)
     | undefined;
 }
+
+/** Backwards-compatible alias for {@link ToOmeZarrOzxOptions}. */
+export type ToNgffZarrOzxOptions = ToOmeZarrOzxOptions;
 
 /**
  * Write multiscales data to an OME-Zarr store.
@@ -69,19 +75,19 @@ export interface ToNgffZarrOzxOptions {
  * @example
  * ```typescript
  * // Writing to .ozx file - version 0.5 is used automatically
- * await toNgffZarr("output.ozx", multiscales);
+ * await toOmeZarr("output.ozx", multiscales);
  *
  * // Writing to regular zarr with version 0.5 (default)
- * await toNgffZarr("output.zarr", multiscales);
+ * await toOmeZarr("output.zarr", multiscales);
  *
  * // Writing to regular zarr with version 0.4
- * await toNgffZarr("output.zarr", multiscales, { version: "0.4" });
+ * await toOmeZarr("output.zarr", multiscales, { version: "0.4" });
  * ```
  */
-export async function toNgffZarr(
+export async function toOmeZarr(
   store: string | MemoryStore | zarr.FetchStore,
   multiscales: NgffMultiscales,
-  options: ToNgffZarrOptions = {},
+  options: ToOmeZarrOptions = {},
 ): Promise<void> {
   const _overwrite = options.overwrite ?? true;
   const _version = options.version ?? "0.5";
@@ -108,8 +114,8 @@ export async function toNgffZarr(
       );
     }
 
-    // Delegate to toNgffZarrOzx (which always uses version 0.5)
-    await toNgffZarrOzx(store, multiscales, { enabledRfcs });
+    // Delegate to toOmeZarrOzx (which always uses version 0.5)
+    await toOmeZarrOzx(store, multiscales, { enabledRfcs });
     return;
   }
 
@@ -221,6 +227,9 @@ export async function toNgffZarr(
     );
   }
 }
+
+/** Backwards-compatible alias for {@link toOmeZarr}. */
+export const toNgffZarr = toOmeZarr;
 
 function _convertDtypeToZarrType(dtype: string): zarr.DataType {
   // Map common numpy/LazyArray dtypes to zarrita data types
@@ -583,25 +592,25 @@ function calculateChunkStride(chunkShape: number[]): number[] {
  * @param path - Output .ozx file path
  * @param multiscales - NgffMultiscales data to write
  * @param options - Options for writing
- * @throws Error if called in a browser environment (use toNgffZarrOzxData instead)
+ * @throws Error if called in a browser environment (use toOmeZarrOzxData instead)
  *
  * @see https://ngff.openmicroscopy.org/rfc/9/index.html
  */
-export async function toNgffZarrOzx(
+export async function toOmeZarrOzx(
   path: string,
   multiscales: NgffMultiscales,
-  options: ToNgffZarrOzxOptions = {},
+  options: ToOmeZarrOzxOptions = {},
 ): Promise<void> {
   // Check for browser environment
   if (typeof window !== "undefined") {
     throw new Error(
-      "toNgffZarrOzx cannot write files in browser environments. " +
-        "Use toNgffZarrOzxData to get the ZIP data as Uint8Array.",
+      "toOmeZarrOzx cannot write files in browser environments. " +
+        "Use toOmeZarrOzxData to get the ZIP data as Uint8Array.",
     );
   }
 
   // Get the ZIP data
-  const zipData = await toNgffZarrOzxData(multiscales, options);
+  const zipData = await toOmeZarrOzxData(multiscales, options);
 
   // Write to file using fs module (works in both Node.js and Deno)
   try {
@@ -618,6 +627,9 @@ export async function toNgffZarrOzx(
   }
 }
 
+/** Backwards-compatible alias for {@link toOmeZarrOzx}. */
+export const toNgffZarrOzx = toOmeZarrOzx;
+
 /**
  * Create OME-Zarr .ozx ZIP data (RFC-9).
  *
@@ -631,17 +643,17 @@ export async function toNgffZarrOzx(
  *
  * @see https://ngff.openmicroscopy.org/rfc/9/index.html
  */
-export async function toNgffZarrOzxData(
+export async function toOmeZarrOzxData(
   multiscales: NgffMultiscales,
-  options: ToNgffZarrOzxOptions = {},
+  options: ToOmeZarrOzxOptions = {},
 ): Promise<Uint8Array> {
   const enabledRfcs = options.enabledRfcs;
 
   // Create a memory store to hold the zarr data
   const memoryStore: MemoryStore = new Map<string, Uint8Array>();
 
-  // Write to the memory store using existing toNgffZarr logic
-  // but we need to inline the core logic since toNgffZarr would
+  // Write to the memory store using existing toOmeZarr logic
+  // but we need to inline the core logic since toOmeZarr would
   // try to detect .ozx again
   await _writeToMemoryStore(
     memoryStore,
@@ -656,9 +668,12 @@ export async function toNgffZarrOzxData(
   return zipData;
 }
 
+/** Backwards-compatible alias for {@link toOmeZarrOzxData}. */
+export const toNgffZarrOzxData = toOmeZarrOzxData;
+
 /**
  * Internal function to write multiscales to a memory store.
- * Used by toNgffZarrOzxData to avoid recursion with toNgffZarr.
+ * Used by toOmeZarrOzxData to avoid recursion with toOmeZarr.
  */
 async function _writeToMemoryStore(
   store: MemoryStore,

--- a/ts/src/types/hcs.ts
+++ b/ts/src/types/hcs.ts
@@ -133,8 +133,8 @@ export class HCSWell {
       return cached;
     }
 
-    // Load the image using fromNgffZarr
-    const { fromNgffZarr } = await import("../io/from_ngff_zarr.ts");
+    // Load the image using fromOmeZarr
+    const { fromOmeZarr } = await import("../io/from_ngff_zarr.ts");
 
     let fullImagePath: string;
     if (typeof this.store === "string") {
@@ -147,7 +147,7 @@ export class HCSWell {
     }
 
     try {
-      const multiscales = await fromNgffZarr(fullImagePath);
+      const multiscales = await fromOmeZarr(fullImagePath);
       this._images.set(imagePath, multiscales);
       return multiscales;
     } catch (error) {


### PR DESCRIPTION
## Summary

Renames the core public API functions from `ngff_zarr` to `ome_zarr` naming across both Python and TypeScript packages, with full backwards compatibility.

- **`to_ngff_zarr` → `to_ome_zarr`** and **`toNgffZarr` → `toOmeZarr`** (write path)
- **`from_ngff_zarr` → `from_ome_zarr`** and **`fromNgffZarr` → `fromOmeZarr`** (read path)
- Add `Multiscales.to_ome_zarr()` instance method and `Multiscales.from_ome_zarr()` classmethod for convenience
- Old names retained as backwards-compatible aliases (Python) and `@deprecated` const/type aliases (TypeScript)

## Why

The OME-Zarr format is the established name in the community. Aligning the public API with `ome_zarr` naming improves discoverability and consistency with the broader ecosystem, while preserving backwards compatibility so existing code continues to work.

## Implementation details

- **Function renames**: Core functions renamed in-place (file names unchanged). Old names assigned as aliases pointing to the new functions.
- **TypeScript**: Interfaces renamed (`FromNgffZarrOptions` → `FromOmeZarrOptions`, etc.) with `@deprecated` type aliases. Functions get `@deprecated` const aliases. Both `mod.ts` (`export *`) and `browser-mod.ts` (explicit exports) updated.
- **Internal callers updated**: `cli.py`, `cli_input_to_ngff_image.py`, `hcs.py`, `mcp/tools.py`, `mcp/utils.py`, `ts/src/types/hcs.ts` all use the new names.
- **Tests left on old names**: Test files intentionally use the old aliases to validate backwards compatibility and avoid unnecessary churn.
- **Circular import prevention**: `Multiscales` methods use lazy imports to avoid circular dependencies with `to_ngff_zarr.py` and `from_ngff_zarr.py`.

## Test plan

- [x] Python: 475 tests passed, 2 skipped
- [x] MCP: 14 tests passed
- [x] TypeScript: lint + fmt clean
- [x] Pre-commit hooks (ruff, commitizen, codespell) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced `from_ome_zarr` and `to_ome_zarr` APIs with improved naming for OME-Zarr format conversion. New convenience methods added to `NgffMultiscales` class for direct format conversion.

* **Refactor**
  * Updated internal code and CLI to use the newly named conversion APIs throughout the package.

* **Backward Compatibility**
  * Legacy `from_ngff_zarr` and `to_ngff_zarr` function names maintained as aliases for existing code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->