### PR TITLE
fix(py): support reading blosc-encoded zarr v3 files with deprecated nthreads/blocksize metadata

### DIFF
--- a/py/ngff_zarr/from_ngff_zarr.py
+++ b/py/ngff_zarr/from_ngff_zarr.py
@@ -17,6 +17,53 @@ zarr_version_major = zarr_version.major
 # Supported remote URL schemes for storage
 REMOTE_URL_SCHEMES = ("s3://", "gs://", "azure://", "http://", "https://")
 
+# -- blosc codec backward-compatibility -----------------------------------
+
+# Deprecated Blosc codec configuration keys that should be stripped on read.
+_DEPRECATED_BLOSC_KEYS: frozenset = frozenset({"nthreads", "blocksize"})
+
+
+def _apply_blosc_codec_compat() -> None:
+    """Monkey-patch BloscCodec.from_dict to strip deprecated nthreads/blocksize keys.
+
+    Older zarr v3 implementations wrote ``nthreads`` and ``blocksize`` into the
+    Blosc codec metadata.  These keys are no longer recognised and cause
+    ``BloscCodec.from_dict`` to raise.  This patch filters them out (both at
+    the top level of the codec dict and inside a nested ``"configuration"``
+    mapping) before passing control to the original method.
+    """
+    try:
+        from zarr.codecs.blosc import BloscCodec
+
+        _orig = BloscCodec.from_dict
+
+        @classmethod
+        def _patched(cls, data):
+            if isinstance(data, dict):
+                if any(k in _DEPRECATED_BLOSC_KEYS for k in data):
+                    data = {
+                        k: v for k, v in data.items() if k not in _DEPRECATED_BLOSC_KEYS
+                    }
+                if "configuration" in data and isinstance(data["configuration"], dict):
+                    cfg = data["configuration"]
+                    if any(k in _DEPRECATED_BLOSC_KEYS for k in cfg):
+                        data = {
+                            **data,
+                            "configuration": {
+                                k: v
+                                for k, v in cfg.items()
+                                if k not in _DEPRECATED_BLOSC_KEYS
+                            },
+                        }
+            return _orig.__func__(cls, data)
+
+        BloscCodec.from_dict = _patched
+    except ImportError:
+        pass
+
+
+_apply_blosc_codec_compat()
+
 
 def from_ome_zarr(
     store: StoreLike,

--- a/py/test/test_from_ngff_zarr.py
+++ b/py/test/test_from_ngff_zarr.py
@@ -313,3 +313,86 @@ def test_from_ngff_zarr_array_at_root(tmp_path):
 
     with pytest.raises(ValueError, match="contains an array at the root level"):
         from_ngff_zarr(str(array_zarr))
+
+
+@pytest.mark.skipif(
+    zarr_version_major < 3, reason="BloscCodec.from_dict exists only in zarr 3"
+)
+class TestBloscCodecCompat:
+    """Tests for blosc codec backward-compatibility (Issue #516)."""
+
+    def test_from_dict_strips_nthreads(self):
+        """BloscCodec.from_dict should accept nthreads/blocksize without error."""
+        from zarr.codecs.blosc import BloscCname, BloscCodec
+
+        result = BloscCodec.from_dict(
+            {
+                "name": "blosc",
+                "configuration": {
+                    "cname": "zlib",
+                    "clevel": 5,
+                    "shuffle": "shuffle",
+                    "nthreads": 4,
+                    "blocksize": 0,
+                },
+            }
+        )
+        assert result is not None
+        assert result.cname == BloscCname.zlib
+        assert result.clevel == 5
+
+    def test_from_ngff_zarr_reads_with_nthreads(self, input_images):
+        """Reading a zarr v3 file with nthreads in blosc metadata should work."""
+        import json
+        import tempfile
+
+        from ngff_zarr import Methods
+
+        dataset_name = "cthead1"
+        image = input_images[dataset_name]
+        chunks = (64, 64)
+        multiscales = to_multiscales(
+            image, [2, 4], chunks=chunks, method=Methods.ITKWASM_GAUSSIAN
+        )
+
+        compressors = zarr.codecs.BloscCodec(
+            cname="zlib", clevel=5, shuffle=zarr.codecs.BloscShuffle.shuffle
+        )
+
+        version = "0.5"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            to_ngff_zarr(
+                tmpdir,
+                multiscales,
+                version=version,
+                compressors=compressors,
+                chunks_per_shard=2,
+            )
+
+            zarr_json_path = tmpdir + "/zarr.json"
+            with open(zarr_json_path) as f:
+                zarr_meta = json.load(f)
+
+            metadata = zarr_meta["consolidated_metadata"]["metadata"]
+            saw_nested_blosc = False
+            for scale_name in metadata:
+                codecs = metadata[scale_name].get("codecs", [])
+                for codec in codecs:
+                    if codec["name"] == "blosc":
+                        codec["configuration"]["nthreads"] = 4
+                        codec["configuration"]["blocksize"] = 0
+                    elif codec["name"] == "sharding_indexed":
+                        inner = codec["configuration"].get("codecs", [])
+                        for inner_codec in inner:
+                            if inner_codec["name"] == "blosc":
+                                saw_nested_blosc = True
+                                inner_codec["configuration"]["nthreads"] = 4
+                                inner_codec["configuration"]["blocksize"] = 0
+
+            assert saw_nested_blosc
+
+            with open(zarr_json_path, "w") as f:
+                json.dump(zarr_meta, f)
+
+            loaded = from_ngff_zarr(tmpdir)
+            assert loaded is not None


### PR DESCRIPTION
## Problem

`ngff_zarr.from_ngff_zarr()` fails when reading blosc-compressed zarr v3 files that contain deprecated `nthreads` or `blocksize` keys in the codec configuration metadata:

```
TypeError: BloscCodec.__init__() got an unexpected keyword argument 'nthreads'
```

These keys can appear in files written by older zarr-python versions or third-party tools. zarr 3.2+ `BloscCodec` no longer accepts them as constructor arguments, but still receives them via `BloscCodec.from_dict()` during metadata parsing.

Fixes #516.

## Changes

- **`py/ngff_zarr/from_ngff_zarr.py`** — Added `_apply_blosc_codec_compat()` which patches `zarr.codecs.blosc.BloscCodec.from_dict` at module import time to strip `nthreads` and `blocksize` from the configuration dict before the original classmethod processes it. Applied once at module level, so it takes effect before any zarr reads.
- **`py/test/test_from_ngff_zarr.py`** — Added `TestBloscCodecCompat` class with two tests:
  - `test_from_dict_strips_nthreads`: unit test verifying `BloscCodec.from_dict` accepts the deprecated keys directly.
  - `test_from_ngff_zarr_reads_with_nthreads`: integration test that writes a blosc-compressed zarr v3 store, injects `nthreads` and `blocksize` into both standalone and sharding-indexed codec configurations, and confirms `from_ngff_zarr` reads without error.

## Implementation Notes

- The patch only strips keys when they are actually present, avoiding overhead for well-formed metadata.
- `blocksize` is also stripped alongside `nthreads` since it is similarly deprecated.
- The `ImportError` guard handles environments where the blosc codec module is not available.
- The patching is idempotent under module reload — double-wrapping produces the same result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restores backward compatibility for Blosc codec metadata so NGFF/Zarr datasets containing legacy codec parameters can be read reliably.

* **Tests**
  * Added unit and integration tests to verify loading of multi-scale Zarr/NGFF datasets and ensure compatibility when legacy Blosc parameters are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->