### PR TITLE
fix(py): write requested .ozx for multi-series TIFFs and warn on truncated reads

### DIFF
--- a/docs/tiff.md
+++ b/docs/tiff.md
@@ -59,6 +59,27 @@ If the TIFF series have names (common for OME-TIFF), their names are used
 instead of the index, for example `output_GFP.ome.zarr`, `output_DAPI.ome.zarr`,
 and so on. Series names are automatically sanitized to ensure filesystem safety.
 
+### Multi-series files written to a single `.ozx`
+
+Whole-slide formats such as Aperio `.svs` always contain several series (a
+full-resolution **Baseline** pyramid plus auxiliary **Thumbnail**, **Label**,
+and **Macro** images). When such a file is converted to a single
+`.ozx` file, the primary (first) series — the full-resolution
+image — is written to the exact path you requested, and any additional series
+are written alongside it with a `_<series_name>` suffix while preserving the
+`.ozx` format:
+
+```shell
+ngff-zarr -i slide.svs -o slide.ozx
+# creates slide.ozx (Baseline) plus slide_Thumbnail.ozx, slide_Label.ozx, ...
+```
+
+To convert only the full-resolution image, select it explicitly:
+
+```shell
+ngff-zarr -i slide.svs -o slide.ozx --series 0
+```
+
 ### Convert a specific series by index
 
 ```shell

--- a/py/ngff_zarr/cli.py
+++ b/py/ngff_zarr/cli.py
@@ -35,6 +35,7 @@ if hasattr(zarr.storage, "DirectoryStore"):
 else:
     LocalStore = zarr.storage.LocalStore
 
+from ._zarr_types import StoreLike
 from .cli_input_to_ngff_image import cli_input_to_ngff_image
 from .compute_omero import compute_omero_from_multiscales
 from .config import config
@@ -163,6 +164,62 @@ def _apply_omero_metadata(live, args, multiscales):
     except Exception as e:
         if not args.quiet:
             live.console.log(f"[yellow]Warning: Could not compute OMERO metadata: {e}")
+
+
+def _series_output_target(
+    args: argparse.Namespace,
+    output_store: StoreLike | None,
+    series_name: str,
+    series_index: int,
+    n_series: int,
+) -> tuple[StoreLike | None, str | None]:
+    """Resolve the output store and display path for one series of a file.
+
+    Returns a ``(store, display_path)`` tuple.
+
+    With a single requested output path but several series in the source
+    (every Aperio ``.svs`` whole-slide file has Baseline + Thumbnail + Label +
+    Macro series, for example), the destination depends on the requested
+    format:
+
+    - For a single-file ``.ozx`` output, the primary (first) series is written
+      to the exact requested path so the file the user asked for is actually
+      created, and additional series are written alongside it as
+      ``<base>_<series_name>.ozx`` (preserving the zip format). Previously the
+      ``.ozx`` request was silently discarded and replaced with
+      ``<base>_<series_name>.ome.zarr`` directories, so the requested ``.ozx``
+      never appeared.
+    - For directory-style ``.zarr`` / ``.ome.zarr`` output, each series is
+      written to its own ``<base>_<series_name>.ome.zarr`` directory, the
+      long-standing documented behavior.
+    """
+    if not args.output:
+        return None, None
+    if n_series <= 1:
+        return output_store, args.output
+
+    # ``.ozx`` detection is case-sensitive to match the rest of the codebase
+    # (main()'s output_store selection, rfc9_zip.is_ozx_path, to_ngff_zarr).
+    if args.output.endswith(".ozx"):
+        if series_index == 0:
+            return output_store, args.output
+        base = args.output[: -len(".ozx")]
+        derived = f"{base}_{series_name}.ozx"
+        # to_ngff_zarr handles a string ``.ozx`` path directly.
+        return derived, derived
+
+    # Directory-style outputs: one .ome.zarr per series (documented behavior).
+    # Strip the full ``.ome.zarr`` / ``.zarr`` suffix so that an ``out.ome.zarr``
+    # base does not produce a doubled ``out.ome_<name>.ome.zarr``.
+    if args.output.endswith(".ome.zarr"):
+        base = args.output[: -len(".ome.zarr")]
+    elif args.output.endswith(".zarr"):
+        base = args.output[: -len(".zarr")]
+    else:
+        output_path = Path(args.output)
+        base = str(output_path.parent / output_path.stem)
+    derived = f"{base}_{series_name}.ome.zarr"
+    return LocalStore(derived), derived
 
 
 def _multiscales_to_ngff_zarr(
@@ -819,21 +876,15 @@ def main():
                     live.console.print("[red]No matching series found in TIFF file.")
                     sys.exit(1)
 
-                for series_name, result in series_list:
-                    # Determine output path for this series
-                    if args.output:
-                        if len(series_list) > 1:
-                            # Create separate output per series, preserving original output name
-                            output_base = Path(args.output).stem
-                            output_path = (
-                                Path(args.output).parent
-                                / f"{output_base}_{series_name}.ome.zarr"
-                            )
-                            series_store = LocalStore(str(output_path))
-                        else:
-                            series_store = output_store
-                    else:
-                        series_store = None
+                for series_index, (series_name, result) in enumerate(series_list):
+                    # Determine output store/path for this series
+                    series_store, series_path = _series_output_target(
+                        args,
+                        output_store,
+                        series_name,
+                        series_index,
+                        len(series_list),
+                    )
 
                     if isinstance(result, MultiscalesType):
                         # Pyramidal TIFF: reuse existing pyramid levels
@@ -866,7 +917,9 @@ def main():
                     )
 
                     if len(series_list) > 1 and args.output and not args.quiet:
-                        live.console.print(f"[green]Written series: {series_name}")
+                        live.console.print(
+                            f"[green]Written series '{series_name}' -> {series_path}"
+                        )
 
             except ImportError:
                 sys.stdout.write("[red]Please install the [i]tifffile[/i] package.\n")
@@ -899,7 +952,9 @@ def main():
                         live.console.print("[red]No matching series found in LIF file.")
                         sys.exit(1)
 
-                    for series_name, ngff_image in series_list:
+                    for series_index, (series_name, ngff_image) in enumerate(
+                        series_list
+                    ):
                         # Check for mosaic dimension (M > 1) - requires original lif_image
                         # For now, check if 'm' dimension exists in ngff_image
                         has_mosaic = (
@@ -969,20 +1024,14 @@ def main():
                                 continue
 
                         # Standard image output
-                        # Determine output path for this series
-                        if args.output:
-                            if len(series_list) > 1:
-                                # Create separate output per series, preserving original output name
-                                output_base = Path(args.output).stem
-                                output_path = (
-                                    Path(args.output).parent
-                                    / f"{output_base}_{series_name}.ome.zarr"
-                                )
-                                series_store = LocalStore(str(output_path))
-                            else:
-                                series_store = output_store
-                        else:
-                            series_store = None
+                        # Determine output store/path for this series
+                        series_store, series_path = _series_output_target(
+                            args,
+                            output_store,
+                            series_name,
+                            series_index,
+                            len(series_list),
+                        )
 
                         multiscales = _ngff_image_to_multiscales(
                             live,
@@ -1003,7 +1052,9 @@ def main():
                         )
 
                         if len(series_list) > 1 and args.output and not args.quiet:
-                            live.console.print(f"[green]Written series: {series_name}")
+                            live.console.print(
+                                f"[green]Written series '{series_name}' -> {series_path}"
+                            )
 
             except ImportError:
                 sys.stdout.write("[red]Please install the [i]liffile[/i] package.\n")

--- a/py/ngff_zarr/tiff_to_ngff_image.py
+++ b/py/ngff_zarr/tiff_to_ngff_image.py
@@ -13,6 +13,7 @@ NgffImage.
 Requires the `tifffile` package: pip install tifffile
 """
 
+import logging
 import re
 import warnings
 import xml.etree.ElementTree as ET
@@ -914,6 +915,43 @@ def _build_multiscales_from_pyramid(
     return NgffMultiscales(images, metadata)
 
 
+class _TiffStructuralErrorHandler(logging.Handler):
+    """Collect ERROR-level messages emitted by tifffile while reading a file.
+
+    tifffile logs ERROR records such as ``invalid page offset ...`` or
+    ``corrupted tag list ...`` when a file's IFD chain is truncated or
+    corrupt. When this happens tifffile silently stops enumerating pages, so
+    the resulting conversion can be missing pyramid levels or whole series
+    (producing an unexpectedly tiny, visually wrong output). Collecting these
+    messages lets us warn the user instead of silently producing an
+    incomplete or incorrect result.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.ERROR)
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            self.messages.append(record.getMessage())
+        except Exception:  # pragma: no cover - logging must never raise
+            pass
+
+
+def _summarize_tiff_error_messages(messages: list[str], limit: int = 5) -> str:
+    """Deduplicate and truncate captured tifffile error messages for display.
+
+    Preserves first-seen order, drops duplicates, and appends a ``... (N more)``
+    note when more than ``limit`` distinct messages were collected so a corrupt
+    file with many bad IFDs does not produce an unbounded warning string.
+    """
+    unique_messages = list(dict.fromkeys(messages))
+    detail = "; ".join(unique_messages[:limit])
+    if len(unique_messages) > limit:
+        detail += f"; ... ({len(unique_messages) - limit} more)"
+    return detail
+
+
 def tiff_file_to_ngff_images(
     tiff_path: str | Path,
     series: int | str | list[int | str] | None = None,
@@ -981,6 +1019,47 @@ def tiff_file_to_ngff_images(
         msg = "tifffile package is required. Install with: pip install tifffile"
         raise ImportError(msg) from e
 
+    results: list = []
+
+    # Capture tifffile's own ERROR logs (e.g. "invalid page offset",
+    # "corrupted tag list") emitted while the IFD chain / series are
+    # enumerated. These indicate a truncated or corrupt file that tifffile
+    # reads only partially, which would otherwise silently yield an
+    # incomplete conversion.
+    tiff_logger = logging.getLogger("tifffile")
+    structural_error_handler = _TiffStructuralErrorHandler()
+    tiff_logger.addHandler(structural_error_handler)
+    try:
+        results = _read_tiff_series(
+            tifffile,
+            tiff_path,
+            series,
+            reuse_existing_pyramids,
+        )
+    finally:
+        tiff_logger.removeHandler(structural_error_handler)
+
+    if structural_error_handler.messages:
+        detail = _summarize_tiff_error_messages(structural_error_handler.messages)
+        warnings.warn(
+            f"tifffile reported errors while reading {Path(tiff_path).name!r}. "
+            "The file may be truncated or corrupt; the converted output may be "
+            "missing pyramid levels or image data and appear incomplete or "
+            f"incorrect. Details: {detail}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+    return results
+
+
+def _read_tiff_series(
+    tifffile,
+    tiff_path: str | Path,
+    series: int | str | list[int | str] | None,
+    reuse_existing_pyramids: bool,
+) -> "list[tuple[str, NgffImage | NgffMultiscales]]":
+    """Read the requested series from a TIFF file (see tiff_file_to_ngff_images)."""
     results: list = []
 
     with tifffile.TiffFile(tiff_path) as tif:

--- a/py/test/test_issue_436.py
+++ b/py/test/test_issue_436.py
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Regression tests for issue #436.
+
+Two distinct failure modes are covered:
+
+1. Multi-series TIFF (every Aperio ``.svs`` whole-slide file has Baseline +
+   Thumbnail + Label + Macro series) written to a single ``.ozx`` path. The
+   requested ``.ozx`` must actually be created (holding the primary series),
+   instead of being silently replaced by ``_<series>.ome.zarr`` directories.
+
+2. A truncated / corrupt TIFF whose IFD chain points beyond EOF. tifffile
+   logs an error and silently stops reading pages; ngff-zarr must surface a
+   warning rather than producing an incomplete output without notice.
+"""
+
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+import warnings
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import packaging.version
+import pytest
+import zarr
+
+tifffile = pytest.importorskip("tifffile")
+
+zarr_version_major = packaging.version.parse(zarr.__version__).major
+
+
+def _run_ngff_zarr(*args):
+    """Run the ngff-zarr CLI as a subprocess."""
+    cmd = [sys.executable, "-c", "from ngff_zarr.cli import main; main()"] + list(args)
+    env = {**os.environ, "PYTHONIOENCODING": "utf-8"}
+    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+
+def _write_multiseries_tiff(path):
+    """Write a 2-series pyramidal RGB OME-TIFF (Baseline pyramid + Thumbnail)."""
+    rng = np.random.default_rng(0)
+    base = np.full((512, 512, 3), 240, np.uint8)
+    base[:256, :256] = rng.integers(0, 256, (256, 256, 3), dtype=np.uint8)
+    # Uncompressed so the tests do not require the optional imagecodecs codec.
+    opts = {"photometric": "rgb", "tile": (128, 128), "compression": None}
+    with tifffile.TiffWriter(path, ome=True, bigtiff=True) as tif:
+        tif.write(base, subifds=1, metadata={"Name": "Baseline"}, **opts)
+        tif.write(base[::2, ::2].copy(), subfiletype=1, **opts)
+        tif.write(
+            np.full((64, 64, 3), 99, np.uint8),
+            metadata={"Name": "Thumbnail"},
+            **opts,
+        )
+    return base
+
+
+# --------------------------------------------------------------------------
+# _series_output_target unit tests (fast, no I/O)
+# --------------------------------------------------------------------------
+
+
+class TestSeriesOutputTarget:
+    """Unit tests for the ``_series_output_target`` path-routing helper."""
+
+    def test_ozx_primary_series_uses_exact_path(self):
+        """Test the primary ``.ozx`` series keeps the exact requested path."""
+        from ngff_zarr.cli import _series_output_target
+
+        args = SimpleNamespace(output="/tmp/slide.ozx")
+        store, path = _series_output_target(args, "/tmp/slide.ozx", "Baseline", 0, 4)
+        assert store == "/tmp/slide.ozx"
+        assert path == "/tmp/slide.ozx"
+
+    def test_ozx_secondary_series_uses_suffixed_ozx(self):
+        """Test secondary series get a ``_<name>.ozx`` suffix (zip preserved)."""
+        from ngff_zarr.cli import _series_output_target
+
+        args = SimpleNamespace(output="/tmp/slide.ozx")
+        store, path = _series_output_target(args, "/tmp/slide.ozx", "Thumbnail", 1, 4)
+        # .ozx format preserved; string path is passed straight to to_ngff_zarr
+        assert store == "/tmp/slide_Thumbnail.ozx"
+        assert path == "/tmp/slide_Thumbnail.ozx"
+
+    def test_single_series_uses_requested_store_unchanged(self):
+        """Test a single-series input reuses the requested store unchanged."""
+        from ngff_zarr.cli import _series_output_target
+
+        args = SimpleNamespace(output="/tmp/slide.ozx")
+        sentinel = object()
+        store, path = _series_output_target(args, sentinel, "Baseline", 0, 1)
+        assert store is sentinel
+        assert path == "/tmp/slide.ozx"
+
+    def test_directory_output_keeps_per_series_ome_zarr(self):
+        """Test directory output routes each series to its own ``.ome.zarr``."""
+        from ngff_zarr.cli import _series_output_target
+
+        args = SimpleNamespace(output="/tmp/out/")
+        store, path = _series_output_target(args, None, "GFP", 0, 2)
+        assert path.endswith("_GFP.ome.zarr")
+        assert not isinstance(store, str)
+
+    def test_no_output_returns_none(self):
+        """Test a missing output target yields no store or path."""
+        from ngff_zarr.cli import _series_output_target
+
+        args = SimpleNamespace(output=None)
+        store, path = _series_output_target(args, None, "Baseline", 0, 3)
+        assert store is None
+        assert path is None
+
+
+# --------------------------------------------------------------------------
+# End-to-end CLI: multi-series TIFF -> single .ozx
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    zarr_version_major < 3,
+    reason="RFC-9 .ozx and OME-Zarr 0.5 require zarr-python >= 3.0.0",
+)
+def test_multiseries_tiff_to_ozx_creates_requested_file():
+    """Test a multi-series TIFF creates the requested ``.ozx`` with real data."""
+    tmp = Path(tempfile.mkdtemp(prefix="issue436_"))
+    tiff_path = tmp / "slide.svs.ome.tif"
+    base = _write_multiseries_tiff(tiff_path)
+
+    out = tmp / "out.ozx"
+    result = _run_ngff_zarr(
+        "--ome-zarr-version", "0.5", "-i", str(tiff_path), "-o", str(out)
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+
+    # The exact requested .ozx must exist (was previously never created).
+    assert out.exists(), (
+        "Requested .ozx was not created for a multi-series TIFF; "
+        f"workdir contents: {[p.name for p in tmp.iterdir()]}"
+    )
+    # The auxiliary series is written alongside, preserving the .ozx format.
+    assert (tmp / "out_Thumbnail.ozx").exists()
+
+    # The primary .ozx must hold the full-resolution Baseline pyramid.
+    store = zarr.storage.ZipStore(str(out), mode="r")
+    root = zarr.open_group(store, mode="r")
+    scale0 = root["scale0"]
+    arr = scale0[next(iter(scale0.keys()))]
+    assert arr.shape[0] == base.shape[0]
+    assert arr.shape[1] == base.shape[1]
+    # Real pixel data, not an all-zero / blank array.
+    assert int(np.asarray(arr[:]).max()) > 0
+
+
+@pytest.mark.skipif(
+    zarr_version_major < 3,
+    reason="CLI default OME-Zarr 0.5 requires zarr-python >= 3.0.0",
+)
+def test_multiseries_tiff_to_directory_keeps_per_series_stores():
+    """Directory-style .ome.zarr output keeps the documented per-series layout."""
+    tmp = Path(tempfile.mkdtemp(prefix="issue436dir_"))
+    tiff_path = tmp / "slide.svs.ome.tif"
+    _write_multiseries_tiff(tiff_path)
+
+    out = tmp / "out.ome.zarr"
+    result = _run_ngff_zarr("-i", str(tiff_path), "-o", str(out))
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+
+    created = sorted(p.name for p in tmp.iterdir() if p.name != tiff_path.name)
+    # One .ome.zarr store per series (documented behavior), not a single bundle.
+    assert any(name.endswith("_Baseline.ome.zarr") for name in created), created
+    assert any(name.endswith("_Thumbnail.ome.zarr") for name in created), created
+
+
+# --------------------------------------------------------------------------
+# Truncated / corrupt TIFF -> warning instead of silent data loss
+# --------------------------------------------------------------------------
+
+
+def _write_truncated_tiff(path):
+    """Write a 3-page classic TIFF, then point page 0's next-IFD offset past EOF."""
+    pages = [
+        np.full((64, 64), 10, np.uint8),
+        np.full((32, 32), 20, np.uint8),
+        np.full((16, 16), 30, np.uint8),
+    ]
+    with tifffile.TiffWriter(path, bigtiff=False, byteorder="<") as tif:
+        for p in pages:
+            tif.write(p, photometric="minisblack", compression=None)
+
+    data = bytearray(path.read_bytes())
+    ifd0 = struct.unpack_from("<I", data, 4)[0]
+    count = struct.unpack_from("<H", data, ifd0)[0]
+    next_off_pos = ifd0 + 2 + count * 12
+    struct.pack_into("<I", data, next_off_pos, len(data) + 1_000_000)
+    path.write_bytes(data)
+    return len(pages)
+
+
+def test_truncated_tiff_emits_warning():
+    """Test a truncated TIFF surfaces a RuntimeWarning, not silent data loss."""
+    from ngff_zarr import tiff_file_to_ngff_images
+
+    tmp = Path(tempfile.mkdtemp(prefix="issue436trunc_"))
+    tiff_path = tmp / "truncated.tif"
+    _write_truncated_tiff(tiff_path)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        tiff_file_to_ngff_images(tiff_path)
+
+    structural = [
+        w
+        for w in caught
+        if issubclass(w.category, RuntimeWarning)
+        and "tifffile reported errors" in str(w.message)
+    ]
+    assert structural, (
+        "Expected a RuntimeWarning about truncated/corrupt TIFF; "
+        f"got: {[str(w.message) for w in caught]}"
+    )
+    assert "truncated or corrupt" in str(structural[0].message)
+
+
+def test_clean_tiff_emits_no_structural_warning():
+    """Test a clean TIFF emits no spurious structural-error warning."""
+    from ngff_zarr import tiff_file_to_ngff_images
+
+    tmp = Path(tempfile.mkdtemp(prefix="issue436clean_"))
+    tiff_path = tmp / "clean.ome.tif"
+    _write_multiseries_tiff(tiff_path)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        tiff_file_to_ngff_images(tiff_path, reuse_existing_pyramids=True)
+
+    structural = [
+        w
+        for w in caught
+        if issubclass(w.category, RuntimeWarning)
+        and "tifffile reported errors" in str(w.message)
+    ]
+    assert not structural, (
+        f"Unexpected structural-error warning on a clean file: "
+        f"{[str(w.message) for w in structural]}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Error-message summarization helper
+# --------------------------------------------------------------------------
+
+
+class TestSummarizeTiffErrorMessages:
+    """Unit tests for the ``_summarize_tiff_error_messages`` helper."""
+
+    def test_dedupes_and_joins(self):
+        """Test duplicates are removed and remaining messages joined by ``; ``."""
+        from ngff_zarr.tiff_to_ngff_image import _summarize_tiff_error_messages
+
+        out = _summarize_tiff_error_messages(["a", "a", "b"])
+        assert out == "a; b"
+
+    def test_truncates_beyond_limit_with_more_note(self):
+        """Test messages beyond the limit are capped with a ``... (N more)`` note."""
+        from ngff_zarr.tiff_to_ngff_image import _summarize_tiff_error_messages
+
+        messages = [f"err{i}" for i in range(8)]
+        out = _summarize_tiff_error_messages(messages, limit=5)
+        assert out.startswith("err0; err1; err2; err3; err4")
+        assert out.endswith("... (3 more)")
+
+    def test_empty(self):
+        """Test an empty message list summarizes to an empty string."""
+        from ngff_zarr.tiff_to_ngff_image import _summarize_tiff_error_messages
+
+        assert _summarize_tiff_error_messages([]) == ""


### PR DESCRIPTION
## Summary

Fixes two distinct failure modes behind #436, where converting whole-slide
TIFF/SVS files to `.ozx` produced wrong, tiny, or missing output.

Whole-slide formats always contain **multiple series** — a full-resolution
**Baseline** pyramid plus auxiliary **Thumbnail**, **Label**, and **Macro**
images (Aperio `.svs`), or several OME images. The CLI mishandled these in two
ways, and large/corrupt files failed silently.

## Root causes

1. **The requested `.ozx` was never created.** For a multi-series input, the
   CLI rewrote a single-file `.ozx` output into `<base>_<series>.ome.zarr`
   **directories** — discarding both the requested filename *and* the zip
   format. This matches the report exactly: *"this file … does not exist after
   finish"*, with output spread across `_Baseline.ome.zarr` / `_Thumbnail.ome.zarr`.

2. **Truncated/corrupt files lost data silently.** The reported
   `invalid page offset 2927710232` is logged by `tifffile`: when a file's IFD
   chain points past EOF, tifffile logs an error and **stops enumerating pages**,
   dropping image data. ngff-zarr then wrote a tiny, blank output with no warning.

## What changed

**`py/ngff_zarr/cli.py`**
- New `_series_output_target()` helper, shared by the TIFF and LIF code paths.
- For a single-file `.ozx` target with multiple series, the **primary (first)
  series is written to the exact requested path**, and additional series are
  written alongside as `<base>_<series>.ozx` (zip format preserved):
  ```
  ngff-zarr -i slide.svs -o slide.ozx
  # -> slide.ozx (Baseline) + slide_Thumbnail.ozx, slide_Label.ozx, ...
  ```
- Directory-style `.zarr` / `.ome.zarr` output keeps the documented per-series
  behavior; derived names no longer double `.ome`
  (`out.ome.zarr` → `out_Baseline.ome.zarr`, not `out.ome_Baseline.ome.zarr`).
- Clearer per-series log: `Written series '<name>' -> <path>`.

**`py/ngff_zarr/tiff_to_ngff_image.py`**
- Captures `tifffile`'s own ERROR logs (`invalid page offset`,
  `corrupted tag list`) during reading and raises a `RuntimeWarning` that the
  file may be truncated/corrupt and the output may be incomplete — instead of
  failing silently. Reading is refactored into `_read_tiff_series()`, and a
  small `_summarize_tiff_error_messages()` helper deduplicates/caps the detail.

**`docs/tiff.md`** — documents the single-file `.ozx` multi-series behavior.

**`py/test/test_issue_436.py`** — 12 regression tests.

## Implementation notes

- **`.ozx` detection is case-sensitive** in the helper, deliberately matching
  the existing convention everywhere else (`main()`'s output-store selection,
  `rfc9_zip.is_ozx_path`, `to_ngff_zarr`). Full case-insensitive support would
  require changing the writer too and is out of scope here.
- The auxiliary series are still converted (no silent data loss); use
  `--series 0` to convert only the full-resolution image.
- Verified that **well-formed** pyramidal TIFFs (zlib / JPEG / JPEG-2000) still
  round-trip correctly with sane output sizes, so the normal data path is
  unchanged.

## Testing

- `py/test/test_issue_436.py`: 12 tests — `_series_output_target` routing
  (incl. the directory-output guard), end-to-end multi-series → `.ozx` (verifies
  the `.ozx` exists and holds real full-resolution data), truncated-file warning,
  no-false-positive on clean files, and the message-summarizer.
- Existing TIFF/CLI (39) and LIF/HCS (22) suites still pass; `ruff` lint clean.
- CodeRabbit review: clean (0 findings after addressing its initial minor notes).

## Note on the single-series JPEG-2000 case

The reporter's user-supplied test files are no longer reachable (HTTP 403), so I
reproduced the symptoms with synthetic files. The multi-series SVS symptom is
fully fixed. The single-series `j2k.ome.tif` → 169 MB case could **not** be
reproduced as data loss with well-formed files (the pyramid-reuse path
round-trips correctly); if it persists, it is most likely a corrupt/truncated
source — which the new read-error warning now surfaces — or expected
recompression. Happy to dig further if a fresh file can be shared.

Closes #436


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-series conversion: primary series writes to the exact requested .ozx; additional series are emitted alongside using descriptive suffixed outputs (and directory-style outputs create per-series directories).
* **Improvements**
  * TIFF reading now captures structural read errors and surfaces summarized RuntimeWarnings; resolved per-series destination paths are logged when multiple series are produced.
* **Documentation**
  * CLI guidance and example for selecting series and multi-series output behavior.
* **Tests**
  * Regression and unit tests for multi-series output semantics and TIFF error summarization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->