### PR TITLE
fix(py): prevent CLI crash on legacy Windows terminal encodings (cp1252)

### DIFF
--- a/py/ngff_zarr/cli.py
+++ b/py/ngff_zarr/cli.py
@@ -53,6 +53,37 @@ from .to_ngff_zarr import to_ome_zarr
 from .v04.zarr_metadata import Omero, OmeroChannel, OmeroWindow, is_unit_supported
 
 
+class _ReplacingTextIO:
+    """Text-stream proxy whose ``write`` never raises ``UnicodeEncodeError``.
+
+    A last resort for streams that cannot be reconfigured in place (for
+    example an ``ipykernel`` ``OutStream``, which has no ``reconfigure``).
+    Characters the underlying stream's encoding cannot represent are replaced
+    rather than raising, so Rich can render without crashing (see issue #37).
+    All other stream behavior is delegated to the wrapped stream.
+    """
+
+    def __init__(self, stream):
+        self._stream = stream
+        self.encoding = getattr(stream, "encoding", None) or "utf-8"
+
+    def write(self, text):
+        try:
+            return self._stream.write(text)
+        except UnicodeEncodeError:
+            safe = text.encode(self.encoding, errors="replace").decode(
+                self.encoding, errors="replace"
+            )
+            return self._stream.write(safe)
+
+    def flush(self):
+        return self._stream.flush()
+
+    def __getattr__(self, name):
+        # Delegate everything else (isatty, fileno, close, ...) to the stream.
+        return getattr(self._stream, name)
+
+
 def _build_console() -> Console:
     """Create a Rich ``Console`` resilient to legacy Windows encodings.
 
@@ -61,28 +92,37 @@ def _build_console() -> Console:
     shell-out, or git-bash. Rich emits Unicode box-drawing and spinner
     glyphs that those code pages cannot encode, so the underlying
     ``str.encode`` raises ``UnicodeEncodeError`` and the CLI crashes before
-    doing any work (see issue #37). Reconfigure the stream to UTF-8 so the
-    glyphs encode cleanly; if reconfiguration is unavailable, fall back to
-    replacing any un-encodable characters instead of raising.
+    doing any work (see issue #37).
+
+    Reconfigure the stream to UTF-8 so the glyphs encode cleanly. If the
+    stream cannot be reconfigured in place, bind the console to a proxy that
+    replaces any un-encodable characters at write time, so rendering degrades
+    gracefully instead of raising.
     """
     stream = sys.stdout
     encoding = (getattr(stream, "encoding", None) or "").lower().replace("-", "")
     # ``startswith`` keeps capable UTF variants (utf-8-sig, utf-16-le, ...) as-is
-    # while still reconfiguring legacy code pages (cp1252, latin-1, ascii, ...).
-    if not encoding.startswith(("utf8", "utf16", "utf32")):
-        reconfigure = getattr(stream, "reconfigure", None)
-        if reconfigure is not None:
+    # while still handling legacy code pages (cp1252, latin-1, ascii, ...).
+    if encoding.startswith(("utf8", "utf16", "utf32")):
+        return Console()
+
+    reconfigure = getattr(stream, "reconfigure", None)
+    if reconfigure is not None:
+        try:
+            reconfigure(encoding="utf-8")
+            return Console()
+        except (ValueError, OSError):
+            # Could not switch to UTF-8 (e.g. a detached/redirected stream);
+            # keep the encoding but replace un-encodable characters in place.
             try:
-                reconfigure(encoding="utf-8")
+                reconfigure(errors="replace")
+                return Console()
             except (ValueError, OSError):
-                # Could not switch to UTF-8 (e.g. a detached/redirected
-                # stream); degrade gracefully by replacing un-encodable
-                # characters rather than crashing.
-                try:
-                    reconfigure(errors="replace")
-                except (ValueError, OSError):
-                    pass
-    return Console()
+                pass
+
+    # The stream cannot be reconfigured in place; wrap it so Rich's writes
+    # never raise UnicodeEncodeError at render time.
+    return Console(file=_ReplacingTextIO(stream))
 
 
 def _apply_omero_metadata(live, args, multiscales):

--- a/py/ngff_zarr/cli.py
+++ b/py/ngff_zarr/cli.py
@@ -53,6 +53,38 @@ from .to_ngff_zarr import to_ome_zarr
 from .v04.zarr_metadata import Omero, OmeroChannel, OmeroWindow, is_unit_supported
 
 
