### PR TITLE
refactor(py): cull all None metadata fields recursively

### DIFF
--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -5,7 +5,7 @@ import tempfile
 import warnings
 from dataclasses import asdict
 from pathlib import Path, PurePosixPath
-from typing import Literal
+from typing import Any, Literal
 
 from .methods._metadata import get_method_metadata
 
@@ -106,22 +106,44 @@ def _numcodecs_to_zarr_v3_codec(compressor):
     return None
 
 
-def _pop_metadata_optionals(metadata_dict, enabled_rfcs: list[int] | None = None):
-    for ax in metadata_dict["axes"]:
-        if ax["unit"] is None:
-            ax.pop("unit")
+def _remove_none_values(obj: Any) -> Any:
+    """Recursively strip ``None``-valued keys from nested dicts and lists.
 
-        # Handle RFC 4: Remove orientation if RFC 4 is not enabled
-        if not is_rfc4_enabled(enabled_rfcs) and "orientation" in ax:
-            ax.pop("orientation")
+    In the OME-Zarr spec the absence of a field carries no significance: only
+    fields that are present are meaningful, and an explicit ``null`` is treated
+    as equivalent to omitting the field. Culling every ``None`` therefore keeps
+    the written metadata clean without enumerating optional fields per spec
+    version. Only ``None`` is removed; falsy-but-valid values such as ``0``,
+    ``0.0``, ``""`` and empty collections are preserved.
+    """
+    if isinstance(obj, dict):
+        return {
+            key: _remove_none_values(value)
+            for key, value in obj.items()
+            if value is not None
+        }
+    if isinstance(obj, list):
+        return [_remove_none_values(item) for item in obj]
+    return obj
 
-    if metadata_dict["coordinateTransformations"] is None:
-        metadata_dict.pop("coordinateTransformations")
 
-    if metadata_dict["omero"] is None:
-        metadata_dict.pop("omero")
+def _pop_metadata_optionals(
+    metadata_dict: dict, enabled_rfcs: list[int] | None = None
+) -> dict:
+    """Strip optional metadata fields that must not be serialized.
 
-    return metadata_dict
+    Removes the draft RFC 4 ``orientation`` from every axis unless RFC 4 is
+    enabled, then recursively culls all remaining ``None``-valued keys.
+    """
+    # RFC 4 anatomical orientation is a draft feature gated behind an explicit
+    # opt-in. Drop it from every axis (even when populated) unless RFC 4 is
+    # enabled; populated orientations on enabled writes survive the None
+    # stripping below.
+    if not is_rfc4_enabled(enabled_rfcs):
+        for ax in metadata_dict.get("axes", []):
+            ax.pop("orientation", None)
+
+    return _remove_none_values(metadata_dict)
 
 
 def _prep_for_to_zarr(store: StoreLike, arr: dask.array.Array) -> dask.array.Array:

