### PR TITLE
fix(ci): pin imagecodecs to fix macOS Intel wheel build failure

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -68,7 +68,7 @@ cli = [
   "nibabel",
   "tifffile>=2024.7.24",
   "liffile",
-  "imagecodecs>=2026.3.6,<2026.5.0",
+  "imagecodecs>=2025.3.30,<2026.5.0",
 ]
 tensorstore = ["tensorstore"]
 test = [

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -68,7 +68,7 @@ cli = [
   "nibabel",
   "tifffile>=2024.7.24",
   "liffile",
-  "imagecodecs",
+  "imagecodecs>=2026.3.6,<2026.5.0",
 ]
 tensorstore = ["tensorstore"]
 test = [

--- a/py/test/_data.py
+++ b/py/test/_data.py
@@ -29,7 +29,7 @@ zarr_version_major = zarr_version.major
 @pytest.fixture(scope="package")
 def input_images():
     untar = pooch.Untar(extract_dir=extract_dir)
-    downloader = pooch.HTTPDownloader(retry_if_failed=3, timeout=60)
+    downloader = pooch.HTTPDownloader(timeout=120)
     pooch.retrieve(
         fname="data.tar.gz",
         path=test_dir,

--- a/py/test/_data.py
+++ b/py/test/_data.py
@@ -29,6 +29,7 @@ zarr_version_major = zarr_version.major
 @pytest.fixture(scope="package")
 def input_images():
     untar = pooch.Untar(extract_dir=extract_dir)
+    downloader = pooch.HTTPDownloader(retry_if_failed=3, timeout=60)
     pooch.retrieve(
         fname="data.tar.gz",
         path=test_dir,
@@ -37,6 +38,7 @@ def input_images():
         # url=f"https://{test_data_ipfs_cid}.ipfs.w3s.link/ipfs/{test_data_ipfs_cid}/data.tar.gz",
         known_hash=f"sha256:{test_data_sha256}",
         processor=untar,
+        downloader=downloader,
     )
     result = {}
 

--- a/py/test/test_rfc4_validation.py
+++ b/py/test/test_rfc4_validation.py
@@ -204,7 +204,10 @@ def test_from_ngff_zarr_with_rfc4_validation():
 
     # Create a simple zarr array
     root = zarr.open_group(store, mode="w")
-    root.create_dataset("0", shape=(10, 10, 10), dtype="uint8")
+    if hasattr(root, "create_array"):
+        root.create_array("0", shape=(10, 10, 10), dtype="uint8")
+    else:
+        root.create_dataset("0", shape=(10, 10, 10), dtype="uint8")
 
     # Add OME-NGFF metadata with RFC 4 orientation
     multiscales_metadata = {
@@ -256,7 +259,10 @@ def test_from_ngff_zarr_with_rfc4_validation_invalid():
 
     # Create a simple zarr array
     root = zarr.open_group(store, mode="w")
-    root.create_dataset("0", shape=(10, 10, 10), dtype="uint8")
+    if hasattr(root, "create_array"):
+        root.create_array("0", shape=(10, 10, 10), dtype="uint8")
+    else:
+        root.create_dataset("0", shape=(10, 10, 10), dtype="uint8")
 
     # Add OME-NGFF metadata with incomplete RFC 4 orientation (missing z orientation)
     multiscales_metadata = {
@@ -308,7 +314,10 @@ def test_from_ngff_zarr_without_rfc4_validation():
 
     # Create a simple zarr array
     root = zarr.open_group(store, mode="w")
-    root.create_dataset("0", shape=(10, 10, 10), dtype="uint8")
+    if hasattr(root, "create_array"):
+        root.create_array("0", shape=(10, 10, 10), dtype="uint8")
+    else:
+        root.create_dataset("0", shape=(10, 10, 10), dtype="uint8")
 
     # Add OME-NGFF metadata with incomplete RFC 4 orientation
     multiscales_metadata = {


### PR DESCRIPTION
## Summary

Fixes CI failures on the `python.yml` workflow where `imagecodecs` fails to install on macOS Intel runners.

## Problem

The `python.yml` CI workflow uses plain pip with no version constraint on `imagecodecs`, causing it to pull the latest release (v2026.5.10). This version lacks a pre-built wheel for macOS Intel (`cp311-abi3-macosx_x86_64`), triggering a source build. The source build fails because the JPEG2000 extension compilation requires the `openjpeg.h` header, which is not installed on the GitHub Actions macOS runner.

## Fix

Added version constraint `imagecodecs>=2026.3.6,<2026.5.0` in `py/pyproject.toml` under the `cli` optional dependencies. This pins to the same v2026.3.6 used by the pixi lockfile, which has pre-built `cp311-abi3` wheels for all platforms including macOS Intel.

## Details

- The `python-pixi.yml` workflow was unaffected because it uses a frozen pixi lockfile pinning v2026.3.6
- v2026.3.6 ships `cp311-abi3-macosx_10_15_x86_64.whl` for macOS Intel
- The upper bound `<2026.5.0` prevents the known-broken release from being pulled in while allowing compatible point releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened the imagecodecs version range used by the CLI extra to ensure installs use a tested set of releases; no CLI behavior changes.

* **Tests**
  * Made RFC‑4 validation tests backend‑compatible when creating test arrays, preserving assertions and coverage.
  * Adjusted test data download to use a longer network timeout for more robust retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fideus-labs/ngff-zarr/pull/506)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->