### PR TITLE
fix(py): fix zarr v3 compression kwargs in codec CLI and large-array paths

### DIFF
--- a/mcp/pixi.lock
+++ b/mcp/pixi.lock
@@ -4660,8 +4660,8 @@ packages:
   timestamp: 1738196177597
 - pypi: ../py
   name: ngff-zarr
-  version: 0.29.0
-  sha256: eaefc08b05057164a8dc94477ea8bf6e3d713f070a71ab46c2b676bcf7e05795
+  version: 0.33.0
+  sha256: f08c4bbce4e9db3ffc521140e6693a943cc59ae002fe78df2bbab56f47da899f
   requires_dist:
   - dask[array]!=2025.12.0,!=2026.1.0,!=2026.1.1
   - importlib-resources
@@ -4725,8 +4725,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: ngff-zarr-mcp
-  version: 0.5.0
-  sha256: beaa4fba3485d1250c26e46e4968e2e3df9025e9b86e005497fa9b3eb98b7f56
+  version: 0.7.0
+  sha256: c3bb06538e82cfb5d4dbdc72b14086f8cb33af3133bf204d3597eb133361447e
   requires_dist:
   - aiofiles
   - aiohttp

--- a/py/ngff_zarr/codecs.py
+++ b/py/ngff_zarr/codecs.py
@@ -86,7 +86,7 @@ def codec_from_name(name: str, level: int | None = None) -> Any:
 
     if name == "blosc" or name.startswith("blosc:"):
         parts = name.split(":", 1)
