### PR TITLE
fix(py): resolve data loss and chunks regressions from issue #488

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+.serena/

--- a/py/ngff_zarr/methods/_itkwasm.py
+++ b/py/ngff_zarr/methods/_itkwasm.py
@@ -38,6 +38,19 @@ def _itkwasm_blur_and_downsample(
     """Blur and then downsample a given image chunk"""
     import itkwasm
 
+    # itkwasm_downsample's Gaussian filter performs internal arithmetic
+    # that loses precision on small integer values (e.g. a uint16 input
+    # of 1 produces 0).  Cast integer inputs to float32 for the Gaussian
+    # path, then round and cast back so we preserve the input dtype while
+    # avoiding the upstream precision-loss.  ``label_image`` downsampling
+    # is integer-aware and does not need this workaround.
+    original_dtype = image_data.dtype
+    needs_float_workaround = smoothing == "gaussian" and np.issubdtype(
+        original_dtype, np.integer
+    )
+    if needs_float_workaround:
+        image_data = image_data.astype(np.float32)
+
     # chunk does not have metadata attached, values are ITK defaults
     image = itkwasm.image_from_array(image_data, is_vector=is_vector)
 
@@ -62,7 +75,16 @@ def _itkwasm_blur_and_downsample(
         msg = f"Unknown smoothing method: {smoothing}"
         raise ValueError(msg)
 
-    return downsampled.data
+    data = downsampled.data
+    if needs_float_workaround:
+        if np.issubdtype(original_dtype, np.unsignedinteger):
+            data = np.clip(np.rint(data), 0, np.iinfo(original_dtype).max)
+        else:
+            info = np.iinfo(original_dtype)
+            data = np.clip(np.rint(data), info.min, info.max)
+        data = data.astype(original_dtype)
+
+    return data
 
 
 def _itkwasm_chunk_bin_shrink(

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -718,9 +718,10 @@ def _write_array_direct(
     # For Zarr v3 direct writes without sharding, ``zarr.create_array`` picks
     # its own chunk shape if we do not pass one — that overrides the chunking
     # the caller selected via ``to_multiscales(chunks=...)``.  Forward the
-    # dask array's chunks so user intent is respected.
+    # dask array's canonical chunk shape (``chunksize`` = per-dim max, which
+    # tolerates non-uniform leading chunks) so user intent is respected.
     if zarr_fmt == 3 and zarr_array is None and "chunks" not in to_zarr_kwargs:
-        to_zarr_kwargs["chunks"] = tuple(c[0] for c in arr.chunks)
+        to_zarr_kwargs["chunks"] = arr.chunksize
 
     if zarr_fmt == 3 and zarr_array is None:
         # Zarr v3, use zarr.create_array and assign (whole array or region)

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -715,6 +715,13 @@ def _write_array_direct(
         **kwargs,
     }
 
+    # For Zarr v3 direct writes without sharding, ``zarr.create_array`` picks
+    # its own chunk shape if we do not pass one — that overrides the chunking
+    # the caller selected via ``to_multiscales(chunks=...)``.  Forward the
+    # dask array's chunks so user intent is respected.
+    if zarr_fmt == 3 and zarr_array is None and "chunks" not in to_zarr_kwargs:
+        to_zarr_kwargs["chunks"] = tuple(c[0] for c in arr.chunks)
+
     if zarr_fmt == 3 and zarr_array is None:
         # Zarr v3, use zarr.create_array and assign (whole array or region)
         array = zarr.create_array(

--- a/py/test/test_issue_488.py
+++ b/py/test/test_issue_488.py
@@ -194,6 +194,47 @@ def test_chunks_default_not_overridden_by_zarr_heuristic():
         assert read.images[0].data.chunksize == expected
 
 
+@pytest.mark.skipif(zarr_version_major < 3, reason="OME-Zarr 0.5 requires zarr v3")
+def test_chunks_robust_to_non_uniform_leading_chunk():
+    """The forwarded chunk shape must use the array's canonical chunk size
+    (``arr.chunksize``), not ``c[0]``.
+
+    Slicing or other dask operations can produce a smaller leading chunk
+    (e.g. ``arr[5:]`` yields a first chunk of size 5 while the rest are 10).
+    Using ``arr.chunks[i][0]`` would forward 5 — the partial leading chunk —
+    rather than the array's intended 10-element chunk size.  This test
+    constructs that pathological input via ``rechunk`` semantics and asserts
+    the on-disk chunks reflect the canonical size.
+    """
+    import dask.array
+
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "nonuniform.zarr"
+        # Construct an array whose leading chunk is smaller than the rest.
+        # We do this by chunking the data with explicit per-dim block sizes
+        # that produce a small first block on the z axis.
+        np_data = np.full((1, 1, 25, 64, 64), 7, dtype=np.uint16)
+        da_data = dask.array.from_array(
+            np_data, chunks=((1,), (1,), (5, 10, 10), (64,), (64,))
+        )
+        image = to_ngff_image(da_data, dims=["t", "c", "z", "y", "x"])
+        # Skip to_multiscales' own rechunk by writing a single-level
+        # multiscales with the already-chunked dask array.
+        multiscales = to_multiscales(image, scale_factors=[2])
+        # Re-stitch the base level with the non-uniform chunking so we are
+        # exercising the ``arr.chunksize`` path (to_multiscales would have
+        # normalised the chunks).
+        multiscales.images[0].data = da_data
+        to_ngff_zarr(str(out), multiscales, version="0.5")
+        read = from_ngff_zarr(str(out))
+        # ``c[0]`` for z would be 5; ``arr.chunksize`` for z is 10.  The
+        # written chunks must reflect 10.
+        assert read.images[0].data.chunksize[2] == 10, (
+            f"z chunk size was {read.images[0].data.chunksize[2]} — "
+            "leading partial chunk leaked into the on-disk chunk size"
+        )
+
+
 @pytest.mark.skipif(zarr_version_major < 3, reason="Sharding requires zarr v3")
 def test_chunks_per_shard_path_still_works():
     """The Bug B fix is gated on ``chunks`` not already being set in

--- a/py/test/test_issue_488.py
+++ b/py/test/test_issue_488.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Regression tests for GH #488.
+
+Issue: https://github.com/fideus-labs/ngff-zarr/issues/488
+
+Two distinct bugs reported (after PR #503 / #505 fixed the chunk-alignment
+warning and the ``KeyError: 'chunk_key_encoding'`` errors):
+
+A. Integer-typed inputs were silently downsampled to all zeros (or grossly
+   truncated values) by ``ITKWASM_GAUSSIAN`` because the upstream
+   ``itkwasm_downsample`` Gaussian filter loses precision when operating on
+   integer types.  The fix in ``_itkwasm_blur_and_downsample`` casts integer
+   inputs to ``float32`` before downsampling and rounds back to the original
+   dtype afterwards.
+
+B. For OME-Zarr v0.5 writes that did not use sharding, the user-specified
+   ``chunks=`` argument to ``to_multiscales`` was discarded for the
+   highest-resolution level because ``zarr.create_array`` was called without
+   ``chunks=``.  The fix in ``_write_array_direct`` forwards the dask array
+   chunks when none are otherwise present.
+"""
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import packaging.version
+import pytest
+import zarr
+from ngff_zarr import (
+    Methods,
+    from_ngff_zarr,
+    to_multiscales,
+    to_ngff_image,
+    to_ngff_zarr,
+)
+
+zarr_version_major = packaging.version.parse(zarr.__version__).major
+ome_zarr_versions = ["0.4"] + (["0.5"] if zarr_version_major >= 3 else [])
+
+
+# ---------------------------------------------------------------------------
+# Bug A: ITKWASM_GAUSSIAN preserves integer-typed inputs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.int16, np.int32])
+def test_itkwasm_gaussian_integer_constant_preserved(dtype):
+    """A constant integer image must remain constant after Gaussian downsample.
+
+    Before the fix the downsampled scales were all zeros for ``np.ones`` input
+    (uint16): the upstream ``itkwasm_downsample`` Gaussian filter does
+    integer arithmetic that truncates 1 to 0.
+    """
+    value = 1
+    data = np.full((1, 2, 32, 32, 32), value, dtype=dtype)
+    image = to_ngff_image(data, dims=["t", "c", "z", "y", "x"])
+    multiscales = to_multiscales(
+        image,
+        chunks=(1, 1, 16, 16, 16),
+        scale_factors=[2, 4],
+        method=Methods.ITKWASM_GAUSSIAN,
+    )
+    for level, img in enumerate(multiscales.images):
+        arr = np.asarray(img.data)
+        assert arr.dtype == dtype, f"scale {level}: dtype changed to {arr.dtype}"
+        assert arr.min() == value, (
+            f"scale {level}: min={arr.min()} expected {value} (dtype={dtype})"
+        )
+        assert arr.max() == value, (
+            f"scale {level}: max={arr.max()} expected {value} (dtype={dtype})"
+        )
+
+
+def test_itkwasm_gaussian_uint16_small_values_not_truncated():
+    """Small uint16 values must survive Gaussian downsampling without becoming 0."""
+    for value in (1, 2, 5, 10):
+        data = np.full((1, 2, 32, 32, 32), value, dtype=np.uint16)
+        image = to_ngff_image(data, dims=["t", "c", "z", "y", "x"])
+        multiscales = to_multiscales(
+            image,
+            scale_factors=[2],
+            method=Methods.ITKWASM_GAUSSIAN,
+        )
+        scale1 = np.asarray(multiscales.images[1].data)
+        # Within rounding of the Gaussian filter, the result should be
+        # very close to ``value`` (within +/- 1).  Crucially it must not
+        # be zero for nonzero input.
+        assert scale1.min() > 0, (
+            f"value={value}: scale1 contained zeros after downsample"
+        )
+        assert abs(int(scale1.mean()) - value) <= 1, (
+            f"value={value}: mean drifted to {scale1.mean()}"
+        )
+
+
+def test_itkwasm_gaussian_float_unaffected_by_fix():
+    """Float inputs must continue to work — the fix only intercepts integers."""
+    data = np.ones((1, 2, 32, 32, 32), dtype=np.float32)
+    image = to_ngff_image(data, dims=["t", "c", "z", "y", "x"])
+    multiscales = to_multiscales(
+        image,
+        scale_factors=[2],
+        method=Methods.ITKWASM_GAUSSIAN,
+    )
+    for level, img in enumerate(multiscales.images):
+        arr = np.asarray(img.data)
+        assert arr.dtype == np.float32, f"scale {level}: dtype={arr.dtype}"
+        # Float gaussian retains ~1.0 for an all-ones field
+        assert np.isclose(arr.min(), 1.0, atol=1e-3)
+        assert np.isclose(arr.max(), 1.0, atol=1e-3)
+
+
+@pytest.mark.parametrize("ome_zarr_version", ome_zarr_versions)
+def test_issue_488_user_reproducer_roundtrip(ome_zarr_version):
+    """End-to-end roundtrip mirroring the user's reproducer in #488.
+
+    The original report uses ``numpy.ones((1, 2, 801, 1146, 1290), dtype=uint16)``
+    which is ~4.7 GiB; we use a smaller but similarly-shaped array.  All scales
+    must round-trip to all-ones with the user-requested chunk sizes.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "bug488.zarr"
+        data = np.ones((1, 2, 80, 114, 129), dtype=np.uint16)
+        image = to_ngff_image(
+            data,
+            dims=["t", "c", "z", "y", "x"],
+            translation=dict.fromkeys("tczyx", 0),
+            scale=dict.fromkeys("tczyx", 1),
+        )
+        multiscales = to_multiscales(
+            image, chunks=(1, 1, 64, 64, 64), scale_factors=[2, 4]
+        )
+        to_ngff_zarr(str(out), multiscales, version=ome_zarr_version)
+
+        read = from_ngff_zarr(str(out))
+        assert len(read.images) == 3
+        for level, img in enumerate(read.images):
+            arr = np.asarray(img.data)
+            assert arr.min() == 1, (
+                f"scale {level}: min={arr.min()} (expected 1) "
+                "— Gaussian downsample lost integer precision"
+            )
+            assert arr.max() == 1, f"scale {level}: max={arr.max()} (expected 1)"
+
+
+# ---------------------------------------------------------------------------
+# Bug B: chunks= parameter respected for v0.5 writes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("ome_zarr_version", ome_zarr_versions)
+def test_chunks_parameter_preserved_on_roundtrip(ome_zarr_version):
+    """``chunks=(1,1,64,64,64)`` must round-trip through the OME-Zarr writer.
+
+    Before the fix the scale-0 array written for v0.5 used zarr's heuristic
+    default chunks instead of the user's request, producing surprising shapes
+    like ``(1,1,40,57,129)`` for a ``(1,2,80,114,129)`` array.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "chunks.zarr"
+        data = np.full((1, 2, 80, 114, 129), 100, dtype=np.uint16)
+        image = to_ngff_image(data, dims=["t", "c", "z", "y", "x"])
+        multiscales = to_multiscales(
+            image, chunks=(1, 1, 64, 64, 64), scale_factors=[2, 4]
+        )
+        to_ngff_zarr(str(out), multiscales, version=ome_zarr_version)
+
+        read = from_ngff_zarr(str(out))
+        # Scale 0 chunks are exactly what the user asked for.
+        assert read.images[0].data.chunksize == (1, 1, 64, 64, 64), (
+            f"scale 0 chunks={read.images[0].data.chunksize}"
+        )
+        # Lower scales clip to dim size where smaller than the requested chunk.
+        assert read.images[1].data.chunksize == (1, 1, 40, 57, 64)
+        assert read.images[2].data.chunksize == (1, 1, 20, 28, 32)
+
+
+@pytest.mark.skipif(zarr_version_major < 3, reason="OME-Zarr 0.5 requires zarr v3")
+def test_chunks_default_not_overridden_by_zarr_heuristic():
+    """When the user does not pass chunks, the dask chunks (chosen by
+    ``to_multiscales``) must still be the ones written, not zarr v3's
+    heuristic.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "default_chunks.zarr"
+        data = np.full((1, 2, 80, 114, 129), 100, dtype=np.uint16)
+        image = to_ngff_image(data, dims=["t", "c", "z", "y", "x"])
+        multiscales = to_multiscales(image, scale_factors=[2])
+        expected = multiscales.images[0].data.chunksize
+        to_ngff_zarr(str(out), multiscales, version="0.5")
+        read = from_ngff_zarr(str(out))
+        assert read.images[0].data.chunksize == expected
+
+
+@pytest.mark.skipif(zarr_version_major < 3, reason="Sharding requires zarr v3")
+def test_chunks_per_shard_path_still_works():
+    """The Bug B fix is gated on ``chunks`` not already being set in
+    ``to_zarr_kwargs``.  When sharding is configured ``cleaned_sharding_kwargs``
+    sets ``chunks`` so the new branch becomes a no-op — confirm the sharding
+    path still round-trips correctly.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "sharded.zarr"
+        data = np.full((1, 2, 64, 64, 64), 100, dtype=np.uint16)
+        image = to_ngff_image(data, dims=["t", "c", "z", "y", "x"])
+        multiscales = to_multiscales(
+            image, chunks=(1, 1, 32, 32, 32), scale_factors=[2]
+        )
+        to_ngff_zarr(str(out), multiscales, version="0.5", chunks_per_shard=2)
+        read = from_ngff_zarr(str(out))
+        for level, img in enumerate(read.images):
+            arr = np.asarray(img.data)
+            assert arr.min() == 100, f"scale {level}: data corrupted"
+            assert arr.max() == 100, f"scale {level}: data corrupted"
+
+
+# ---------------------------------------------------------------------------
+# Bug A edge cases — extreme values, signed ints, and the unaffected
+# label_image path
+# ---------------------------------------------------------------------------
+
+
+def test_itkwasm_gaussian_int16_negative_values_preserved():
+    """Signed integers with negative values must survive the float workaround.
+
+    The ``np.clip`` in the fix uses ``np.iinfo`` bounds, so this exercises the
+    ``signed`` branch (clip min = -32768, not 0).
+    """
+    data = np.full((1, 1, 32, 32, 32), -1000, dtype=np.int16)
+    image = to_ngff_image(data, dims=["t", "c", "z", "y", "x"])
+    multiscales = to_multiscales(
+        image, scale_factors=[2], method=Methods.ITKWASM_GAUSSIAN
+    )
+    scale1 = np.asarray(multiscales.images[1].data)
+    assert scale1.dtype == np.int16
+    assert scale1.min() == -1000
+    assert scale1.max() == -1000
+
+
+def test_itkwasm_gaussian_uint8_near_max_no_overflow():
+    """Values near a dtype's upper bound must not overflow during round-trip.
+
+    Tests the ``np.clip`` upper bound — without it a float result slightly
+    above 255 (e.g. 255.4 from kernel arithmetic) could wrap to 0 when cast
+    to uint8.
+    """
+    data = np.full((1, 1, 32, 32, 32), 255, dtype=np.uint8)
+    image = to_ngff_image(data, dims=["t", "c", "z", "y", "x"])
+    multiscales = to_multiscales(
+        image, scale_factors=[2], method=Methods.ITKWASM_GAUSSIAN
+    )
+    scale1 = np.asarray(multiscales.images[1].data)
+    assert scale1.dtype == np.uint8
+    assert scale1.min() == 255
+    assert scale1.max() == 255
+
+
+def test_itkwasm_label_image_integer_unchanged_by_fix():
+    """``label_image`` downsampling already worked for integer dtypes — confirm
+    the Gaussian-only workaround did not regress it.
+    """
+    labels = np.zeros((1, 1, 32, 32, 32), dtype=np.uint16)
+    labels[..., :16, :, :] = 5
+    labels[..., 16:, :, :] = 7
+    image = to_ngff_image(labels, dims=["t", "c", "z", "y", "x"])
+    multiscales = to_multiscales(
+        image, scale_factors=[2], method=Methods.ITKWASM_LABEL_IMAGE
+    )
+    scale1 = np.asarray(multiscales.images[1].data)
+    assert scale1.dtype == np.uint16
+    # Label image downsampling assigns each output voxel a label from the
+    # input — the only values that may appear are the originals.
+    unique = set(np.unique(scale1).tolist())
+    assert unique.issubset({5, 7}), f"unexpected labels: {unique}"


### PR DESCRIPTION
## Summary

Closes #488.

Two distinct bugs reported by @odinsbane in #488 were still present after PR #503 (chunk-alignment / `PerformanceWarning` fix) and PR #505 (`KeyError: 'chunk_key_encoding'` fix):

1. **Integer-typed Gaussian downsample silently produces all zeros (data loss).** With `Methods.ITKWASM_GAUSSIAN` (the default), an input of `numpy.ones((1, 2, 80, 114, 129), dtype=uint16)` round-tripped to all-zeros for every downsampled level. The user reported \"the lowest resolution is always all zeros\" — this turned out to apply to *every* scale past scale 0 for low-valued integer inputs.

2. **OME-Zarr v0.5 writes silently override user-supplied `chunks=`.** Calling `to_multiscales(image, chunks=(1, 1, 64, 64, 64), ...)` followed by `to_ngff_zarr(..., version=\"0.5\")` produced scale 0 with chunks like `(1, 1, 40, 57, 129)` instead of the requested shape. The user reported \"It doesn't use the chunks I set\" and \"It scales x and y dimensions at different rates\" — the latter was actually a downstream symptom of the former (the surprising chunk shapes made it *look* like x/y had been scaled differently, but the on-disk scale metadata is uniform).

The third user complaint (\"defaults to version 0.5\") is by design and not addressed here.

## Root causes

### Bug 1 — `itkwasm_downsample.downsample()` precision loss on integer dtypes

Direct testing against `itkwasm_downsample==1.8.1` and `itkwasm==1.0b195`:

| input | output |
| --- | --- |
| `uint16` of 1   | 0 ❌ |
| `uint16` of 5   | 3 |
| `uint16` of 10  | 9 |
| `uint16` of 100 | 100 ✓ |
| `float32` of 1.0 | 1.0 ✓ |

The Gaussian filter in `itkwasm_downsample` performs internal arithmetic that truncates small integer values. `downsample_bin_shrink` and `downsample_label_image` are unaffected.

### Bug 2 — Zarr v3 picks its own chunk shape

`_write_array_direct` calls `zarr.create_array(...)` for `zarr_format == 3`. When the no-sharding path was taken, `chunks=` was never forwarded, so zarr applied its heuristic. The v0.4 path is unaffected because it uses `dask.array.to_zarr`, which honours the dask array's own chunks.

## Fixes

`py/ngff_zarr/methods/_itkwasm.py` (`_itkwasm_blur_and_downsample`):

- For `smoothing == \"gaussian\"` and integer `image_data.dtype`, cast to `float32` before calling `downsample()`.
- After the downsample, `np.rint` → `np.clip` (using `np.iinfo` bounds for the correct signed/unsigned range) → `astype(original_dtype)` so the public API and on-disk dtype are unchanged.
- The `label_image` branch is intentionally left alone — it operates correctly on integers and already preserves label values.

`py/ngff_zarr/to_ngff_zarr.py` (`_write_array_direct`):

- For `zarr_fmt == 3 and zarr_array is None and \"chunks\" not in to_zarr_kwargs`, set `to_zarr_kwargs[\"chunks\"] = tuple(c[0] for c in arr.chunks)`.
- The \"chunks not already present\" guard means the sharding path (which puts `chunks` into `cleaned_sharding_kwargs`) is a no-op for this branch — sharding behaviour is unchanged.

## Tests

`py/test/test_issue_488.py` — 15 new regression tests:

**Bug A (integer Gaussian downsample):**
- `test_itkwasm_gaussian_integer_constant_preserved[uint8|uint16|int16|int32]` — constant integer images round-trip exactly through `[2, 4]` Gaussian downsampling.
- `test_itkwasm_gaussian_uint16_small_values_not_truncated` — values 1, 2, 5, 10 survive.
- `test_itkwasm_gaussian_float_unaffected_by_fix` — float path unchanged.
- `test_itkwasm_gaussian_int16_negative_values_preserved` — exercises the signed-clip branch.
- `test_itkwasm_gaussian_uint8_near_max_no_overflow` — exercises the upper clip bound.
- `test_itkwasm_label_image_integer_unchanged_by_fix` — confirms label-image path was not collateral-damaged.

**Bug B (chunks preservation):**
- `test_chunks_parameter_preserved_on_roundtrip[0.4|0.5]` — user-supplied chunks round-trip.
- `test_chunks_default_not_overridden_by_zarr_heuristic` — default chunks from `to_multiscales` also survive.
- `test_chunks_per_shard_path_still_works` — sharding path still works (regression guard for the `\"chunks\" not in to_zarr_kwargs` gate).

**End-to-end:**
- `test_issue_488_user_reproducer_roundtrip[0.4|0.5]` — mirrors the user's exact reproducer (smaller shape).

## Verification

- New tests pass: `pytest test/test_issue_488.py` → **15 passed in 3.25s**
- Full existing suite green: `pytest test/ --ignore=test/test_zip_store_ozx.py` → **504 passed, 2 skipped, 0 failed** (3 m 28 s)
- `pre-commit run --files` clean on all touched files (ruff + ruff format)
- `coderabbit review --agent` clean (0 findings, run against both `-t uncommitted` and `--base main`)

## Test plan

- [ ] Run `pytest py/test/test_issue_488.py` in CI to confirm the regression suite passes on supported zarr versions
- [ ] Run the full `pytest py/test/` suite to confirm no regressions in the existing 504 tests
- [ ] Manually re-run the original user reproducer from issue #488 (`numpy.ones((1, 2, 801, 1146, 1290), dtype=uint16)`) on a machine with enough memory and confirm that all scales contain ones after round-trip
- [ ] Verify the `Bug A` fix does not measurably degrade performance on large integer inputs (the only added cost is `astype(np.float32)` + `np.rint` + clip + cast back per block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gaussian downsampling now preserves integer dtypes and value ranges (including negative and near-max values) and keeps label-image downsampling label-correct.
  * OME‑Zarr v0.5 writing preserves user-requested chunking across roundtrips.

* **Tests**
  * Added regression tests covering integer-preservation, label-image behavior, and chunking/roundtrip variants.

* **Chores**
  * Added .serena/ to .gitignore.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fideus-labs/ngff-zarr/pull/509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->