--- a/py/test/test_metadata_none_removal.py
+++ b/py/test/test_metadata_none_removal.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Unit tests for generalized removal of ``None`` metadata fields (issue #496)."""
+
+from ngff_zarr.to_ngff_zarr import _pop_metadata_optionals, _remove_none_values
+
+
+def test_remove_none_values_top_level():
+    """A top-level ``None`` value is dropped while other keys are kept."""
+    assert _remove_none_values({"a": 1, "b": None}) == {"a": 1}
+
+
+def test_remove_none_values_nested_dict():
+    """``None`` values are stripped recursively from nested dicts."""
+    obj = {"a": {"b": None, "c": 2}, "d": None}
+    assert _remove_none_values(obj) == {"a": {"c": 2}}
+
+
+def test_remove_none_values_inside_list():
+    """``None`` values are stripped from dicts nested inside lists."""
+    obj = {"axes": [{"name": "x", "unit": None}, {"name": "c", "unit": "second"}]}
+    assert _remove_none_values(obj) == {
+        "axes": [{"name": "x"}, {"name": "c", "unit": "second"}]
+    }
+
+
+def test_remove_none_values_preserves_falsy_but_valid():
+    """Falsy-but-valid values (``0``, ``""``, ``False``, empties) are kept."""
+    # Zero scales/translations and other falsy values must survive.
+    obj = {
+        "zero_int": 0,
+        "zero_float": 0.0,
+        "empty_str": "",
+        "false": False,
+        "empty_list": [],
+        "empty_dict": {},
+        "scale": [0.0, 1.0, 0.0],
+        "drop_me": None,
+    }
+    result = _remove_none_values(obj)
+    assert "drop_me" not in result
+    assert result == {
+        "zero_int": 0,
+        "zero_float": 0.0,
+        "empty_str": "",
+        "false": False,
+        "empty_list": [],
+        "empty_dict": {},
+        "scale": [0.0, 1.0, 0.0],
+    }
+
+
+def test_remove_none_values_returns_scalars_unchanged():
+    """Scalars, including ``None`` itself, pass through unchanged."""
+    assert _remove_none_values(5) == 5
+    assert _remove_none_values("x") == "x"
+    assert _remove_none_values(None) is None
+
+
+def _sample_metadata_dict():
+    """Metadata dict mixing populated, ``None``, and orientation fields."""
+    return {
+        "axes": [
+            {
+                "name": "x",
+                "type": "space",
+                "unit": None,
+                "orientation": {"type": "anatomical", "value": "left-to-right"},
+            },
+            {"name": "c", "type": "channel", "unit": None, "orientation": None},
+        ],
+        "datasets": [
+            {
+                "path": "scale0/image",
+                "coordinateTransformations": [{"scale": [1.0, 0.0], "type": "scale"}],
+            }
+        ],
+        "coordinateTransformations": None,
+        "omero": None,
+        "name": "image",
+        "version": "0.4",
+        "type": None,
+        "metadata": None,
+    }
+
+
+def test_pop_optionals_rfc4_disabled_drops_populated_orientation():
+    """With RFC 4 disabled, orientation and all ``None`` fields are removed."""
+    result = _pop_metadata_optionals(_sample_metadata_dict(), enabled_rfcs=None)
+    for axis in result["axes"]:
+        assert "orientation" not in axis
+        assert "unit" not in axis  # None units are stripped too
+    # All None-valued top-level fields are gone.
+    assert "coordinateTransformations" not in result
+    assert "omero" not in result
+    assert "type" not in result
+    assert "metadata" not in result
+    # Valid data, including a zero scale value, is preserved.
+    assert result["datasets"][0]["coordinateTransformations"][0]["scale"] == [1.0, 0.0]
+
+
+def test_pop_optionals_rfc4_enabled_keeps_populated_drops_null_orientation():
+    """With RFC 4 enabled, populated orientation stays but ``None`` is culled."""
+    result = _pop_metadata_optionals(_sample_metadata_dict(), enabled_rfcs=[4])
+    by_name = {axis["name"]: axis for axis in result["axes"]}
+    # Populated orientation survives when RFC 4 is enabled.
+    assert by_name["x"]["orientation"] == {
+        "type": "anatomical",
+        "value": "left-to-right",
+    }
+    # A None orientation on a non-spatial axis is culled, not serialized.
+    assert "orientation" not in by_name["c"]

--- a/py/test/test_rfc4_integration.py
+++ b/py/test/test_rfc4_integration.py
@@ -91,6 +91,9 @@ def test_rfc4_integration_with_enabled_rfcs():
                 assert "orientation" in axis
                 assert axis["orientation"]["type"] == "anatomical"
                 assert axis["orientation"]["value"] == "superior-to-inferior"
+
+
+def test_rfc4_integration_without_enabled_rfcs():
     """Test RFC 4 anatomical orientation when not enabled."""
     # Create a simple 3D image
     data = np.random.rand(10, 20, 30).astype(np.float32)
@@ -210,3 +213,55 @@ def test_rfc4_integration_with_other_rfcs():
         assert (
             len(spatial_axes_with_orientation) == 3
         )  # x, y, z should have orientation
+
+
+def test_rfc4_no_null_orientation_on_non_spatial_axes():
+    """Non-spatial axes must not emit ``orientation: null`` when RFC 4 is on.
+
+    Only the spatial axes carry an anatomical orientation. The time and
+    channel axes have ``orientation=None``, which must be culled rather than
+    serialized as an explicit ``null`` (regression test for issue #496).
+    """
+    data = np.random.rand(3, 2, 8, 16, 24).astype(np.float32)
+
+    orientations = {
+        "x": AnatomicalOrientation(value=AnatomicalOrientationValues.left_to_right),
+        "y": AnatomicalOrientation(
+            value=AnatomicalOrientationValues.posterior_to_anterior
+        ),
+        "z": AnatomicalOrientation(
+            value=AnatomicalOrientationValues.superior_to_inferior
+        ),
+    }
+
+    ngff_image = NgffImage(
+        data=data,
+        dims=("t", "c", "z", "y", "x"),
+        scale={"x": 1.0, "y": 1.0, "z": 1.0, "c": 1.0, "t": 1.0},
+        translation={"x": 0.0, "y": 0.0, "z": 0.0, "c": 0.0, "t": 0.0},
+        axes_orientations=orientations,
+    )
+
+    multiscales = to_multiscales(ngff_image, scale_factors=[2])
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        store_path = Path(temp_dir) / "test.zarr"
+
+        to_ngff_zarr(store=str(store_path), multiscales=multiscales, enabled_rfcs=[4])
+
+        zarr_group = zarr.open(str(store_path), mode="r")
+        raw_attrs = dict(zarr_group.attrs)
+        if "ome" in raw_attrs:
+            multiscales_metadata = raw_attrs["ome"]["multiscales"][0]
+        else:
+            multiscales_metadata = raw_attrs["multiscales"][0]
+        axes_metadata = multiscales_metadata["axes"]
+
+        for axis in axes_metadata:
+            if axis["name"] in ("t", "c"):
+                # The key must be absent entirely, not present with a null value.
+                assert "orientation" not in axis, (
+                    f"Non-spatial axis {axis['name']} should not carry orientation"
+                )
+            else:
+                assert axis["orientation"]["type"] == "anatomical"


### PR DESCRIPTION
## Summary

Closes #496.

`_pop_metadata_optionals` in `py/ngff_zarr/to_ngff_zarr.py` previously removed
`None` metadata fields by enumerating each optional field by hand (axis `unit`,
top-level `coordinateTransformations`, `omero`, plus RFC 4 `orientation`). That
approach has to be revisited every time a new OME-Zarr version or RFC adds a
field. This PR replaces it with a small recursive helper that culls **any**
`None`-valued key, making the cleanup version-agnostic.

As discussed in the issue, the OME-Zarr spec treats an absent field and an
explicit `null` as equivalent — only fields that are present carry meaning — so
stripping every `None` is safe.

## What changed

- **`_remove_none_values(obj)`** (new): recursively walks nested dicts/lists and
  drops every key whose value is `None`. Returns a new structure. Only `None` is
  removed — falsy-but-valid values (`0`, `0.0`, `""`, `False`, empty
  collections, and importantly zero `scale`/`translation` entries) are kept.
- **`_pop_metadata_optionals`**: reduced to (1) the RFC 4 orientation gate, then
  (2) a single `_remove_none_values(metadata_dict)` call. The per-field
  `pop(...)` logic is gone.

## Why the RFC 4 gate stays

The issue suggested the `enabled_rfcs` check might be unnecessary. It is still
required, but for a reason orthogonal to `None`-stripping: `orientation` is
populated onto axes back in `to_multiscales()`, independent of which RFCs are
enabled at write time. RFC 4 is a draft feature, so a **populated** orientation
must remain opt-in and is dropped unless `enabled_rfcs=[4]`. Removing the gate
would leak draft metadata for any image that happens to carry orientations
(`test_rfc4_integration_without_enabled_rfcs` asserts exactly this). The gate is
therefore kept; the recursive pass then handles the `None` case for both
enabled and disabled writes.

## Behavioral fix

With RFC 4 enabled on a 5D image, the non-spatial `t`/`c` axes used to serialize
`"orientation": null` (their orientation is `None`, and the old code only popped
orientation when RFC 4 was *disabled*). These keys are now culled instead of
written as `null`.

Standard output is otherwise unchanged: in practice `to_multiscales` always sets
a downsampling method, so top-level `type`/`metadata` are non-null, and the
existing baseline `DeepDiff` comparisons still match byte-for-byte.

## Tests

- **`py/test/test_metadata_none_removal.py`** (new): 7 unit tests for
  `_remove_none_values` (top-level / nested / in-list removal, falsy-value
  preservation, scalar passthrough) and `_pop_metadata_optionals` (RFC 4
  on/off).
- **`py/test/test_rfc4_integration.py`**: added
  `test_rfc4_no_null_orientation_on_non_spatial_axes` (regression for the fix
  above) and split `test_rfc4_integration_without_enabled_rfcs` into its own
  function — its `def` line was missing, so its gating assertions had been
  running as a non-isolated block inside the with-enabled test.

Verified locally (115 tests) across the new unit tests, all RFC 4 tests,
multiscales metadata/type, baseline-comparison tests
(`test_from_ngff_zarr`, `test_to_ngff_zarr_{dask_image,itkwasm,itk,tensorstore}`),
v0.5 / RFC 2, sharding, and RFC 9 `.ozx`. `ruff format` + `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Metadata output now recursively removes null optional fields (including nested dicts/lists) while preserving falsy-but-valid values (0, "", False, empty lists/dicts). RFC4 anatomical orientation is handled correctly: orientation entries are removed when RFC4 is disabled, and non-spatial axes do not emit null orientation when RFC4 is enabled.

* **Tests**
  * Added unit and integration tests covering recursive metadata cleaning, nested structures, lists, falsy values, and RFC4 orientation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->