### PR TITLE
feat(py,ts): add v0.6 coordinate/displacement transformations with indexTransformation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,3 +410,8 @@ export class NgffImage {
   with `pixi run --as-is -e test pytest tests/test_*.py`. Do not try to use
   `pixi run --as-is pytest ...` or `pixi run --as-is python -c '<command>'` as these will not
   work correctly.
+- **Before every `git commit`, ALWAYS run the pre-commit lint tasks.** Run
+  `pixi run -e lint lint` from `py/` and `pixi run lint` from `ts/` until they
+  pass cleanly with no file modifications. When pre-commit hooks modify files,
+  re-stage them with `git add` and re-run lint until all hooks pass. Failure to
+  do this causes the `ci` to fail.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,7 +411,7 @@ export class NgffImage {
   `pixi run --as-is pytest ...` or `pixi run --as-is python -c '<command>'` as these will not
   work correctly.
 - **Before every `git commit`, ALWAYS run the pre-commit lint tasks.** Run
-  `pixi run -e lint lint` from `py/` and `pixi run lint` from `ts/` until they
+  `pixi run --as-is lint` from `py/` and `pixi run --as-is lint` from `ts/` until they
   pass cleanly with no file modifications. When pre-commit hooks modify files,
   re-stage them with `git add` and re-run lint until all hooks pass. Failure to
   do this causes the `ci` to fail.

--- a/py/ngff_zarr/_supported_versions.py
+++ b/py/ngff_zarr/_supported_versions.py
@@ -28,7 +28,8 @@ class NgffVersion(StrEnum):
     V03 = "0.3"
     V04 = "0.4"
     V05 = "0.5"
-    LATEST = "0.5"
+    V06 = "0.6"
+    LATEST = "0.6"
 
 
 # Supported NGFF specification versions
@@ -38,4 +39,5 @@ SUPPORTED_VERSIONS = (
     NgffVersion.V03,
     NgffVersion.V04,
     NgffVersion.V05,
+    NgffVersion.V06,
 )

--- a/py/ngff_zarr/spec/0.6/schemas/_version.schema
+++ b/py/ngff_zarr/spec/0.6/schemas/_version.schema
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6/schemas/_version.schema",
+  "title": "OME-Zarr Metadata version",
+  "description": "The version of the OME-Zarr Metadata",
+  "type": "string",
+  "enum": [
+    "0.6"
+  ]
+}

--- a/py/ngff_zarr/spec/0.6/schemas/bf2raw.schema
+++ b/py/ngff_zarr/spec/0.6/schemas/bf2raw.schema
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6/schemas/bf2raw.schema",
+  "title": "OME-Zarr container produced by bioformats2raw",
+  "description": "The zarr.json attributes key",
+  "type": "object",
+  "properties": {
+    "ome": {
+      "description": "The versioned OME-Zarr Metadata namespace",
+      "type": "object",
+      "properties": {
+        "bioformats2raw.layout": {
+          "description": "The top-level identifier metadata added by bioformats2raw",
+          "type": "number",
+          "enum": [
+            3
+          ]
+        },
+        "version": {
+          "$ref": "https://ngff.openmicroscopy.org/0.6/schemas/_version.schema"
+        }
+      },
+      "required": [
+        "bioformats2raw.layout",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "ome"
+  ]
+}

--- a/py/ngff_zarr/spec/0.6/schemas/image.schema
+++ b/py/ngff_zarr/spec/0.6/schemas/image.schema
@@ -1,0 +1,625 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6/schemas/image.schema",
+  "title": "OME-Zarr Image",
+  "description": "The zarr.json attributes key",
+  "type": "object",
+  "properties": {
+    "ome": {
+      "description": "The versioned OME-Zarr Metadata namespace",
+      "type": "object",
+      "properties": {
+        "multiscales": {
+          "$ref": "#/$defs/multiscales"
+        },
+        "omero": {
+          "$ref": "#/$defs/omero"
+        },
+        "version": {
+          "$ref": "https://ngff.openmicroscopy.org/0.6/schemas/_version.schema"
+        }
+      },
+      "required": [
+        "multiscales",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "ome"
+  ],
+  "$defs": {
+    "multiscales": {
+      "description": "The multiscale datasets for this image",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "datasets": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "coordinateTransformations": {
+                  "$ref": "#/$defs/datasetCoordinateTransformations"
+                }
+              },
+              "required": [
+                "path",
+                "coordinateTransformations"
+              ]
+            }
+          },
+          "axes": {
+            "$ref": "#/$defs/axes"
+          },
+          "coordinateTransformations": {
+            "$ref": "#/$defs/coordinateTransformations"
+          },
+          "coordinateSystems": {
+            "$ref": "#/$defs/coordinateSystems"
+          }
+        },
+        "required": [
+          "datasets",
+          "axes"
+        ]
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "omero": {
+      "type": "object",
+      "properties": {
+        "channels": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "window": {
+                "type": "object",
+                "properties": {
+                  "end": {
+                    "type": "number"
+                  },
+                  "max": {
+                    "type": "number"
+                  },
+                  "min": {
+                    "type": "number"
+                  },
+                  "start": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "start",
+                  "min",
+                  "end",
+                  "max"
+                ]
+              },
+              "label": {
+                "type": "string"
+              },
+              "family": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "active": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "channels"
+      ]
+    },
+    "axes": {
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 2,
+      "maxItems": 5,
+      "contains": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "space"
+            ]
+          },
+          "unit": {
+            "type": "string"
+          }
+        }
+      },
+      "minContains": 2,
+      "maxContains": 3,
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "channel",
+                  "time",
+                  "space"
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "not": {
+                  "enum": [
+                    "space",
+                    "time",
+                    "channel"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        ]
+      }
+    },
+    "coordinateSystems": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "axes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "unit": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ]
+            }
+          }
+        },
+        "required": [
+          "name",
+          "axes"
+        ]
+      }
+    },
+    "datasetCoordinateTransformations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "scale"
+                ]
+              },
+              "scale": {
+                "type": "array",
+                "minItems": 2,
+                "items": {
+                  "type": "number"
+                }
+              }
+            },
+            "required": [
+              "type",
+              "scale"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "translation"
+                ]
+              },
+              "translation": {
+                "type": "array",
+                "minItems": 2,
+                "items": {
+                  "type": "number"
+                }
+              }
+            },
+            "required": [
+              "type",
+              "translation"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "identity"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      }
+    },
+    "coordinateTransformations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "identity"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "mapAxis"
+                ]
+              },
+              "mapAxis": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "type",
+              "mapAxis"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "scale"
+                ]
+              },
+              "scale": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              },
+              "path": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              { "required": ["scale"] },
+              { "required": ["path"] }
+            ],
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "translation"
+                ]
+              },
+              "translation": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              },
+              "path": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              { "required": ["translation"] },
+              { "required": ["path"] }
+            ],
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "affine"
+                ]
+              },
+              "affine": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              },
+              "path": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              { "required": ["affine"] },
+              { "required": ["path"] }
+            ],
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "rotation"
+                ]
+              },
+              "rotation": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              },
+              "path": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              { "required": ["rotation"] },
+              { "required": ["path"] }
+            ],
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "displacements"
+                ]
+              },
+              "path": {
+                "type": "string"
+              },
+              "indexTransformation": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": ["identity"]
+                      }
+                    },
+                    "required": ["type"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": ["scale"]
+                      },
+                      "scale": {
+                        "type": "array",
+                        "items": { "type": "number" }
+                      }
+                    },
+                    "required": ["type", "scale"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": ["sequence"]
+                      },
+                      "transformations": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": { "type": "string", "enum": ["scale"] },
+                                "scale": { "type": "array", "items": { "type": "number" } }
+                              },
+                              "required": ["type", "scale"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": { "type": "string", "enum": ["translation"] },
+                                "translation": { "type": "array", "items": { "type": "number" } }
+                              },
+                              "required": ["type", "translation"]
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "required": ["type", "transformations"]
+                  }
+                ]
+              },
+              "interpolation": {
+                "type": "string",
+                "enum": ["nearest", "linear", "cubic"]
+              }
+            },
+            "required": [
+              "type",
+              "path",
+              "indexTransformation"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "coordinates"
+                ]
+              },
+              "path": {
+                "type": "string"
+              },
+              "indexTransformation": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": ["identity"]
+                      }
+                    },
+                    "required": ["type"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": ["scale"]
+                      },
+                      "scale": {
+                        "type": "array",
+                        "items": { "type": "number" }
+                      }
+                    },
+                    "required": ["type", "scale"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": ["sequence"]
+                      },
+                      "transformations": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": { "type": "string", "enum": ["scale"] },
+                                "scale": { "type": "array", "items": { "type": "number" } }
+                              },
+                              "required": ["type", "scale"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": { "type": "string", "enum": ["translation"] },
+                                "translation": { "type": "array", "items": { "type": "number" } }
+                              },
+                              "required": ["type", "translation"]
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "required": ["type", "transformations"]
+                  }
+                ]
+              },
+              "interpolation": {
+                "type": "string",
+                "enum": ["nearest", "linear", "cubic"]
+              }
+            },
+            "required": [
+              "type",
+              "path",
+              "indexTransformation"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/py/ngff_zarr/spec/0.6/schemas/label.schema
+++ b/py/ngff_zarr/spec/0.6/schemas/label.schema
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6/schemas/label.schema",
+  "title": "OME-Zarr labelled image schema",
+  "description": "The zarr.json attributes key",
+  "type": "object",
+  "properties": {
+    "ome": {
+      "description": "The versioned OME-Zarr Metadata namespace",
+      "type": "object",
+      "properties": {
+        "image-label": {
+          "$ref": "#/$defs/image-label"
+        },
+        "version": {
+          "$ref": "https://ngff.openmicroscopy.org/0.6/schemas/_version.schema"
+        }
+      },
+      "required": [
+        "image-label",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "ome"
+  ],
+  "$defs": {
+    "image-label": {
+      "type": "object",
+      "properties": {
+        "colors": {
+          "description": "The colors for this label image",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "label-value": {
+                "description": "The value of the label",
+                "type": "number"
+              },
+              "rgba": {
+                "description": "The RGBA color stored as an array of four integers between 0 and 255",
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 255
+                },
+                "minItems": 4,
+                "maxItems": 4
+              }
+            },
+            "required": [
+              "label-value"
+            ]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "properties": {
+          "description": "The properties for this label image",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "label-value": {
+                "description": "The pixel value for this label",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "label-value"
+            ]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "source": {
+          "description": "The source of this label image",
+          "type": "object",
+          "properties": {
+            "image": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/py/ngff_zarr/spec/0.6/schemas/ome.schema
+++ b/py/ngff_zarr/spec/0.6/schemas/ome.schema
@@ -15,7 +15,7 @@
           "items": {
             "type": "string"
           },
-          "minContains": 1
+          "minItems": 1
         },
         "version": {
           "$ref": "https://ngff.openmicroscopy.org/0.6/schemas/_version.schema"

--- a/py/ngff_zarr/spec/0.6/schemas/ome.schema
+++ b/py/ngff_zarr/spec/0.6/schemas/ome.schema
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6/schemas/ome.schema",
+  "title": "OME-Zarr group produced by bioformats2raw to contain OME metadata",
+  "description": "The zarr.json attributes key",
+  "type": "object",
+  "properties": {
+    "ome": {
+      "description": "The versioned OME-Zarr Metadata namespace",
+      "type": "object",
+      "properties": {
+        "series": {
+          "description": "An array of the same length and the same order as the images defined in the OME-XML",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minContains": 1
+        },
+        "version": {
+          "$ref": "https://ngff.openmicroscopy.org/0.6/schemas/_version.schema"
+        }
+      },
+      "required": [
+        "series",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "ome"
+  ]
+}

--- a/py/ngff_zarr/spec/0.6/schemas/ome_zarr.schema
+++ b/py/ngff_zarr/spec/0.6/schemas/ome_zarr.schema
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6/schemas/ome_zarr.schema",
+  "anyOf": [
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.6/schemas/bf2raw.schema"
+    },
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.6/schemas/image.schema"
+    },
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.6/schemas/label.schema"
+    },
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.6/schemas/ome.schema"
+    },
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.6/schemas/plate.schema"
+    },
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.6/schemas/well.schema"
+    }
+  ]
+}

--- a/py/ngff_zarr/spec/0.6/schemas/plate.schema
+++ b/py/ngff_zarr/spec/0.6/schemas/plate.schema
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6/schemas/plate.schema",
+  "title": "OME-Zarr plate schema",
+  "description": "The zarr.json attributes key",
+  "type": "object",
+  "properties": {
+    "ome": {
+      "description": "The versioned OME-Zarr Metadata namespace",
+      "type": "object",
+      "properties": {
+        "plate": {
+          "type": "object",
+          "properties": {
+            "acquisitions": {
+              "description": "The acquisitions for this plate",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "description": "A unique identifier within the context of the plate",
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "maximumfieldcount": {
+                    "description": "The maximum number of fields of view for the acquisition",
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  },
+                  "name": {
+                    "description": "The name of the acquisition",
+                    "type": "string"
+                  },
+                  "description": {
+                    "description": "The description of the acquisition",
+                    "type": "string"
+                  },
+                  "starttime": {
+                    "description": "The start timestamp of the acquisition, expressed as epoch time i.e. the number seconds since the Epoch",
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "endtime": {
+                    "description": "The end timestamp of the acquisition, expressed as epoch time i.e. the number seconds since the Epoch",
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            },
+            "field_count": {
+              "description": "The maximum number of fields per view across all wells",
+              "type": "integer",
+              "exclusiveMinimum": 0
+            },
+            "name": {
+              "description": "The name of the plate",
+              "type": "string"
+            },
+            "columns": {
+              "description": "The columns of the plate",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "The column name",
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9]+$"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            },
+            "rows": {
+              "description": "The rows of the plate",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "The row name",
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9]+$"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            },
+            "wells": {
+              "description": "The wells of the plate",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "description": "The path to the well subgroup",
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9]+/[A-Za-z0-9]+$"
+                  },
+                  "rowIndex": {
+                    "description": "The index of the well in the rows list",
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "columnIndex": {
+                    "description": "The index of the well in the columns list",
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "path",
+                  "rowIndex",
+                  "columnIndex"
+                ]
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          },
+          "required": [
+            "columns",
+            "rows",
+            "wells"
+          ]
+        },
+        "version": {
+          "$ref": "https://ngff.openmicroscopy.org/0.6/schemas/_version.schema"
+        }
+      },
+      "required": [
+        "plate",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "ome"
+  ]
+}

--- a/py/ngff_zarr/spec/0.6/schemas/strict_image.schema
+++ b/py/ngff_zarr/spec/0.6/schemas/strict_image.schema
@@ -1,0 +1,25 @@
+{
+  "$id": "https://ngff.openmicroscopy.org/0.6/schemas/strict_image.schema",
+  "allOf": [
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.6/schemas/image.schema"
+    },
+    {
+      "properties": {
+        "ome": {
+          "properties": {
+            "multiscales": {
+              "items": {
+                "required": [
+                  "metadata",
+                  "type",
+                  "name"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/py/ngff_zarr/spec/0.6/schemas/strict_label.schema
+++ b/py/ngff_zarr/spec/0.6/schemas/strict_label.schema
@@ -1,0 +1,21 @@
+{
+  "$id": "https://ngff.openmicroscopy.org/0.6/schemas/strict_label.schema",
+  "allOf": [
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.6/schemas/label.schema"
+    },
+    {
+      "properties": {
+        "ome": {
+          "properties": {
+            "image-label": {
+              "required": [
+                "colors"
+              ]
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/py/ngff_zarr/spec/0.6/schemas/strict_plate.schema
+++ b/py/ngff_zarr/spec/0.6/schemas/strict_plate.schema
@@ -1,0 +1,31 @@
+{
+  "$id": "https://ngff.openmicroscopy.org/0.6/schemas/strict_plate.schema",
+  "allOf": [
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.6/schemas/plate.schema"
+    },
+    {
+      "properties": {
+        "ome": {
+          "properties": {
+            "plate": {
+              "properties": {
+                "acquisitions": {
+                  "items": {
+                    "required": [
+                      "name",
+                      "maximumfieldcount"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "name"
+              ]
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/py/ngff_zarr/spec/0.6/schemas/strict_well.schema
+++ b/py/ngff_zarr/spec/0.6/schemas/strict_well.schema
@@ -1,0 +1,8 @@
+{
+  "$id": "https://ngff.openmicroscopy.org/0.6/schemas/strict_well.schema",
+  "allOf": [
+    {
+      "$ref": "https://ngff.openmicroscopy.org/0.6/schemas/well.schema"
+    }
+  ]
+}

--- a/py/ngff_zarr/spec/0.6/schemas/well.schema
+++ b/py/ngff_zarr/spec/0.6/schemas/well.schema
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6/schemas/well.schema",
+  "title": "OME-Zarr well schema",
+  "description": "JSON from OME-Zarr zarr.json",
+  "type": "object",
+  "properties": {
+    "ome": {
+      "description": "The versioned OME-Zarr Metadata namespace",
+      "type": "object",
+      "properties": {
+        "well": {
+          "type": "object",
+          "properties": {
+            "images": {
+              "description": "The fields of view for this well",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "acquisition": {
+                    "description": "A unique identifier within the context of the plate",
+                    "type": "integer"
+                  },
+                  "path": {
+                    "description": "The path for this field of view subgroup",
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9]+$"
+                  }
+                },
+                "required": [
+                  "path"
+                ]
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          },
+          "required": [
+            "images"
+          ]
+        },
+        "version": {
+          "$ref": "https://ngff.openmicroscopy.org/0.6/schemas/_version.schema"
+        }
+      },
+      "required": [
+        "well",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "ome"
+  ]
+}

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -115,8 +115,16 @@ def _pop_metadata_optionals(metadata_dict, enabled_rfcs: list[int] | None = None
         if not is_rfc4_enabled(enabled_rfcs) and "orientation" in ax:
             ax.pop("orientation")
 
-    if metadata_dict["coordinateTransformations"] is None:
-        metadata_dict.pop("coordinateTransformations")
+    # Clean up coordinateTransformations
+    ct = metadata_dict.get("coordinateTransformations")
+    if ct is None:
+        metadata_dict.pop("coordinateTransformations", None)
+    elif isinstance(ct, list):
+        for transform in ct:
+            if isinstance(transform, dict):
+                for key in list(transform.keys()):
+                    if transform[key] is None:
+                        transform.pop(key)
 
     if metadata_dict["omero"] is None:
         metadata_dict.pop("omero")

--- a/py/ngff_zarr/v04/zarr_metadata.py
+++ b/py/ngff_zarr/v04/zarr_metadata.py
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
 # SPDX-License-Identifier: MIT
+from __future__ import annotations
+
 import functools
 import logging
 import re
@@ -22,7 +24,14 @@ SupportedDims = Union[
 ]
 
 SpatialDims = Union[Literal["x"], Literal["y"], Literal["z"]]
-AxesType = Union[Literal["time"], Literal["space"], Literal["channel"]]
+AxesType = Union[
+    Literal["time"],
+    Literal["space"],
+    Literal["channel"],
+    Literal["array"],
+    Literal["coordinate"],
+    Literal["displacement"],
+]
 SpaceUnits = Union[
     Literal["angstrom"],
     Literal["attometer"],
@@ -146,6 +155,69 @@ def is_unit_supported(unit: str) -> bool:
     return (unit in time_units) or (unit in space_units)
 
 
+def _parse_transform(transform_dict: dict) -> Transform:
+    """Parse a single transformation dict into its appropriate Transform type."""
+    transform_type = transform_dict.get("type", "")
+
+    if transform_type == "identity":
+        return Identity()
+
+    if transform_type == "scale":
+        scale_val = transform_dict.get("scale")
+        if scale_val is not None:
+            return Scale(scale_val)
+        if "path" in transform_dict:
+            return Scale(scale=[], type="scale")
+
+    if transform_type == "translation":
+        translation_val = transform_dict.get("translation")
+        if translation_val is not None:
+            return Translation(translation_val)
+        if "path" in transform_dict:
+            return Translation(translation=[], type="translation")
+
+    if transform_type == "displacements":
+        path = transform_dict.get("path", "")
+        idx_transform = None
+        if "indexTransformation" in transform_dict:
+            idx_transform = _parse_transform(transform_dict["indexTransformation"])
+        return Displacements(
+            path=path,
+            indexTransformation=idx_transform,
+            interpolation=transform_dict.get("interpolation"),
+        )
+
+    if transform_type == "coordinates":
+        path = transform_dict.get("path", "")
+        idx_transform = None
+        if "indexTransformation" in transform_dict:
+            idx_transform = _parse_transform(transform_dict["indexTransformation"])
+        return Coordinates(
+            path=path,
+            indexTransformation=idx_transform,
+            interpolation=transform_dict.get("interpolation"),
+        )
+
+    if "scale" in transform_dict:
+        return Scale(transform_dict["scale"])
+    if "translation" in transform_dict:
+        return Translation(transform_dict["translation"])
+
+    return Scale([], type=transform_type)
+
+
+def _parse_group_transforms(
+    transforms: list[dict] | None,
+) -> list[Transform] | None:
+    """Parse group-level coordinate transformations."""
+    if transforms is None:
+        return None
+    result = []
+    for t in transforms:
+        result.append(_parse_transform(t))
+    return result
+
+
 @functools.lru_cache(maxsize=1)
 def _get_axis_fields() -> set[str]:
     """Get the set of valid field names for the Axis dataclass.
@@ -209,7 +281,25 @@ class Translation:
     type: str = "translation"
 
 
-Transform = Union[Scale, Translation]
+@dataclass
+class Displacements:
+    path: str
+    indexTransformation: Transform | None = None
+    type: str = "displacements"
+    interpolation: str | None = None
+    name: str | None = None
+
+
+@dataclass
+class Coordinates:
+    path: str
+    indexTransformation: Transform | None = None
+    type: str = "coordinates"
+    interpolation: str | None = None
+    name: str | None = None
+
+
+Transform = Union[Scale, Translation, Identity, Displacements, Coordinates]
 
 
 @dataclass
@@ -310,7 +400,7 @@ class Metadata:
     type: str | None = None
     metadata: MethodMetadata | None = None
 
-    def to_version(self, version: str | NgffVersion) -> "Metadata":
+    def to_version(self, version: str | NgffVersion) -> Metadata:
         if isinstance(version, str):
             # raise error for invalid version string
             version = NgffVersion(version)
@@ -322,14 +412,14 @@ class Metadata:
         raise ValueError(f"Unsupported version conversion: 0.4 -> {version}")
 
     @classmethod
-    def from_version(cls, metadata: "Metadata") -> "Metadata":
+    def from_version(cls, metadata: Metadata) -> Metadata:
         from ..v05.zarr_metadata import Metadata as Metadata_v05
 
         if isinstance(metadata, Metadata_v05):
             return cls._from_v05(metadata)
         raise ValueError(f"Unsupported metadata type: {type(metadata)}")
 
-    def _to_v05(self) -> "Metadata":
+    def _to_v05(self) -> Metadata:
         from ..v05.zarr_metadata import Metadata as Metadata_v05
 
         metadata = Metadata_v05(
@@ -344,7 +434,7 @@ class Metadata:
         return metadata
 
     @classmethod
-    def _from_v05(cls, metadata_v05: "Metadata") -> "Metadata":
+    def _from_v05(cls, metadata_v05: Metadata) -> Metadata:
         metadata = cls(
             axes=metadata_v05.axes,
             datasets=metadata_v05.datasets,
@@ -363,7 +453,7 @@ class Metadata:
         store: StoreLike,
         validate: bool = False,
         subpath: str | None = None,
-    ) -> tuple["Metadata", list["NgffImage"]]:
+    ) -> tuple[Metadata, list[NgffImage]]:
         """Create Metadata instance from ome-zarr metadata dictionary.
 
         Parameters
@@ -498,6 +588,8 @@ class Metadata:
                         coordinateTransformations.append(
                             Translation(transformation["translation"])
                         )
+                    elif transformation.get("type") == "identity":
+                        coordinateTransformations.append(Identity())
             datasets.append(
                 Dataset(
                     path=dataset["path"],
@@ -521,7 +613,9 @@ class Metadata:
             name=root_attrs.get("name", "image"),
             version=root_attrs.get("version", "0.4"),
             omero=omero,
-            coordinateTransformations=root_attrs.get("coordinateTransformations", None),
+            coordinateTransformations=_parse_group_transforms(
+                root_attrs.get("coordinateTransformations")
+            ),
         )
 
         return metadata, images

--- a/py/ngff_zarr/v04/zarr_metadata.py
+++ b/py/ngff_zarr/v04/zarr_metadata.py
@@ -167,14 +167,18 @@ def _parse_transform(transform_dict: dict) -> Transform:
         if scale_val is not None:
             return Scale(scale_val)
         if "path" in transform_dict:
-            return Scale(scale=[], type="scale")
+            raise ValueError(
+                f"Path-backed scale transforms are not supported: {transform_dict}"
+            )
 
     if transform_type == "translation":
         translation_val = transform_dict.get("translation")
         if translation_val is not None:
             return Translation(translation_val)
         if "path" in transform_dict:
-            return Translation(translation=[], type="translation")
+            raise ValueError(
+                f"Path-backed translation transforms are not supported: {transform_dict}"
+            )
 
     if transform_type == "displacements":
         path = transform_dict.get("path", "")
@@ -203,7 +207,7 @@ def _parse_transform(transform_dict: dict) -> Transform:
     if "translation" in transform_dict:
         return Translation(transform_dict["translation"])
 
-    return Scale([], type=transform_type)
+    raise ValueError(f"Unsupported transform type: {transform_dict}")
 
 
 def _parse_group_transforms(

--- a/py/test/test_tiff_pyramid_rgb.py
+++ b/py/test/test_tiff_pyramid_rgb.py
@@ -68,14 +68,14 @@ def test_pyramidal_rgb_tiff_channel_consistency():
     # Should be a NgffMultiscales object (pyramid was reused)
     from ngff_zarr.multiscales import NgffMultiscales
 
-    assert isinstance(
-        result, NgffMultiscales
-    ), "Should return NgffMultiscales for pyramidal TIFF"
+    assert isinstance(result, NgffMultiscales), (
+        "Should return NgffMultiscales for pyramidal TIFF"
+    )
 
     # Check that we have 3 pyramid levels
-    assert (
-        len(result.images) == 3
-    ), f"Expected 3 pyramid levels, got {len(result.images)}"
+    assert len(result.images) == 3, (
+        f"Expected 3 pyramid levels, got {len(result.images)}"
+    )
 
     # Verify all levels have consistent dimensions
     for i, img in enumerate(result.images):
@@ -88,9 +88,9 @@ def test_pyramidal_rgb_tiff_channel_consistency():
         # Check shape consistency
         expected_size = 256 // (2**i)  # 256, 128, 64
         expected_shape = (expected_size, expected_size, 3)
-        assert (
-            img.data.shape == expected_shape
-        ), f"Level {i} should have shape {expected_shape}, got {img.data.shape}"
+        assert img.data.shape == expected_shape, (
+            f"Level {i} should have shape {expected_shape}, got {img.data.shape}"
+        )
 
     # Verify data can be computed without errors
     for i, img in enumerate(result.images):
@@ -101,9 +101,9 @@ def test_pyramidal_rgb_tiff_channel_consistency():
             4,
             3,
         ), f"Level {i} slice should have shape (4, 4, 3), got {slice_data.shape}"
-        assert (
-            slice_data.dtype == np.uint8
-        ), f"Level {i} should preserve uint8 dtype, got {slice_data.dtype}"
+        assert slice_data.dtype == np.uint8, (
+            f"Level {i} should preserve uint8 dtype, got {slice_data.dtype}"
+        )
 
 
 def test_pyramidal_grayscale_tiff():
@@ -156,6 +156,6 @@ def test_pyramidal_grayscale_tiff():
         ), f"Level {i} should have dims ('y', 'x'), got {img.dims}"
         expected_size = 256 // (2**i)
         expected_shape = (expected_size, expected_size)
-        assert (
-            img.data.shape == expected_shape
-        ), f"Level {i} should have shape {expected_shape}, got {img.data.shape}"
+        assert img.data.shape == expected_shape, (
+            f"Level {i} should have shape {expected_shape}, got {img.data.shape}"
+        )

--- a/py/test/test_v06_transforms.py
+++ b/py/test/test_v06_transforms.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Tests for v0.6 coordinate/displacement transformation types."""
+
+from dataclasses import asdict
+
+import numpy as np
+from ngff_zarr import from_ngff_zarr, to_multiscales, to_ngff_image, to_ngff_zarr
+from ngff_zarr.v04.zarr_metadata import (
+    Coordinates,
+    Displacements,
+    Identity,
+    Scale,
+    Transform,
+    Translation,
+    _parse_group_transforms,
+    _parse_transform,
+)
+
+
+def test_displacements_dataclass():
+    d = Displacements(
+        path="coordinateTransformations/field",
+        indexTransformation=Scale(scale=[1.0, 2.0]),
+        interpolation="linear",
+    )
+    assert d.path == "coordinateTransformations/field"
+    assert d.type == "displacements"
+    assert d.interpolation == "linear"
+    assert isinstance(d.indexTransformation, Scale)
+    assert d.indexTransformation.scale == [1.0, 2.0]
+
+    d2 = Displacements(
+        path="field",
+        indexTransformation=Identity(),
+    )
+    assert d2.interpolation is None
+    assert d2.indexTransformation.type == "identity"
+
+
+def test_coordinates_dataclass():
+    c = Coordinates(
+        path="coordinateTransformations/coord_field",
+        indexTransformation=Scale(scale=[3.0, 1.0]),
+        interpolation="nearest",
+    )
+    assert c.path == "coordinateTransformations/coord_field"
+    assert c.type == "coordinates"
+    assert c.interpolation == "nearest"
+    assert isinstance(c.indexTransformation, Scale)
+    assert c.indexTransformation.scale == [3.0, 1.0]
+
+    c2 = Coordinates(
+        path="field",
+        indexTransformation=Identity(),
+    )
+    assert c2.interpolation is None
+
+
+def test_displacements_serialization_roundtrip():
+    d = Displacements(
+        path="coordinateTransformations/field",
+        indexTransformation=Scale(scale=[1.0, 2.0]),
+        interpolation="linear",
+        name="my_disp",
+    )
+    d_dict = asdict(d)
+    assert d_dict["type"] == "displacements"
+    assert d_dict["path"] == "coordinateTransformations/field"
+    assert d_dict["indexTransformation"] == {"scale": [1.0, 2.0], "type": "scale"}
+    assert d_dict["interpolation"] == "linear"
+    assert d_dict["name"] == "my_disp"
+
+
+def test_coordinates_serialization_roundtrip():
+    c = Coordinates(
+        path="coord_field",
+        indexTransformation=Identity(),
+        interpolation="cubic",
+    )
+    c_dict = asdict(c)
+    assert c_dict["type"] == "coordinates"
+    assert c_dict["path"] == "coord_field"
+    assert c_dict["indexTransformation"] == {"type": "identity"}
+    assert c_dict["interpolation"] == "cubic"
+
+
+def test_parse_transform_displacements():
+    transform_dict = {
+        "type": "displacements",
+        "path": "coordinateTransformations/field",
+        "indexTransformation": {"type": "scale", "scale": [2.0, 1.0]},
+        "interpolation": "nearest",
+    }
+    result = _parse_transform(transform_dict)
+    assert isinstance(result, Displacements)
+    assert result.path == "coordinateTransformations/field"
+    assert result.interpolation == "nearest"
+    assert isinstance(result.indexTransformation, Scale)
+    assert result.indexTransformation.scale == [2.0, 1.0]
+
+
+def test_parse_transform_displacements_identity():
+    transform_dict = {
+        "type": "displacements",
+        "path": "field",
+        "indexTransformation": {"type": "identity"},
+    }
+    result = _parse_transform(transform_dict)
+    assert isinstance(result, Displacements)
+    assert result.path == "field"
+    assert isinstance(result.indexTransformation, Identity)
+
+
+def test_parse_transform_coordinates():
+    transform_dict = {
+        "type": "coordinates",
+        "path": "coordinateTransformations/coord_field",
+        "indexTransformation": {"type": "identity"},
+        "interpolation": "linear",
+    }
+    result = _parse_transform(transform_dict)
+    assert isinstance(result, Coordinates)
+    assert result.path == "coordinateTransformations/coord_field"
+    assert result.interpolation == "linear"
+    assert isinstance(result.indexTransformation, Identity)
+
+
+def test_parse_transform_scale():
+    result = _parse_transform({"type": "scale", "scale": [1.0, 2.0]})
+    assert isinstance(result, Scale)
+    assert result.scale == [1.0, 2.0]
+
+
+def test_parse_transform_translation():
+    result = _parse_transform({"type": "translation", "translation": [0.5, 1.0]})
+    assert isinstance(result, Translation)
+    assert result.translation == [0.5, 1.0]
+
+
+def test_parse_group_transforms():
+    transforms = [
+        {"type": "scale", "scale": [1.0, 2.0]},
+        {"type": "translation", "translation": [0.5, 1.0]},
+        {
+            "type": "displacements",
+            "path": "field",
+            "indexTransformation": {"type": "identity"},
+        },
+    ]
+    result = _parse_group_transforms(transforms)
+    assert len(result) == 3
+    assert isinstance(result[0], Scale)
+    assert isinstance(result[1], Translation)
+    assert isinstance(result[2], Displacements)
+
+
+def test_parse_group_transforms_none():
+    assert _parse_group_transforms(None) is None
+
+
+def test_transform_union_includes_new_types():
+    d = Displacements(path="field", indexTransformation=Identity())
+    c = Coordinates(path="field", indexTransformation=Scale(scale=[1.0]))
+    assert d.path == "field"
+    assert c.path == "field"
+
+
+def test_identity_in_dataset_transforms(tmp_path):
+    """Test round-trip preserves dataset coordinateTransformations."""
+    data = np.random.randint(0, 255, (32, 32), dtype=np.uint8)
+    store = str(tmp_path / "test_id.zarr")
+    image = to_ngff_image(data=data, dims=["y", "x"])
+    multiscales = to_multiscales(image, scale_factors=[])
+    to_ngff_zarr(store, multiscales, version="0.4")
+
+    result = from_ngff_zarr(store, version="0.4")
+    for dataset in result.metadata.datasets:
+        for t in dataset.coordinateTransformations:
+            assert t.type in ("scale", "translation")
+
+    assert result.images[0].data.shape == (32, 32)
+
+
+def test_identity_dataclass():
+    ident = Identity()
+    assert ident.type == "identity"
+    assert asdict(ident) == {"type": "identity"}
+
+
+def test_transforms_union_compatibility():
+    transforms: list[Transform] = [
+        Scale(scale=[1.0]),
+        Translation(translation=[0.0]),
+        Identity(),
+    ]
+    assert len(transforms) == 3
+    assert transforms[0].type == "scale"
+    assert transforms[1].type == "translation"
+    assert transforms[2].type == "identity"

--- a/ts/src/schemas/coordinate_systems.ts
+++ b/ts/src/schemas/coordinate_systems.ts
@@ -219,9 +219,30 @@ export const ByDimensionTransformationSchema: z.ZodType<{
 // Index transformation for coordinates/displacements
 // Must be identity, scale, or sequence of [scale, translation]
 const indexTransformationTypes: z.ZodType<
-  | { type: "identity"; input?: string | string[] | undefined; output?: string | string[] | undefined; name?: string | undefined }
-  | { type: "scale"; scale?: number[] | undefined; path?: string | undefined; input?: string | string[] | undefined; output?: string | string[] | undefined; name?: string | undefined }
-  | { type: "sequence"; transformations: ({ type: "scale"; scale: number[] } | { type: "translation"; translation: number[] })[]; input?: string | string[] | undefined; output?: string | string[] | undefined; name?: string | undefined }
+  | {
+    type: "identity";
+    input?: string | string[] | undefined;
+    output?: string | string[] | undefined;
+    name?: string | undefined;
+  }
+  | {
+    type: "scale";
+    scale?: number[] | undefined;
+    path?: string | undefined;
+    input?: string | string[] | undefined;
+    output?: string | string[] | undefined;
+    name?: string | undefined;
+  }
+  | {
+    type: "sequence";
+    transformations: ({ type: "scale"; scale: number[] } | {
+      type: "translation";
+      translation: number[];
+    })[];
+    input?: string | string[] | undefined;
+    output?: string | string[] | undefined;
+    name?: string | undefined;
+  }
 > = z.union([
   IdentityTransformationSchema,
   ScaleTransformationSchema,
@@ -229,12 +250,11 @@ const indexTransformationTypes: z.ZodType<
     type: z.literal("sequence"),
     transformations: z.tuple([
       z.object({ type: z.literal("scale"), scale: z.array(z.number()) }),
-    ]).rest(
-      z.union([
-        z.object({ type: z.literal("translation"), translation: z.array(z.number()) }),
-        z.object({ type: z.literal("scale"), scale: z.array(z.number()) }),
-      ]),
-    ),
+      z.object({
+        type: z.literal("translation"),
+        translation: z.array(z.number()),
+      }),
+    ]),
     input: z.union([z.string(), z.array(z.string())]).optional(),
     output: z.union([z.string(), z.array(z.string())]).optional(),
     name: z.string().optional(),

--- a/ts/src/schemas/coordinate_systems.ts
+++ b/ts/src/schemas/coordinate_systems.ts
@@ -216,6 +216,69 @@ export const ByDimensionTransformationSchema: z.ZodType<{
   name: z.string().optional(),
 });
 
+// Index transformation for coordinates/displacements
+// Must be identity, scale, or sequence of [scale, translation]
+const indexTransformationTypes: z.ZodType<
+  | { type: "identity"; input?: string | string[] | undefined; output?: string | string[] | undefined; name?: string | undefined }
+  | { type: "scale"; scale?: number[] | undefined; path?: string | undefined; input?: string | string[] | undefined; output?: string | string[] | undefined; name?: string | undefined }
+  | { type: "sequence"; transformations: ({ type: "scale"; scale: number[] } | { type: "translation"; translation: number[] })[]; input?: string | string[] | undefined; output?: string | string[] | undefined; name?: string | undefined }
+> = z.union([
+  IdentityTransformationSchema,
+  ScaleTransformationSchema,
+  z.object({
+    type: z.literal("sequence"),
+    transformations: z.tuple([
+      z.object({ type: z.literal("scale"), scale: z.array(z.number()) }),
+    ]).rest(
+      z.union([
+        z.object({ type: z.literal("translation"), translation: z.array(z.number()) }),
+        z.object({ type: z.literal("scale"), scale: z.array(z.number()) }),
+      ]),
+    ),
+    input: z.union([z.string(), z.array(z.string())]).optional(),
+    output: z.union([z.string(), z.array(z.string())]).optional(),
+    name: z.string().optional(),
+  }),
+]);
+
+// Displacement transformation
+export const DisplacementTransformationSchema: z.ZodType<{
+  type: "displacements";
+  path: string;
+  indexTransformation: z.infer<typeof indexTransformationTypes>;
+  interpolation?: string | undefined;
+  input?: string | string[] | undefined;
+  output?: string | string[] | undefined;
+  name?: string | undefined;
+}> = z.object({
+  type: z.literal("displacements"),
+  path: z.string().min(1),
+  indexTransformation: indexTransformationTypes,
+  interpolation: z.enum(["nearest", "linear", "cubic"]).optional(),
+  input: z.union([z.string(), z.array(z.string())]).optional(),
+  output: z.union([z.string(), z.array(z.string())]).optional(),
+  name: z.string().optional(),
+});
+
+// Coordinate field transformation
+export const CoordinatesTransformationSchema: z.ZodType<{
+  type: "coordinates";
+  path: string;
+  indexTransformation: z.infer<typeof indexTransformationTypes>;
+  interpolation?: string | undefined;
+  input?: string | string[] | undefined;
+  output?: string | string[] | undefined;
+  name?: string | undefined;
+}> = z.object({
+  type: z.literal("coordinates"),
+  path: z.string().min(1),
+  indexTransformation: indexTransformationTypes,
+  interpolation: z.enum(["nearest", "linear", "cubic"]).optional(),
+  input: z.union([z.string(), z.array(z.string())]).optional(),
+  output: z.union([z.string(), z.array(z.string())]).optional(),
+  name: z.string().optional(),
+});
+
 // Complete coordinate transformation schema (union of all types)
 export const CoordinateTransformationSchema: z.ZodType<
   | {
@@ -292,6 +355,24 @@ export const CoordinateTransformationSchema: z.ZodType<
     output?: string | string[] | undefined;
     name?: string | undefined;
   }
+  | {
+    type: "displacements";
+    path: string;
+    indexTransformation: z.infer<typeof indexTransformationTypes>;
+    interpolation?: string | undefined;
+    input?: string | string[] | undefined;
+    output?: string | string[] | undefined;
+    name?: string | undefined;
+  }
+  | {
+    type: "coordinates";
+    path: string;
+    indexTransformation: z.infer<typeof indexTransformationTypes>;
+    interpolation?: string | undefined;
+    input?: string | string[] | undefined;
+    output?: string | string[] | undefined;
+    name?: string | undefined;
+  }
 > = z.union([
   IdentityTransformationSchema,
   MapAxisTransformationSchema,
@@ -303,6 +384,8 @@ export const CoordinateTransformationSchema: z.ZodType<
   InverseTransformationSchema,
   BijectionTransformationSchema,
   ByDimensionTransformationSchema,
+  DisplacementTransformationSchema,
+  CoordinatesTransformationSchema,
 ]);
 
 // Array coordinate system schema
@@ -339,6 +422,12 @@ export type BijectionTransformation = z.infer<
 >;
 export type ByDimensionTransformation = z.infer<
   typeof ByDimensionTransformationSchema
+>;
+export type DisplacementTransformation = z.infer<
+  typeof DisplacementTransformationSchema
+>;
+export type CoordinatesTransformation = z.infer<
+  typeof CoordinatesTransformationSchema
 >;
 export type CoordinateTransformation = z.infer<
   typeof CoordinateTransformationSchema

--- a/ts/src/schemas/coordinate_systems.ts
+++ b/ts/src/schemas/coordinate_systems.ts
@@ -235,10 +235,10 @@ const indexTransformationTypes: z.ZodType<
   }
   | {
     type: "sequence";
-    transformations: ({ type: "scale"; scale: number[] } | {
+    transformations: [{ type: "scale"; scale: number[] }, {
       type: "translation";
       translation: number[];
-    })[];
+    }];
     input?: string | string[] | undefined;
     output?: string | string[] | undefined;
     name?: string | undefined;

--- a/ts/src/schemas/units.ts
+++ b/ts/src/schemas/units.ts
@@ -30,7 +30,14 @@ export const AxesTypeSchema: z.ZodEnum<{
   array: "array";
   coordinate: "coordinate";
   displacement: "displacement";
-}> = z.enum(["time", "space", "channel", "array", "coordinate", "displacement"]);
+}> = z.enum([
+  "time",
+  "space",
+  "channel",
+  "array",
+  "coordinate",
+  "displacement",
+]);
 
 export const SpaceUnitsSchema: z.ZodEnum<{
   angstrom: "angstrom";

--- a/ts/src/schemas/units.ts
+++ b/ts/src/schemas/units.ts
@@ -27,7 +27,10 @@ export const AxesTypeSchema: z.ZodEnum<{
   time: "time";
   space: "space";
   channel: "channel";
-}> = z.enum(["time", "space", "channel"]);
+  array: "array";
+  coordinate: "coordinate";
+  displacement: "displacement";
+}> = z.enum(["time", "space", "channel", "array", "coordinate", "displacement"]);
 
 export const SpaceUnitsSchema: z.ZodEnum<{
   angstrom: "angstrom";

--- a/ts/src/types/supported_versions.ts
+++ b/ts/src/types/supported_versions.ts
@@ -11,7 +11,8 @@ export enum NgffVersion {
   V03 = "0.3",
   V04 = "0.4",
   V05 = "0.5",
-  LATEST = "0.5",
+  V06 = "0.6",
+  LATEST = "0.6",
 }
 
 /**
@@ -23,6 +24,7 @@ export const SUPPORTED_VERSIONS: readonly NgffVersion[] = [
   NgffVersion.V03,
   NgffVersion.V04,
   NgffVersion.V05,
+  NgffVersion.V06,
 ] as const;
 
 /**

--- a/ts/src/types/zarr_metadata.ts
+++ b/ts/src/types/zarr_metadata.ts
@@ -35,7 +35,34 @@ export interface Translation {
   type: "translation";
 }
 
-export type Transform = Scale | Translation;
+export type Transform = Scale | Translation | Identity;
+
+export interface DisplacementTransform {
+  type: "displacements";
+  path: string;
+  indexTransformation: Transform;
+  interpolation?: string;
+  input?: string | string[];
+  output?: string | string[];
+  name?: string;
+}
+
+export interface CoordinateTransform {
+  type: "coordinates";
+  path: string;
+  indexTransformation: Transform;
+  interpolation?: string;
+  input?: string | string[];
+  output?: string | string[];
+  name?: string;
+}
+
+export type GroupTransform =
+  | Scale
+  | Translation
+  | Identity
+  | DisplacementTransform
+  | CoordinateTransform;
 
 export interface Dataset {
   path: string;
@@ -73,7 +100,7 @@ export interface MethodMetadata {
 export interface MetadataInterface {
   axes: Axis[];
   datasets: Dataset[];
-  coordinateTransformations: Transform[] | undefined;
+  coordinateTransformations: GroupTransform[] | undefined;
   omero: Omero | undefined;
   name: string;
   version: string;
@@ -131,6 +158,11 @@ export function createMetadataWithVersion(
     return {
       ...metadata,
       version: "0.5",
+    };
+  } else if (version === NgffVersion.V06) {
+    return {
+      ...metadata,
+      version: "0.6",
     };
   } else {
     throw new Error(

--- a/ts/src/types/zarr_metadata.ts
+++ b/ts/src/types/zarr_metadata.ts
@@ -35,7 +35,15 @@ export interface Translation {
   type: "translation";
 }
 
-export type Transform = Scale | Translation | Identity;
+export interface SequenceTransform {
+  type: "sequence";
+  transformations: Transform[];
+  input?: string | string[];
+  output?: string | string[];
+  name?: string;
+}
+
+export type Transform = Scale | Translation | Identity | SequenceTransform;
 
 export interface DisplacementTransform {
   type: "displacements";
@@ -61,6 +69,7 @@ export type GroupTransform =
   | Scale
   | Translation
   | Identity
+  | SequenceTransform
   | DisplacementTransform
   | CoordinateTransform;
 

--- a/ts/src/utils/from_zarr_attrs.ts
+++ b/ts/src/utils/from_zarr_attrs.ts
@@ -10,6 +10,7 @@ import type {
   Axis,
   Dataset,
   FromZarrAttrsResult,
+  Identity,
   MetadataInterface,
   Omero,
   Scale,
@@ -298,36 +299,38 @@ export async function fromZarrAttrsV04(
     );
     const coordinateTransformations: Transform[] = [];
 
-    if ("coordinateTransformations" in dataset) {
-      const transforms = dataset.coordinateTransformations as Array<
-        Record<string, unknown>
-      >;
-      for (const transformation of transforms) {
-        if ("scale" in transformation) {
-          const scaleValues = transformation.scale as number[];
-          dims.forEach((dim, i) => {
-            if (i < scaleValues.length) {
-              scale[dim] = scaleValues[i];
+        if ("coordinateTransformations" in dataset) {
+          const transforms = dataset.coordinateTransformations as Array<
+            Record<string, unknown>
+          >;
+          for (const transformation of transforms) {
+            if ("scale" in transformation) {
+              const scaleValues = transformation.scale as number[];
+              dims.forEach((dim, i) => {
+                if (i < scaleValues.length) {
+                  scale[dim] = scaleValues[i];
+                }
+              });
+              coordinateTransformations.push({
+                type: "scale",
+                scale: scaleValues,
+              } as Scale);
+            } else if ("translation" in transformation) {
+              const translationValues = transformation.translation as number[];
+              dims.forEach((dim, i) => {
+                if (i < translationValues.length) {
+                  translation[dim] = translationValues[i];
+                }
+              });
+              coordinateTransformations.push({
+                type: "translation",
+                translation: translationValues,
+              } as Translation);
+            } else if (transformation.type === "identity") {
+              coordinateTransformations.push({ type: "identity" } as Identity);
             }
-          });
-          coordinateTransformations.push({
-            type: "scale",
-            scale: scaleValues,
-          } as Scale);
-        } else if ("translation" in transformation) {
-          const translationValues = transformation.translation as number[];
-          dims.forEach((dim, i) => {
-            if (i < translationValues.length) {
-              translation[dim] = translationValues[i];
-            }
-          });
-          coordinateTransformations.push({
-            type: "translation",
-            translation: translationValues,
-          } as Translation);
+          }
         }
-      }
-    }
 
     datasets.push({
       path,

--- a/ts/src/utils/from_zarr_attrs.ts
+++ b/ts/src/utils/from_zarr_attrs.ts
@@ -299,38 +299,38 @@ export async function fromZarrAttrsV04(
     );
     const coordinateTransformations: Transform[] = [];
 
-        if ("coordinateTransformations" in dataset) {
-          const transforms = dataset.coordinateTransformations as Array<
-            Record<string, unknown>
-          >;
-          for (const transformation of transforms) {
-            if ("scale" in transformation) {
-              const scaleValues = transformation.scale as number[];
-              dims.forEach((dim, i) => {
-                if (i < scaleValues.length) {
-                  scale[dim] = scaleValues[i];
-                }
-              });
-              coordinateTransformations.push({
-                type: "scale",
-                scale: scaleValues,
-              } as Scale);
-            } else if ("translation" in transformation) {
-              const translationValues = transformation.translation as number[];
-              dims.forEach((dim, i) => {
-                if (i < translationValues.length) {
-                  translation[dim] = translationValues[i];
-                }
-              });
-              coordinateTransformations.push({
-                type: "translation",
-                translation: translationValues,
-              } as Translation);
-            } else if (transformation.type === "identity") {
-              coordinateTransformations.push({ type: "identity" } as Identity);
+    if ("coordinateTransformations" in dataset) {
+      const transforms = dataset.coordinateTransformations as Array<
+        Record<string, unknown>
+      >;
+      for (const transformation of transforms) {
+        if ("scale" in transformation) {
+          const scaleValues = transformation.scale as number[];
+          dims.forEach((dim, i) => {
+            if (i < scaleValues.length) {
+              scale[dim] = scaleValues[i];
             }
-          }
+          });
+          coordinateTransformations.push({
+            type: "scale",
+            scale: scaleValues,
+          } as Scale);
+        } else if ("translation" in transformation) {
+          const translationValues = transformation.translation as number[];
+          dims.forEach((dim, i) => {
+            if (i < translationValues.length) {
+              translation[dim] = translationValues[i];
+            }
+          });
+          coordinateTransformations.push({
+            type: "translation",
+            translation: translationValues,
+          } as Translation);
+        } else if (transformation.type === "identity") {
+          coordinateTransformations.push({ type: "identity" } as Identity);
         }
+      }
+    }
 
     datasets.push({
       path,

--- a/ts/test/rfc4_rfc5_schemas_test.ts
+++ b/ts/test/rfc4_rfc5_schemas_test.ts
@@ -9,10 +9,10 @@ import {
   // Enhanced zarr metadata with RFC4 support
   AxisSchema,
   ChannelAxisSchema,
+  CoordinatesTransformationSchema,
   // RFC5 coordinate systems
   CoordinateSystemSchema,
   CoordinateTransformationSchema,
-  CoordinatesTransformationSchema,
   DisplacementTransformationSchema,
   MetadataSchema,
   ScaleTransformationSchema,

--- a/ts/test/rfc4_rfc5_schemas_test.ts
+++ b/ts/test/rfc4_rfc5_schemas_test.ts
@@ -12,6 +12,8 @@ import {
   // RFC5 coordinate systems
   CoordinateSystemSchema,
   CoordinateTransformationSchema,
+  CoordinatesTransformationSchema,
+  DisplacementTransformationSchema,
   MetadataSchema,
   ScaleTransformationSchema,
   SequenceTransformationSchema,
@@ -361,3 +363,182 @@ Deno.test("Enhanced MetadataSchema with RFC4 and RFC5 features", () => {
     assertEquals(axis.orientation?.type, "anatomical");
   });
 });
+
+// RFC-5 coordinate/displacement transformations (Issue #520)
+Deno.test(
+  "DisplacementTransformationSchema - valid with scale indexTransformation",
+  () => {
+    const valid = {
+      type: "displacements",
+      path: "coordinateTransformations/field",
+      indexTransformation: { type: "scale", scale: [2.0, 1.0] },
+      interpolation: "nearest",
+      input: "in",
+      output: "out",
+      name: "my_displacement",
+    };
+    const result = DisplacementTransformationSchema.parse(valid);
+    assertEquals(result.type, "displacements");
+    assertEquals(result.path, "coordinateTransformations/field");
+    assertEquals(result.indexTransformation.type, "scale");
+    assertEquals(result.interpolation, "nearest");
+  },
+);
+
+Deno.test(
+  "DisplacementTransformationSchema - valid with identity indexTransformation",
+  () => {
+    const valid = {
+      type: "displacements",
+      path: "field",
+      indexTransformation: { type: "identity" },
+    };
+    const result = DisplacementTransformationSchema.parse(valid);
+    assertEquals(result.type, "displacements");
+    assertEquals(result.indexTransformation.type, "identity");
+  },
+);
+
+Deno.test(
+  "DisplacementTransformationSchema - valid with sequence indexTransformation",
+  () => {
+    const valid = {
+      type: "displacements",
+      path: "coordinateTransformations/field",
+      indexTransformation: {
+        type: "sequence",
+        transformations: [
+          { type: "scale", scale: [2.0, 1.0] },
+          { type: "translation", translation: [0.5, 0.0] },
+        ],
+      },
+    };
+    const result = DisplacementTransformationSchema.parse(valid);
+    assertEquals(result.type, "displacements");
+    assertEquals(result.indexTransformation.type, "sequence");
+    const seq = result.indexTransformation as {
+      type: "sequence";
+      transformations: Record<string, unknown>[];
+    };
+    assertEquals(Array.isArray(seq.transformations), true);
+  },
+);
+
+Deno.test(
+  "DisplacementTransformationSchema - missing indexTransformation throws",
+  () => {
+    assertThrows(() =>
+      DisplacementTransformationSchema.parse({
+        type: "displacements",
+        path: "field",
+      })
+    );
+  },
+);
+
+Deno.test(
+  "DisplacementTransformationSchema - missing path throws",
+  () => {
+    assertThrows(() =>
+      DisplacementTransformationSchema.parse({
+        type: "displacements",
+        indexTransformation: { type: "identity" },
+      })
+    );
+  },
+);
+
+Deno.test(
+  "CoordinatesTransformationSchema - valid with identity indexTransformation",
+  () => {
+    const valid = {
+      type: "coordinates",
+      path: "coordinateTransformations/coord_field",
+      indexTransformation: { type: "identity" },
+      interpolation: "linear",
+    };
+    const result = CoordinatesTransformationSchema.parse(valid);
+    assertEquals(result.type, "coordinates");
+    assertEquals(result.path, "coordinateTransformations/coord_field");
+    assertEquals(result.indexTransformation.type, "identity");
+    assertEquals(result.interpolation, "linear");
+  },
+);
+
+Deno.test(
+  "CoordinatesTransformationSchema - valid with scale indexTransformation",
+  () => {
+    const valid = {
+      type: "coordinates",
+      path: "field",
+      indexTransformation: { type: "scale", scale: [3.0, 1.0] },
+    };
+    const result = CoordinatesTransformationSchema.parse(valid);
+    assertEquals(result.type, "coordinates");
+    assertEquals(result.indexTransformation.type, "scale");
+  },
+);
+
+Deno.test(
+  "CoordinatesTransformationSchema - missing indexTransformation throws",
+  () => {
+    assertThrows(() =>
+      CoordinatesTransformationSchema.parse({
+        type: "coordinates",
+        path: "field",
+      })
+    );
+  },
+);
+
+Deno.test(
+  "CoordinatesTransformationSchema - missing path throws",
+  () => {
+    assertThrows(() =>
+      CoordinatesTransformationSchema.parse({
+        type: "coordinates",
+        indexTransformation: { type: "identity" },
+      })
+    );
+  },
+);
+
+Deno.test(
+  "CoordinatesTransformationSchema - invalid interpolation throws",
+  () => {
+    assertThrows(() =>
+      CoordinatesTransformationSchema.parse({
+        type: "coordinates",
+        path: "field",
+        indexTransformation: { type: "identity" },
+        interpolation: "invalid_method",
+      })
+    );
+  },
+);
+
+Deno.test(
+  "CoordinateTransformationSchema union - accepts displacements",
+  () => {
+    const valid = {
+      type: "displacements",
+      path: "coordinateTransformations/field",
+      indexTransformation: { type: "identity" },
+    };
+    const result = CoordinateTransformationSchema.parse(valid);
+    assertEquals(result.type, "displacements");
+  },
+);
+
+Deno.test(
+  "CoordinateTransformationSchema union - accepts coordinates",
+  () => {
+    const valid = {
+      type: "coordinates",
+      path: "coordinateTransformations/coord_field",
+      indexTransformation: { type: "scale", scale: [1.0] },
+    };
+    const result = CoordinateTransformationSchema.parse(valid);
+    assertEquals(result.type, "coordinates");
+  },
+);


### PR DESCRIPTION
Implement RFC-5 changes from [ome/ngff#520](https://github.com/ome/ngff/issues/520) (spec PR [ome/ngff-spec#134](https://github.com/ome/ngff-spec/pull/134)) which relocates the array-index-to-input-coordinate transformation from array-level `ome.*` metadata into a required `indexTransformation` field on the coordinate/displacement transformation definition.

## What changed

### TypeScript
- **`ts/src/types/supported_versions.ts`** — Add `V06 = "0.6"` to `NgffVersion` enum, update `LATEST`
- **`ts/src/schemas/units.ts`** — Add `"array"`, `"coordinate"`, `"displacement"` to `AxesTypeSchema`
- **`ts/src/schemas/coordinate_systems.ts`** — Add `DisplacementTransformationSchema` and `CoordinatesTransformationSchema` with required `indexTransformation` field (must be identity, scale, or sequence of scale+translation); add both to `CoordinateTransformationSchema` union
- **`ts/src/types/zarr_metadata.ts`** — Add `DisplacementTransform` and `CoordinateTransform` interfaces, `GroupTransform` type, add `Identity` to `Transform` union
- **`ts/src/utils/from_zarr_attrs.ts`** — Handle `identity` type in dataset-level coordinateTransformations
- **`ts/test/rfc4_rfc5_schemas_test.ts`** — Add 12 new schema validation tests

### Python
- **`py/ngff_zarr/_supported_versions.py`** — Add `V06 = "0.6"` to `NgffVersion` enum, update `LATEST` and `SUPPORTED_VERSIONS`
- **`py/ngff_zarr/v04/zarr_metadata.py`** — Add `Displacements` and `Coordinates` dataclasses with `indexTransformation` field; add `Identity` to `Transform` union; add `_parse_transform()` and `_parse_group_transforms()` for parsing new transform types from zarr metadata; handle identity in dataset coordinateTransformations; add `"array"`/`"coordinate"`/`"displacement"` to `AxesType`
- **`py/ngff_zarr/to_ngff_zarr.py`** — Safe-pop `coordinateTransformations` key (avoid KeyError); strip null fields from transform dicts
- **`py/ngff_zarr/spec/0.6/schemas/`** — New v0.6 validation schemas with expanded `coordinateTransformations` supporting all RFC-5 types (identity, mapAxis, scale, translation, affine, rotation, displacements, coordinates)
- **`py/test/test_v06_transforms.py`** — 15 new tests covering dataclass creation, serialization round-trip, transform parsing, and union compatibility

## Test Results
- **Python**: 542 passed, 2 skipped (15 new tests)
- **TypeScript**: type check passes, lint passes, 47 schema tests pass (12 new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NGFF 0.6 support with full schema set and validation.
  * Added coordinate transformation types: displacements, coordinates, identity, and sequence; expanded axes types.

* **Improvements**
  * Enhanced metadata parsing and version conversion to handle new transform shapes and preserve round‑trips.

* **Tests**
  * Added comprehensive v0.6 transform and schema tests; tightened image pyramid assertions.

* **Chores**
  * Added pre-commit lint/run guidance for contributors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->