### PR TITLE
fix(py): avoid Windows PermissionError when writing .ozx over an existing directory

### DIFF
--- a/py/ngff_zarr/rfc9_zip.py
+++ b/py/ngff_zarr/rfc9_zip.py
@@ -157,6 +157,28 @@ def write_store_to_zip(
 
     ordered_files = _order_files_rfc9(all_files)
 
+    # Prepare the destination. On Windows, opening a directory path in write
+    # mode raises PermissionError (Errno 13) rather than IsADirectoryError, so
+    # an existing directory at the destination must be removed explicitly. This
+    # commonly happens when a plate was first written as an unzipped store to
+    # the same path before being converted to .ozx (see GH #241). A pre-existing
+    # regular file is fine -- zipfile mode="w" overwrites it.
+    if zip_path.exists() and zip_path.is_dir():
+        # Refuse to delete the source store itself.
+        if root_dir is not None:
+            try:
+                same_path = zip_path.resolve() == root_dir.resolve()
+            except OSError:
+                same_path = False
+            if same_path:
+                raise ValueError(
+                    f"Destination path '{zip_path}' is the same as the source "
+                    "store. Choose a different destination for the .ozx archive."
+                )
+        import shutil
+
+        shutil.rmtree(zip_path)
+
     # Create ZIP archive with ZIP64 support
     with zipfile.ZipFile(
         zip_path, mode="w", compression=compression, allowZip64=True

--- a/py/test/test_write_store_to_zip.py
+++ b/py/test/test_write_store_to_zip.py
@@ -129,6 +129,63 @@ def test_write_store_to_zip_hcs_plate():
     assert len(well.images) == 1
 
 
+def test_write_store_to_zip_overwrites_existing_directory():
+    """A pre-existing directory at the .ozx destination must be replaced.
+
+    Regression test for GH #241: on Windows, opening a directory path in write
+    mode raises PermissionError (Errno 13). This happens when a plate is first
+    written unzipped to the same path that is later used for the .ozx archive.
+    """
+    OUTPUT_DIR.mkdir(exist_ok=True)
+
+    data = np.random.randint(0, 255, (2, 32, 32), dtype=np.uint8)
+    image = to_ngff_image(data=data, dims=["c", "y", "x"])
+    multiscales = to_multiscales(image)
+
+    zarr_path = OUTPUT_DIR / "test_overwrite_dir.ome.zarr"
+    ozx_path = OUTPUT_DIR / "test_overwrite_dir.ozx"
+
+    to_ngff_zarr(str(zarr_path), multiscales, version="0.5")
+
+    # Simulate a stale directory (e.g. an unzipped store) sitting at the
+    # destination .ozx path.
+    if ozx_path.exists():
+        import shutil
+
+        shutil.rmtree(ozx_path, ignore_errors=True)
+    ozx_path.mkdir()
+    (ozx_path / "leftover.txt").write_text("stale")
+    assert ozx_path.is_dir()
+
+    # Should not raise (previously raised PermissionError on Windows).
+    write_store_to_zip(str(zarr_path), str(ozx_path), version="0.5")
+
+    assert ozx_path.is_file()
+    assert zipfile.is_zipfile(ozx_path)
+    with zipfile.ZipFile(ozx_path, "r") as zf:
+        assert "leftover.txt" not in zf.namelist()
+        assert "zarr.json" in zf.namelist()
+
+
+def test_write_store_to_zip_rejects_same_source_and_destination():
+    """Writing the archive onto the source store path must raise, not delete it."""
+    OUTPUT_DIR.mkdir(exist_ok=True)
+
+    data = np.random.randint(0, 255, (2, 32, 32), dtype=np.uint8)
+    image = to_ngff_image(data=data, dims=["c", "y", "x"])
+    multiscales = to_multiscales(image)
+
+    zarr_path = OUTPUT_DIR / "test_same_path_store"
+    to_ngff_zarr(str(zarr_path), multiscales, version="0.5")
+
+    with pytest.raises(ValueError, match="same as the source"):
+        write_store_to_zip(str(zarr_path), str(zarr_path), version="0.5")
+
+    # Source store must remain intact.
+    assert zarr_path.is_dir()
+    assert (zarr_path / "zarr.json").exists()
+
+
 def test_write_store_to_zip_with_path_object():
     """Test that write_store_to_zip works with Path objects too"""
     OUTPUT_DIR.mkdir(exist_ok=True)

--- a/py/test/test_write_store_to_zip.py
+++ b/py/test/test_write_store_to_zip.py
@@ -152,7 +152,10 @@ def test_write_store_to_zip_overwrites_existing_directory():
     if ozx_path.exists():
         import shutil
 
-        shutil.rmtree(ozx_path, ignore_errors=True)
+        if ozx_path.is_dir():
+            shutil.rmtree(ozx_path)
+        else:
+            ozx_path.unlink()
     ozx_path.mkdir()
     (ozx_path / "leftover.txt").write_text("stale")
     assert ozx_path.is_dir()


### PR DESCRIPTION
## Summary

Fixes a Windows-specific `PermissionError: [Errno 13]` crash when writing an HCS plate (or any zarr store) to the single-file `.ozx` format, reported in #241.

On Windows, opening a **directory** path in write mode raises `PermissionError` (Errno 13) rather than the `IsADirectoryError` seen on POSIX. `write_store_to_zip` opened the destination with `zipfile.ZipFile(zip_path, mode="w")` without checking whether a directory already existed there, so the call crashed. This surfaced through `HCSPlateWriter.__exit__`, which calls `write_store_to_zip` to materialize the `.ozx` archive when the context manager exits.

## Why

The reporter's workflow first wrote an unzipped plate to a path and then converted/wrote the same path as `.ozx`, leaving a stale directory at the destination. The resulting traceback ended at `rfc9_zip.py` in `write_store_to_zip`:

```
PermissionError: [Errno 13] Permission denied: '...WP96_4Pos_B4-10_DAPI_HCSplate.ozx'
```

This is the "Windows-platform-specific issue [that] will need a workaround" noted in the issue thread.

## What changed

`py/ngff_zarr/rfc9_zip.py` — in `write_store_to_zip`, the destination is now prepared before the ZIP archive is opened:

- If a **directory** already exists at the destination `.ozx` path, it is removed with `shutil.rmtree` so the archive can be created.
- A guard refuses to delete the directory when its resolved path is the **same as the source store**, raising a clear `ValueError` instead of destroying source data.
- Pre-existing **regular files** at the destination are left to be overwritten by `zipfile` `mode="w"` (unchanged behavior).

## Implementation details

- The same-path guard resolves both `zip_path` and the source store root (`root_dir`, already computed earlier in the function) and compares them; `OSError` during resolution is treated as "not the same path" so resolution failures never block a legitimate write.
- The fix is purely internal robustness — no public API signature or documented behavior changed, so `README.md` / `docs/hcs.md` required no updates.

## Tests

Adds two regression tests in `py/test/test_write_store_to_zip.py`:

- `test_write_store_to_zip_overwrites_existing_directory` — reproduces the #241 scenario (stale directory at the `.ozx` destination) and asserts the archive is created, is a valid zip, and no longer contains leftover files.
- `test_write_store_to_zip_rejects_same_source_and_destination` — asserts a `ValueError` is raised and the source store is left intact when source and destination paths coincide.

All related HCS/`.ozx` test files pass locally (`test_write_store_to_zip.py`, `test_hcs_ozx.py`, `test_hcs_plate_writer.py`, `test_rfc9_ozx.py`).

Fixes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoid failures when the destination path already exists as a directory by removing stale content and creating a valid ZIP archive.
  * Reject using the same filesystem location for both source data and destination archive.

* **Tests**
  * Added tests to verify cleanup/replacement of existing destination directories.
  * Added tests to ensure source and destination paths must differ.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fideus-labs/ngff-zarr/pull/518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->