-        cname = parts[1] if len(parts) == 2 else "lz4"
+        cname = parts[1] if len(parts) == 2 and parts[1] else "lz4"
         return numcodecs.Blosc(cname=cname, clevel=level if level is not None else 5)
 
     available = get_available_codecs()

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -664,6 +664,10 @@ def _write_array_direct(
                 v3_codec = _numcodecs_to_zarr_v3_codec(user_compressor)
                 if v3_codec is not None:
                     compression_kwargs["compressors"] = [v3_codec]
+                else:
+                    # Fallback: pass numcodecs object directly; zarr v3 can
+                    # wrap it via its numcodecs compatibility layer.
+                    compression_kwargs["compressors"] = [user_compressor]
             else:
                 # zarr format 2: pass numcodecs objects directly
                 compression_kwargs["compressors"] = [user_compressor]
@@ -929,18 +933,38 @@ def _handle_large_array_writing(
     # compression settings that were not captured by the sharding setup above.
     if not codecs_kwargs:
         user_compressor = kwargs.get("compressor")
+        user_compressors = kwargs.get("compressors")
         zarr_fmt = format_kwargs["zarr_format"]
-        if zarr_fmt == 2 and user_compressor is not None:
+        if zarr_fmt == 3:
+            from zarr.codecs.bytes import BytesCodec
+
+            if user_compressors is not None:
+                from collections.abc import Iterable as IterableABC
+
+                from zarr.abc.codec import Codec
+
+                if isinstance(user_compressors, (Codec, dict)):
+                    comp_list = [user_compressors]
+                elif isinstance(user_compressors, IterableABC):
+                    comp_list = list(user_compressors)
+                else:
+                    comp_list = [user_compressors]
+                if not any(isinstance(c, BytesCodec) for c in comp_list):
+                    comp_list = [BytesCodec()] + comp_list
+                codecs_kwargs["codecs"] = comp_list
+            elif user_compressor is not None:
+                v3_codec = _numcodecs_to_zarr_v3_codec(user_compressor)
+                if v3_codec is not None:
+                    codecs_kwargs["codecs"] = [BytesCodec(), v3_codec]
+                else:
+                    codecs_kwargs["codecs"] = [BytesCodec(), user_compressor]
+        elif zarr_fmt == 2 and user_compressor is not None:
+            # open_array() (unlike dask's create_array) accepts 'compressor'
+            # singular for format 2 even in zarr v3.
             zarr_kwargs["compressor"] = user_compressor
             user_filters = kwargs.get("filters")
             if user_filters is not None:
                 zarr_kwargs["filters"] = user_filters
-        elif zarr_fmt == 3 and user_compressor is not None:
-            from zarr.codecs.bytes import BytesCodec
-
-            v3_codec = _numcodecs_to_zarr_v3_codec(user_compressor)
-            if v3_codec is not None:
-                codecs_kwargs["codecs"] = [BytesCodec(), v3_codec]
 
     zarr_array = open_array(
         shape=arr.shape,

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -585,6 +585,23 @@ def _prepare_zarr_kwargs(to_zarr_kwargs: dict):
             to_zarr_kwargs["dimension_separator"] = "/"
             to_zarr_kwargs.pop("chunk_key_encoding", None)
 
+    # Old dask (< 2025.12) passes kwargs to zarr.create() which only accepts
+    # 'compressor' (singular).  Newer dask uses zarr.create_array() which
+    # accepts 'compressors' (plural).  We normalise here so the rest of the
+    # code can always build kwargs with the plural form for zarr v3.
+    if IS_ZARR_V3_PLUS and not DASK_SUPPORTS_SHARDING:
+        _sentinel = object()
+        compressors_val = to_zarr_kwargs.pop("compressors", _sentinel)
+        if compressors_val is not _sentinel:
+            if compressors_val is None:
+                to_zarr_kwargs["compressor"] = None
+            elif isinstance(compressors_val, (list, tuple)):
+                to_zarr_kwargs["compressor"] = (
+                    compressors_val[0] if compressors_val else None
+                )
+            else:
+                to_zarr_kwargs["compressor"] = compressors_val
+
     # New dask doesn't accept zarr_format in zarr_array_kwargs
     if DASK_SUPPORTS_SHARDING:
         to_zarr_kwargs.pop("zarr_format", None)
@@ -646,14 +663,11 @@ def _write_array_direct(
         cleaned_sharding_kwargs = sharding_kwargs
 
     # Translate user-supplied compression settings into format-appropriate kwargs.
-    # zarr v3's ``zarr.create_array`` (called by ``dask.array.to_zarr``) only
-    # accepts ``compressors`` (plural) — even for zarr format 2.  zarr v2's
-    # ``open_array`` / ``open`` uses ``compressor`` (singular).
+    # zarr v3's ``zarr.create_array`` uses ``compressors`` (plural).  When the
+    # dask path is taken, ``_prepare_zarr_kwargs`` converts back to singular
+    # for older dask versions that call ``zarr.create()`` instead.
     compression_kwargs = {}
     if IS_ZARR_V3_PLUS:
-        # zarr v3's create_array() uses 'compressors' (plural) for all formats.
-        # dask.array.to_zarr() forwards kwargs to zarr.create_array(), so we
-        # must always use the plural form when zarr v3 is installed.
         if user_compressors is not None:
             compression_kwargs["compressors"] = user_compressors
         elif has_compressor:

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -40,6 +40,18 @@ zarr_version = Version(zarr.__version__)
 IS_ZARR_V3_PLUS = zarr_version.major >= 3
 DASK_SUPPORTS_SHARDING = Version(dask_version) >= Version("2025.12.0")
 
+# Detect whether dask.array.to_zarr uses Group.create_array() (which rejects
+# ``zarr_format`` but inherits it from the group) or top-level
+# ``zarr.create_array()`` (which needs ``zarr_format`` to avoid defaulting to
+# format 3).  Changed in dask ~2026.3.0.
+_DASK_USES_GROUP_CREATE = False
+if DASK_SUPPORTS_SHARDING:
+    import inspect as _inspect
+    import re as _re
+
+    _src = _inspect.getsource(dask.array.core.to_zarr)
+    _DASK_USES_GROUP_CREATE = bool(_re.search(r"root\s*=\s*zarr\.open_group", _src))
+
 ScaleStrategy = Literal["pad", "exact"]
 
 
@@ -586,9 +598,8 @@ def _prepare_zarr_kwargs(to_zarr_kwargs: dict):
             to_zarr_kwargs.pop("chunk_key_encoding", None)
 
     # Old dask (< 2025.12) passes kwargs to zarr.create() which only accepts
-    # 'compressor' (singular).  Newer dask uses zarr.create_array() which
-    # accepts 'compressors' (plural).  We normalise here so the rest of the
-    # code can always build kwargs with the plural form for zarr v3.
+    # 'compressor' (singular).  Newer dask uses Group.create_array() which
+    # accepts 'compressors' (plural).
     if IS_ZARR_V3_PLUS and not DASK_SUPPORTS_SHARDING:
         _sentinel = object()
         compressors_val = to_zarr_kwargs.pop("compressors", _sentinel)
@@ -601,9 +612,11 @@ def _prepare_zarr_kwargs(to_zarr_kwargs: dict):
                 )
             else:
                 to_zarr_kwargs["compressor"] = compressors_val
-
-    # New dask doesn't accept zarr_format in zarr_array_kwargs
-    if DASK_SUPPORTS_SHARDING:
+    # Dask versions that use Group.create_array() (< ~2026.3) reject
+    # zarr_format (it's inherited from the group).  Newer dask uses
+    # zarr.create_array() directly and NEEDS zarr_format to avoid
+    # defaulting to format 3.
+    if DASK_SUPPORTS_SHARDING and _DASK_USES_GROUP_CREATE:
         to_zarr_kwargs.pop("zarr_format", None)
 
 
@@ -663,9 +676,9 @@ def _write_array_direct(
         cleaned_sharding_kwargs = sharding_kwargs
 
     # Translate user-supplied compression settings into format-appropriate kwargs.
-    # zarr v3's ``zarr.create_array`` uses ``compressors`` (plural).  When the
-    # dask path is taken, ``_prepare_zarr_kwargs`` converts back to singular
-    # for older dask versions that call ``zarr.create()`` instead.
+    # zarr v3's ``zarr.create_array`` uses ``compressors`` (plural).  When
+    # older dask is used (< 2025.12, calls ``zarr.create()``),
+    # ``_prepare_zarr_kwargs`` converts back to singular ``compressor``.
     compression_kwargs = {}
     if IS_ZARR_V3_PLUS:
         if user_compressors is not None:
@@ -676,14 +689,13 @@ def _write_array_direct(
             elif zarr_fmt == 3:
                 # zarr format 3 needs zarr v3 codec objects
                 v3_codec = _numcodecs_to_zarr_v3_codec(user_compressor)
-                if v3_codec is not None:
-                    compression_kwargs["compressors"] = [v3_codec]
-                else:
-                    # Fallback: pass numcodecs object directly; zarr v3 can
-                    # wrap it via its numcodecs compatibility layer.
-                    compression_kwargs["compressors"] = [user_compressor]
+                compression_kwargs["compressors"] = (
+                    [v3_codec] if v3_codec is not None else [user_compressor]
+                )
             else:
-                # zarr format 2: pass numcodecs objects directly
+                # zarr format 2: numcodecs objects are accepted by
+                # Group.create_array() (used by new dask) when the group
+                # is format 2.
                 compression_kwargs["compressors"] = [user_compressor]
         if user_filters is not None:
             compression_kwargs["filters"] = user_filters

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -646,26 +646,35 @@ def _write_array_direct(
         cleaned_sharding_kwargs = sharding_kwargs
 
     # Translate user-supplied compression settings into format-appropriate kwargs.
-    # zarr v2 uses ``compressor`` (singular); zarr v3's ``zarr.create_array``
-    # accepts ``compressors`` (plural, a list or ``None``).
+    # zarr v3's ``zarr.create_array`` (called by ``dask.array.to_zarr``) only
+    # accepts ``compressors`` (plural) — even for zarr format 2.  zarr v2's
+    # ``open_array`` / ``open`` uses ``compressor`` (singular).
     compression_kwargs = {}
-    if zarr_fmt == 2:
-        if has_compressor:
-            # compressor=None means "no compression" for zarr v2
-            compression_kwargs["compressor"] = user_compressor
-        if user_filters is not None:
-            compression_kwargs["filters"] = user_filters
-    elif zarr_fmt == 3:
+    if IS_ZARR_V3_PLUS:
+        # zarr v3's create_array() uses 'compressors' (plural) for all formats.
+        # dask.array.to_zarr() forwards kwargs to zarr.create_array(), so we
+        # must always use the plural form when zarr v3 is installed.
         if user_compressors is not None:
             compression_kwargs["compressors"] = user_compressors
         elif has_compressor:
             if user_compressor is None:
-                # Explicit "no compression"
                 compression_kwargs["compressors"] = None
-            else:
+            elif zarr_fmt == 3:
+                # zarr format 3 needs zarr v3 codec objects
                 v3_codec = _numcodecs_to_zarr_v3_codec(user_compressor)
                 if v3_codec is not None:
                     compression_kwargs["compressors"] = [v3_codec]
+            else:
+                # zarr format 2: pass numcodecs objects directly
+                compression_kwargs["compressors"] = [user_compressor]
+        if user_filters is not None:
+            compression_kwargs["filters"] = user_filters
+    else:
+        # zarr v2 library uses 'compressor' (singular)
+        if has_compressor:
+            compression_kwargs["compressor"] = user_compressor
+        if user_filters is not None:
+            compression_kwargs["filters"] = user_filters
 
     to_zarr_kwargs = {
         **cleaned_sharding_kwargs,

--- a/ts/test/browser-npm/browser-test.html
+++ b/ts/test/browser-npm/browser-test.html
@@ -8,8 +8,7 @@
     <pre id="output">Loading...</pre>
 
     <script type="module">
-      document.getElementById("output").textContent =
-        "Starting test...\n";
+      document.getElementById("output").textContent = "Starting test...\n";
 
       try {
         console.log("Attempting to load browser bundle...");

--- a/ts/test/browser-npm/from_ngff_zarr_test.html
+++ b/ts/test/browser-npm/from_ngff_zarr_test.html
@@ -94,9 +94,7 @@
         section.className = "test-section";
 
         const resultDiv = document.createElement("div");
-        resultDiv.className = `test-result ${
-          success ? "success" : "error"
-        }`;
+        resultDiv.className = `test-result ${success ? "success" : "error"}`;
 
         const icon = document.createElement("span");
         icon.className = `status-icon ${success ? "success" : "error"}`;
@@ -169,8 +167,7 @@
               "Local file path was NOT rejected - this is unexpected!",
             );
           } catch (error) {
-            const rejectedCorrectly =
-              error.message.includes("browser") ||
+            const rejectedCorrectly = error.message.includes("browser") ||
               error.message.includes("Local file") ||
               error.message.includes("HTTP");
             addTestResult(
@@ -249,8 +246,7 @@
                 "Local file path was NOT rejected - this is unexpected!",
               );
             } catch (error) {
-              const rejectedCorrectly =
-                error.message.includes("browser") ||
+              const rejectedCorrectly = error.message.includes("browser") ||
                 error.message.includes("Local file") ||
                 error.message.includes("MemoryStore");
               addTestResult(
@@ -284,8 +280,7 @@
                 "HTTP URL was NOT rejected - this is unexpected!",
               );
             } catch (error) {
-              const rejectedCorrectly =
-                error.message.includes("read-only") ||
+              const rejectedCorrectly = error.message.includes("read-only") ||
                 error.message.includes("HTTP") ||
                 error.message.includes("MemoryStore");
               addTestResult(

--- a/ts/test/browser-npm/index.html
+++ b/ts/test/browser-npm/index.html
@@ -5,16 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NGFF Zarr NPM Package Test</title>
     <script type="importmap">
-      {
-        "imports": {
-          "zod": "./npm/node_modules/zod/index.js",
-          "zarrita": "./npm/node_modules/zarrita/dist/src/index.js",
-          "@zarrita/storage": "./npm/node_modules/@zarrita/storage/dist/src/index.js",
-          "@zarrita/storage/fetch": "./npm/node_modules/@zarrita/storage/dist/src/fetch.js",
-          "@zarrita/storage/ref": "./npm/node_modules/@zarrita/storage/dist/src/ref.js",
-          "numcodecs": "./npm/node_modules/numcodecs/dist/index.js"
-        }
+    {
+      "imports": {
+        "zod": "./npm/node_modules/zod/index.js",
+        "zarrita": "./npm/node_modules/zarrita/dist/src/index.js",
+        "@zarrita/storage": "./npm/node_modules/@zarrita/storage/dist/src/index.js",
+        "@zarrita/storage/fetch": "./npm/node_modules/@zarrita/storage/dist/src/fetch.js",
+        "@zarrita/storage/ref": "./npm/node_modules/@zarrita/storage/dist/src/ref.js",
+        "numcodecs": "./npm/node_modules/numcodecs/dist/index.js"
       }
+    }
     </script>
     <style>
       body {

--- a/ts/test/browser-npm/omero-benchmark.html
+++ b/ts/test/browser-npm/omero-benchmark.html
@@ -772,8 +772,8 @@
             summarySection.style.display = "block";
             document.getElementById("summary-throughput").textContent =
               peakThroughput.toFixed(1);
-            document.getElementById("summary-total").textContent =
-              totalTime.toFixed(0);
+            document.getElementById("summary-total").textContent = totalTime
+              .toFixed(0);
             document.getElementById("summary-tests").textContent =
               testsCompleted.toString();
           }

--- a/ts/test/browser-npm/simple-test.html
+++ b/ts/test/browser-npm/simple-test.html
@@ -8,8 +8,7 @@
     <pre id="output">Loading...</pre>
 
     <script type="module">
-      document.getElementById("output").textContent =
-        "Starting test...\n";
+      document.getElementById("output").textContent = "Starting test...\n";
 
       try {
         console.log("Attempting to load bundle...");


### PR DESCRIPTION
## Summary

Fixes failing CI in PR #393 (`--codec` / `--compression-level` CLI options) and addresses code review findings.

- **Root cause**: `dask.array.to_zarr()` forwards kwargs to `zarr.create_array()`, which in zarr v3 only accepts `compressors` (plural) — not `compressor` (singular). The PR #393 code passed `compressor` singular, causing `TypeError` for all codec CLI tests.
- **Fix in `_write_array_direct`**: Intercept `compressor`/`compressors`/`filters` from kwargs early, then re-emit them in the correct form depending on zarr version (`compressors` plural for zarr v3, `compressor` singular for zarr v2). For zarr format 3, numcodecs objects are translated to native zarr v3 codec objects via `_numcodecs_to_zarr_v3_codec()`.
- **Fix in `_handle_large_array_writing`**: The non-sharding path now handles both `compressors` (plural) and `compressor` (singular) for format 3, with proper `BytesCodec` prepending. Format 2 continues using `compressor` singular since `open_array()` accepts it.
- **Fix in `codecs.py`**: `"blosc:"` with empty variant (e.g. trailing colon) now defaults to `cname="lz4"` instead of passing `cname=""`.
- **Fallback handling**: When `_numcodecs_to_zarr_v3_codec()` cannot translate a compressor (returns `None`), the numcodecs object is now passed directly instead of silently dropping compression.

## Test plan

- [x] All 7 `TestCodecCLI` tests pass (gzip, blosc:zstd, with-level, none, gzip-v3, none-v3, invalid)
- [x] All 15 `test_codecs.py` unit tests pass
- [x] Full test suite: 497 passed, 2 skipped
- [x] All pre-commit hooks pass (ruff, codespell, commitizen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)