+def _build_console() -> Console:
+    """Create a Rich ``Console`` resilient to legacy Windows encodings.
+
+    In some Windows environments the standard output stream uses a legacy
+    code page such as ``cp1252`` -- for example a Jupyter/IPython ``!``
+    shell-out, or git-bash. Rich emits Unicode box-drawing and spinner
+    glyphs that those code pages cannot encode, so the underlying
+    ``str.encode`` raises ``UnicodeEncodeError`` and the CLI crashes before
+    doing any work (see issue #37). Reconfigure the stream to UTF-8 so the
+    glyphs encode cleanly; if reconfiguration is unavailable, fall back to
+    replacing any un-encodable characters instead of raising.
+    """
+    stream = sys.stdout
+    encoding = (getattr(stream, "encoding", None) or "").lower().replace("-", "")
+    # ``startswith`` keeps capable UTF variants (utf-8-sig, utf-16-le, ...) as-is
+    # while still reconfiguring legacy code pages (cp1252, latin-1, ascii, ...).
+    if not encoding.startswith(("utf8", "utf16", "utf32")):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            try:
+                reconfigure(encoding="utf-8")
+            except (ValueError, OSError):
+                # Could not switch to UTF-8 (e.g. a detached/redirected
+                # stream); degrade gracefully by replacing un-encodable
+                # characters rather than crashing.
+                try:
+                    reconfigure(errors="replace")
+                except (ValueError, OSError):
+                    pass
+    return Console()
+
+
 def _apply_omero_metadata(live, args, multiscales):
     """Apply OMERO metadata to multiscales based on CLI arguments.
 
@@ -572,7 +604,7 @@ def main():
             Path.makedirs(cache_dir, parents=True)
         config.cache_store = LocalStore(cache_dir)
 
-    console = Console()
+    console = _build_console()
     progress = RichProgress(
         SpinnerColumn(),
         MofNCompleteColumn(),

--- a/py/test/test_cli_encoding.py
+++ b/py/test/test_cli_encoding.py
@@ -16,7 +16,7 @@ import io
 import sys
 
 import pytest
-from ngff_zarr.cli import _build_console
+from ngff_zarr.cli import _build_console, _ReplacingTextIO
 
 # The opening corner of the panel border Rich draws -- not encodable as cp1252.
 _BOX_GLYPH = "╭"
@@ -109,17 +109,25 @@ def test_build_console_leaves_utf_stdout_untouched(monkeypatch, encoding):
     assert calls == []
 
 
-def test_build_console_without_reconfigure_does_not_raise(monkeypatch):
-    """A legacy stream lacking ``reconfigure`` degrades gracefully, no crash."""
+def test_build_console_without_reconfigure_renders_without_crashing(monkeypatch):
+    """A legacy stream lacking ``reconfigure`` still renders (via the proxy)."""
+    from rich.spinner import Spinner
+
     stream = _cp1252_stream()
-    # ``getattr(stream, "reconfigure", None)`` now returns None.
+    # ``getattr(stream, "reconfigure", None)`` now returns None, so the helper
+    # cannot reconfigure in place and must fall back to the replacing proxy.
     monkeypatch.setattr(stream, "reconfigure", None)
     monkeypatch.setattr(sys, "stdout", stream)
 
-    _build_console()
+    console = _build_console()
 
-    # The stream could not be switched, so it stays cp1252 -- but no exception.
+    # The stream stays cp1252, but rendering the spinner glyphs that crashed
+    # issue #37 must now degrade gracefully instead of raising.
+    console.print(Spinner("point", text="Loading input..."))
+    stream.flush()
+
     assert stream.encoding.lower() == "cp1252"
+    assert b"Loading input" in stream.buffer.getvalue()
 
 
 def test_build_console_falls_back_to_errors_replace(monkeypatch):
@@ -143,7 +151,9 @@ def test_build_console_falls_back_to_errors_replace(monkeypatch):
 
 
 def test_build_console_swallows_reconfigure_failures(monkeypatch):
-    """When neither reconfigure attempt works, the CLI still gets a console."""
+    """When neither reconfigure attempt works, rendering still degrades gracefully."""
+    from rich.spinner import Spinner
+
     stream = _cp1252_stream()
 
     def reconfigure(*args, **kwargs):
@@ -152,7 +162,27 @@ def test_build_console_swallows_reconfigure_failures(monkeypatch):
     monkeypatch.setattr(stream, "reconfigure", reconfigure)
     monkeypatch.setattr(sys, "stdout", stream)
 
-    # Both attempts raise; the failures must be swallowed and a Console returned.
+    # Both attempts raise; the failures must be swallowed and a usable Console
+    # returned -- one whose writes replace un-encodable glyphs instead of raising.
     console = _build_console()
+    console.print(Spinner("point", text="Loading input..."))
+    stream.flush()
 
-    assert console is not None
+    assert b"Loading input" in stream.buffer.getvalue()
+
+
+def test_replacing_textio_replaces_unencodable_and_delegates():
+    """The proxy replaces un-encodable glyphs on write and delegates attributes."""
+    stream = _cp1252_stream()
+    proxy = _ReplacingTextIO(stream)
+
+    # ``∙`` (U+2219) is not cp1252-encodable; the proxy must not raise.
+    proxy.write("a∙b")
+    proxy.flush()
+
+    raw = stream.buffer.getvalue()
+    assert b"a" in raw  # surrounding text preserved
+    assert b"b" in raw
+    assert proxy.encoding.lower() == "cp1252"  # reports the real encoding
+    # Unknown attributes are delegated to the wrapped stream.
+    assert proxy.writable() is True

--- a/py/test/test_cli_encoding.py
+++ b/py/test/test_cli_encoding.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Regression tests for issue #37.
+
+On some Windows environments (a Jupyter/IPython ``!`` shell-out, git-bash)
+the standard output stream uses a legacy code page such as ``cp1252`` that
+cannot encode the Unicode box-drawing and spinner glyphs Rich emits. That
+raised ``UnicodeEncodeError`` and crashed the CLI before it did any work.
+
+``_build_console`` reconfigures the stream so those glyphs encode cleanly.
+The legacy code page is the trigger regardless of platform, so we reproduce
+it portably with an in-memory ``cp1252`` stream.
+"""
+
+import io
+import sys
+
+import pytest
+from ngff_zarr.cli import _build_console
+
+# The opening corner of the panel border Rich draws -- not encodable as cp1252.
+_BOX_GLYPH = "╭"
+
+
+def _cp1252_stream():
+    return io.TextIOWrapper(io.BytesIO(), encoding="cp1252")
+
+
+def _is_cp1252_encodable(ch):
+    try:
+        ch.encode("cp1252")
+    except UnicodeEncodeError:
+        return False
+    return True
+
+
+def test_cp1252_cannot_encode_box_glyph():
+    """Guard the premise: this glyph genuinely breaks cp1252 (the #37 trigger)."""
+    with pytest.raises(UnicodeEncodeError):
+        _BOX_GLYPH.encode("cp1252")
+
+
+def test_build_console_reconfigures_legacy_stdout(monkeypatch):
+    """A cp1252 stdout is reconfigured so Rich's glyphs become encodable."""
+    monkeypatch.setattr(sys, "stdout", _cp1252_stream())
+    assert sys.stdout.encoding.lower() == "cp1252"
+
+    _build_console()
+
+    # After reconfiguration the glyph that crashed the CLI must encode cleanly.
+    _BOX_GLYPH.encode(sys.stdout.encoding)
+
+
+def test_unfixed_cp1252_spinner_render_crashes():
+    """Guard the premise: the CLI's spinner glyphs crash an un-fixed cp1252 stream.
+
+    The CLI's initial panel wraps ``Spinner("point", ...)`` whose frames use
+    ``∙``/``●`` (positions 0-2 in the issue #37 traceback). ``safe_box`` does
+    not substitute those, so on a cp1252 stream the render raises -- this is the
+    failure ``_build_console`` exists to prevent.
+    """
+    from rich.console import Console
+    from rich.spinner import Spinner
+
+    stream = _cp1252_stream()
+    console = Console(file=stream, force_terminal=True, legacy_windows=True)
+    with pytest.raises(UnicodeEncodeError):
+        console.print(Spinner("point", text="Loading input..."))
+        stream.flush()
+
+
+def test_build_console_renders_spinner_without_crashing(monkeypatch):
+    """After _build_console, the CLI's spinner renders to a legacy stream cleanly."""
+    from rich.console import Console
+    from rich.spinner import Spinner
+
+    monkeypatch.setattr(sys, "stdout", _cp1252_stream())
+    _build_console()
+
+    # Force the terminal/legacy-windows rendering path that produced the
+    # original traceback, bound to the (now reconfigured) stdout.
+    console = Console(file=sys.stdout, force_terminal=True, legacy_windows=True)
+    console.print(Spinner("point", text="Loading input..."))
+    sys.stdout.flush()
+
+    output = sys.stdout.buffer.getvalue().decode("utf-8")
+    # Rich emitted spinner glyphs that cp1252 cannot encode -- exactly the
+    # characters that crashed the CLI before the stream was reconfigured.
+    assert any(not _is_cp1252_encodable(ch) for ch in output)
+
+
+@pytest.mark.parametrize("encoding", ["utf-8", "utf-8-sig", "utf-16", "utf-32"])
+def test_build_console_leaves_utf_stdout_untouched(monkeypatch, encoding):
+    """Any capable UTF variant is left as-is and must not be reconfigured."""
+    calls = []
+    stream = io.TextIOWrapper(io.BytesIO(), encoding=encoding)
+
+    original_reconfigure = stream.reconfigure
+
+    def spy(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original_reconfigure(*args, **kwargs)
+
+    monkeypatch.setattr(stream, "reconfigure", spy)
+    monkeypatch.setattr(sys, "stdout", stream)
+
+    _build_console()
+
+    assert calls == []
+
+
+def test_build_console_without_reconfigure_does_not_raise(monkeypatch):
+    """A legacy stream lacking ``reconfigure`` degrades gracefully, no crash."""
+    stream = _cp1252_stream()
+    # ``getattr(stream, "reconfigure", None)`` now returns None.
+    monkeypatch.setattr(stream, "reconfigure", None)
+    monkeypatch.setattr(sys, "stdout", stream)
+
+    _build_console()
+
+    # The stream could not be switched, so it stays cp1252 -- but no exception.
+    assert stream.encoding.lower() == "cp1252"
+
+
+def test_build_console_falls_back_to_errors_replace(monkeypatch):
+    """If switching to UTF-8 fails, fall back to replacing un-encodable chars."""
+    stream = _cp1252_stream()
+    calls = []
+
+    def reconfigure(*args, **kwargs):
+        calls.append(kwargs)
+        if "encoding" in kwargs:
+            raise OSError("cannot change encoding on this stream")
+
+    monkeypatch.setattr(stream, "reconfigure", reconfigure)
+    monkeypatch.setattr(sys, "stdout", stream)
+
+    _build_console()
+
+    # First the UTF-8 switch is attempted, then the replace fallback.
+    assert {"encoding": "utf-8"} in calls
+    assert {"errors": "replace"} in calls
+
+
+def test_build_console_swallows_reconfigure_failures(monkeypatch):
+    """When neither reconfigure attempt works, the CLI still gets a console."""
+    stream = _cp1252_stream()
+
+    def reconfigure(*args, **kwargs):
+        raise ValueError("stream refuses reconfiguration")
+
+    monkeypatch.setattr(stream, "reconfigure", reconfigure)
+    monkeypatch.setattr(sys, "stdout", stream)
+
+    # Both attempts raise; the failures must be swallowed and a Console returned.
+    console = _build_console()
+
+    assert console is not None


### PR DESCRIPTION
## Summary

Fixes #37 — the `ngff-zarr` CLI crashed with `UnicodeEncodeError` when launched from an environment whose stdout uses a legacy code page such as `cp1252` (a Jupyter/IPython `!` shell-out, or git-bash on Windows). The crash happened during the very first Rich `Live` panel render, before any conversion work began.

## Root cause

The CLI's initial panel wraps `Spinner("point", ...)`, whose animation frames use the glyphs `∙`/`●` (U+2219/U+25CF). Rich's `safe_box` substitutes ASCII for box-drawing characters but **not** for spinner glyphs, so on a `cp1252` stream those characters reach `str.encode` and raise `UnicodeEncodeError` (matching the "characters in position 0-2" traceback in the issue). This was confirmed by direct reproduction.

## Changes

- **`py/ngff_zarr/cli.py`**: Added `_build_console()`, which inspects `sys.stdout.encoding` and, when it is not already a UTF variant, reconfigures the stream to UTF-8 so Rich's glyphs encode cleanly. `main()` now constructs its Rich `Console` through this helper instead of calling `Console()` directly.
- **`py/test/test_cli_encoding.py`** (new): Regression tests covering the spinner-glyph trigger and every branch of the helper.

## Implementation details

- **Capability check via `startswith`**: the encoding is normalized (lowercased, hyphens stripped) and compared with `startswith(("utf8", "utf16", "utf32"))`. This leaves already-capable UTF variants (`utf-8-sig`, `utf-16-le`, …) untouched while still reconfiguring legacy code pages (`cp1252`, `latin-1`, `ascii`, …).
- **Graceful degradation**: if `reconfigure(encoding="utf-8")` fails (e.g. a detached/redirected stream), it falls back to `reconfigure(errors="replace")`; if the stream has no `reconfigure` at all, or both attempts fail, the helper still returns a `Console` rather than raising — strictly better than the prior crash.
- **Reconfiguration is in-place** on `sys.stdout`, so `Console()` (which reads `sys.stdout` at construction) picks up the new encoding. The mutation is intentional and scoped to the CLI entry point, so Python's own prints are protected too. UTF-8 terminals are left completely untouched.

## Testing

- New `test/test_cli_encoding.py`: **11 passed** (premise guards, the cp1252 reproduction, the post-fix render, the `startswith` UTF-variant cases, and all reconfigure-failure branches).
- Existing `test/test_cli_relative_paths.py`: **9 passed** — no regression.
- `ruff` v0.15.2 (repo's pinned pre-commit version): `check` and `format --check` both clean.

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI output now reliably renders box-drawing characters and spinners on Windows and legacy/limited stdout encodings by attempting UTF-8, falling back to safe replacement behavior, and ensuring rendering does not crash.

* **Tests**
  * Added regression tests covering encoding fallbacks, spinner/glyph rendering, and graceful behavior when stdout cannot be reconfigured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->