### PR TITLE
fix(py): fix zarr_kwargs mutation causing KeyError on multi-scale v0.4 writes

### DIFF
--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -771,6 +771,9 @@ def _handle_large_array_writing(
     **kwargs,
 ) -> None:
     """Handle writing large arrays by splitting them into manageable pieces."""
+    # Copy zarr_kwargs to avoid mutating the caller's dict across loop iterations
+    zarr_kwargs = zarr_kwargs.copy()
+
     shrink_factors = []
     for dim in dims:
         if dim in dim_factors:

--- a/py/test/test_slab_slices_fix.py
+++ b/py/test/test_slab_slices_fix.py
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
 # SPDX-License-Identifier: MIT
-"""Regression tests for PR #447 fix: _compute_write_regions uses slab_slices for Z boundaries."""
+"""Regression tests for PR #447 fix and zarr_kwargs mutation fix.
+
+PR #447: _compute_write_regions uses slab_slices for Z boundaries.
+GH #490: _handle_large_array_writing mutated caller's zarr_kwargs dict.
+"""
 
 import tempfile
 
@@ -145,6 +149,55 @@ def test_slab_slices_with_non_divisible_shape(ome_zarr_version):
             )
 
             # Full round-trip check, including the partial final slab z[16:20].
+            np.testing.assert_array_equal(read_data, data)
+
+    finally:
+        config.memory_target = default_mem_target
+
+
+@pytest.mark.skipif(
+    zarr_version_major < 3,
+    reason="Bug only manifests with zarr v3 (IS_ZARR_V3_PLUS) writing zarr v2 format",
+)
+def test_zarr_kwargs_not_mutated_across_scale_iterations():
+    """Regression test for zarr_kwargs mutation in _handle_large_array_writing.
+
+    _handle_large_array_writing mutates zarr_kwargs in-place when
+    zarr_format == 2 (OME-Zarr v0.4) and IS_ZARR_V3_PLUS (deleting
+    chunk_key_encoding, adding dimension_separator).  Without a defensive
+    copy, subsequent loop iterations in _to_ngff_zarr_impl fail with
+    KeyError: 'chunk_key_encoding'.
+    """
+    default_mem_target = config.memory_target
+
+    try:
+        shape = (64, 128, 128)
+        data = np.arange(np.prod(shape), dtype=np.uint8).reshape(shape)
+
+        image = to_ngff_image(
+            data=data,
+            dims=("z", "y", "x"),
+            scale={"z": 1.0, "y": 1.0, "x": 1.0},
+        )
+
+        multiscales = to_multiscales(image, scale_factors=[2], cache=False)
+
+        assert len(multiscales.images) == 2, (
+            f"Expected 2 scales, got {len(multiscales.images)}"
+        )
+
+        # Force large-array path for both scales:
+        #   scale 0: (64, 128, 128) = 1 048 576 bytes
+        #   scale 1: (32,  64,  64) =   131 072 bytes
+        config.memory_target = 100_000
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            to_ngff_zarr(tmpdir, multiscales, version="0.4")
+
+            read_multiscales = from_ngff_zarr(tmpdir)
+            assert len(read_multiscales.images) == 2
+
+            read_data = np.asarray(read_multiscales.images[0].data)
             np.testing.assert_array_equal(read_data, data)
 
     finally:


### PR DESCRIPTION
## Summary

Fixed a dict mutation bug in `_handle_large_array_writing` that caused `KeyError: 'chunk_key_encoding'` when writing multi-scale OME-Zarr v0.4 (zarr format 2) with zarr v3.

## Changes

- **`py/ngff_zarr/to_ngff_zarr.py`** — Added `zarr_kwargs = zarr_kwargs.copy()` at entry to `_handle_large_array_writing` to prevent in-place mutation from leaking to the caller. Without this, the function deleted `chunk_key_encoding` and added `dimension_separator` on the first scale iteration, causing the second iteration to crash.
- **`py/test/test_slab_slices_fix.py`** — Added regression test `test_zarr_kwargs_not_mutated_across_scale_iterations` that forces the large-array path with multi-scale v0.4 output and verifies round-trip correctness. Verified the test catches the bug when the fix is reverted.

## Root Cause

`_to_ngff_zarr_impl` creates `_zarr_kwargs` once and passes the same dict to every scale iteration. When `zarr_format == 2` and `IS_ZARR_V3_PLUS`, `_handle_large_array_writing` mutated the dict (deleting `chunk_key_encoding`, setting `dimension_separator`). The second iteration received the already-mutated dict and failed.

## Verification

- All 504 tests pass (499 existing + 5 slab slice tests)
- Ruff format and lint pass clean
- Regression test confirmed to fail without the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented inadvertent modification of zarr configuration during large-array, multi-scale writes so settings remain consistent across iterations.

* **Tests**
  * Added a regression test that reproduces the large-array multi-scale path and verifies zarr configuration is not mutated (run gated to compatible zarr versions).

* **Documentation**
  * Expanded module-level notes describing the addressed regressions and test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fideus-labs/ngff-zarr/pull/505)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->