### PR TITLE
docs(py): document all anti-aliasing Methods and cross-link from to_multiscales

### DIFF
--- a/py/ngff_zarr/methods/__init__.py
+++ b/py/ngff_zarr/methods/__init__.py
@@ -1,17 +1,68 @@
 # SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
 # SPDX-License-Identifier: MIT
+"""Anti-aliasing methods used to downsample images into a multiscale pyramid."""
+
 from enum import Enum
 
-methods = [
-    ("ITKWASM_GAUSSIAN", "itkwasm_gaussian"),
-    ("ITKWASM_BIN_SHRINK", "itkwasm_bin_shrink"),
-    ("ITKWASM_LABEL_IMAGE", "itkwasm_label_image"),
-    ("ITK_GAUSSIAN", "itk_gaussian"),
-    ("ITK_BIN_SHRINK", "itk_bin_shrink"),
-    #    ("ITK_LABEL_GAUSSIAN", "itk_label_gaussian"),
-    ("DASK_IMAGE_GAUSSIAN", "dask_image_gaussian"),
-    ("DASK_IMAGE_MODE", "dask_image_mode"),
-    ("DASK_IMAGE_NEAREST", "dask_image_nearest"),
-]
-methods_values = [m[1] for m in methods]
-Methods = Enum("Methods", methods)
+
+class Methods(Enum):
+    """Anti-aliasing methods for downsampling an image into a multiscale pyramid.
+
+    To avoid aliasing artifacts when generating a multiscale representation, the
+    input image is smoothed before it is downsampled. The available methods
+    differ primarily in the smoothing that is applied prior to resampling, and
+    therefore in their amount of artifacts, speed, hardware requirements and
+    portability, and suitability for intensity or label images.
+
+    Pass a member to {py:func}`~ngff_zarr.to_multiscales.to_multiscales`, for
+    example ``to_multiscales(image, method=Methods.ITKWASM_GAUSSIAN)``. See the
+    {doc}`Methods guide </methods>` for installation requirements and
+    GPU-accelerated variants of these methods.
+    """
+
+    ITKWASM_GAUSSIAN = "itkwasm_gaussian"
+    """Smoothed with a discrete Gaussian filter to generate a scale space, ideal
+    for intensity images. The ITK-Wasm implementation is extremely portable and
+    SIMD accelerated. This is the default method."""
+
+    ITKWASM_BIN_SHRINK = "itkwasm_bin_shrink"
+    """Uses the local mean for the output value. WebAssembly build. Fast but
+    generates more artifacts than Gaussian-based methods. Appropriate for
+    intensity images."""
+
+    ITKWASM_LABEL_IMAGE = "itkwasm_label_image"
+    """A sample is the mode of the linearly weighted local labels in the image.
+    Fast with minimal artifacts. For label images."""
+
+    ITK_GAUSSIAN = "itk_gaussian"
+    """Similar to ITKWASM_GAUSSIAN, but built to native binaries. Smoothed with a
+    discrete Gaussian filter to generate a scale space, ideal for intensity
+    images."""
+
+    ITK_BIN_SHRINK = "itk_bin_shrink"
+    """Uses the local mean for the output value. Native binary build. Fast but
+    generates more artifacts than Gaussian-based methods. Appropriate for
+    intensity images."""
+
+    # ITK_LABEL_GAUSSIAN = "itk_label_gaussian"
+
+    DASK_IMAGE_GAUSSIAN = "dask_image_gaussian"
+    """Smoothed with a discrete Gaussian filter to generate a scale space, ideal
+    for intensity images. dask-image implementation based on SciPy."""
+
+    DASK_IMAGE_MODE = "dask_image_mode"
+    """Local mode for label images. Fewer artifacts than simple nearest neighbor
+    interpolation, but slower."""
+
+    DASK_IMAGE_NEAREST = "dask_image_nearest"
+    """Nearest neighbor for label images. Will have many artifacts for
+    high-frequency content and/or multiple scales."""
+
+
+# Backwards-compatible (name, value) pairs and value strings, derived from the
+# Methods enum. ``methods_values`` is used for CLI ``--method`` argument choices.
+methods = [(member.name, member.value) for member in Methods]
+"""Backwards-compatible ``(name, value)`` pairs for each ``Methods`` member."""
+
+methods_values = [member.value for member in Methods]
+"""String values of the ``Methods`` members, e.g. the CLI ``--method`` choices."""

--- a/py/ngff_zarr/to_multiscales.py
+++ b/py/ngff_zarr/to_multiscales.py
@@ -495,8 +495,8 @@ def to_multiscales(
         Scaling is constrained by size of chunks - we do not scale below the chunk size.
     :type  scale_factors: int of minimum length, int per scale or dict of spatial dimension int's per scale
 
-    :param method:  Specify the anti-aliasing method used to downsample the image. Default is ITKWASM_GAUSSIAN.
-    :type  Methods: ngff_zarr.Methods enum
+    :param method:  Specify the anti-aliasing method used to downsample the image. Default is ITKWASM_GAUSSIAN. See the {py:class}`Methods <ngff_zarr.methods.Methods>` enum for all available options.
+    :type  method: Methods, optional
 
     :param chunks: Specify the chunking used in each output scale. The default is 128 for 3D images and 256 for 2D images.
     :type  chunks: Dask array chunking specification, optional

--- a/py/test/test_methods.py
+++ b/py/test/test_methods.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Contract tests for the ``Methods`` enum and its derived helpers.
+
+These lock in the public surface of :mod:`ngff_zarr.methods`: the exact set of
+members and their ``.value`` strings (which are persisted verbatim in OME-Zarr
+``multiscales.type`` metadata), the backwards-compatible ``methods`` /
+``methods_values`` helpers, value-based lookup (used by the CLI and metadata
+parser), and that every member is documented.
+"""
+
+import ast
+import enum
+import inspect
+import textwrap
+
+import ngff_zarr
+from ngff_zarr.methods import Methods, methods, methods_values
+
+# Name -> value mapping, in definition order. The values are written to disk in
+# OME-Zarr metadata, so changing one is a breaking change and must be deliberate.
+EXPECTED_MEMBERS = {
+    "ITKWASM_GAUSSIAN": "itkwasm_gaussian",
+    "ITKWASM_BIN_SHRINK": "itkwasm_bin_shrink",
+    "ITKWASM_LABEL_IMAGE": "itkwasm_label_image",
+    "ITK_GAUSSIAN": "itk_gaussian",
+    "ITK_BIN_SHRINK": "itk_bin_shrink",
+    "DASK_IMAGE_GAUSSIAN": "dask_image_gaussian",
+    "DASK_IMAGE_MODE": "dask_image_mode",
+    "DASK_IMAGE_NEAREST": "dask_image_nearest",
+}
+
+
+def test_methods_is_enum_exported_at_top_level():
+    assert issubclass(Methods, enum.Enum)
+    # The top-level re-export must be the very same object.
+    assert ngff_zarr.Methods is Methods
+
+
+def test_member_names_and_values_are_stable():
+    """Members and their persisted value strings must not drift unexpectedly."""
+    assert {member.name: member.value for member in Methods} == EXPECTED_MEMBERS
+    # Order matters for CLI choices and is part of the public contract.
+    assert [member.name for member in Methods] == list(EXPECTED_MEMBERS.keys())
+
+
+def test_methods_helper_matches_enum():
+    """``methods`` is the (name, value) pairs derived from the enum."""
+    assert methods == [(member.name, member.value) for member in Methods]
+    assert methods == list(EXPECTED_MEMBERS.items())
+
+
+def test_methods_values_helper_matches_enum():
+    """``methods_values`` (used for CLI ``--method`` choices) tracks the enum."""
+    assert methods_values == [member.value for member in Methods]
+    assert methods_values == list(EXPECTED_MEMBERS.values())
+
+
+def test_value_lookup_roundtrips():
+    """``Methods(value)`` resolves to the member, as cli.py / parse_metadata rely on."""
+    for member in Methods:
+        assert Methods(member.value) is member
+
+
+def test_class_has_docstring():
+    assert Methods.__doc__ is not None
+    assert Methods.__doc__.strip()
+
+
+def test_every_member_has_an_attribute_docstring():
+    """Each member must be followed by a docstring (the gap that caused gh-227).
+
+    Attribute docstrings are not available at runtime, so inspect the source AST:
+    every ``NAME = "value"`` assignment in the class body must be immediately
+    followed by a string-literal expression statement.
+    """
+    class_source = textwrap.dedent(inspect.getsource(Methods))
+    class_def = ast.parse(class_source).body[0]
+    assert isinstance(class_def, ast.ClassDef)
+
+    body = class_def.body
+    documented = set()
+    for index, node in enumerate(body):
+        is_member_assign = (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        )
+        if not is_member_assign:
+            continue
+        following = body[index + 1] if index + 1 < len(body) else None
+        has_docstring = (
+            isinstance(following, ast.Expr)
+            and isinstance(following.value, ast.Constant)
+            and isinstance(following.value.value, str)
+        )
+        if has_docstring:
+            documented.add(node.targets[0].id)
+
+    member_names = {member.name for member in Methods}
+    undocumented = member_names - documented
+    assert not undocumented, f"Methods members missing a docstring: {undocumented}"


### PR DESCRIPTION
Closes #227.

Fixes the auto-generated API documentation for the downsampling / anti-aliasing methods so every method is listed and the `method` parameter of `to_multiscales` links to it.

## Problem

In the [`ngff_zarr.methods` API reference](https://ngff-zarr.readthedocs.io/en/latest/apidocs/ngff_zarr/ngff_zarr.methods.html), `Methods` rendered as an opaque data attribute valued `'Enum(...)'` — **none** of the actual methods were listed. Separately, the `method` parameter on `to_multiscales` showed **no type at all** and did not link to `Methods`.

Root cause: the docs are generated by `sphinx-autodoc2`, which performs **static** source analysis. `Methods` was built with the dynamic functional API (`Enum("Methods", methods)`), which autodoc2 cannot introspect. The `to_multiscales` docstring also had a mistyped field — `:type Methods:` instead of `:type method:` — that orphaned the type so it never displayed.

## What changed

- **`py/ngff_zarr/methods/__init__.py`** — Rewrote `Methods` as a static `class Methods(Enum)` with a class docstring and an attribute docstring on every member (descriptions sourced from the existing `methods/_metadata.py` and `docs/methods.md`). autodoc2 now lists all 8 members with their descriptions. `methods` and `methods_values` are kept for backward compatibility, now **derived** from the enum.
- **`py/ngff_zarr/to_multiscales.py`** — Fixed the `method` parameter docstring to `:type method: Methods, optional` (correct field name → the type now displays and auto-links to the enum) and added a `{py:class}` cross-reference in the description.
- **`py/test/test_methods.py`** *(new)* — Contract tests that lock in the enum's public surface.

## Why

Issue #227 asked to (1) un-truncate the methods API docs so all methods are listed, and (2) link the type from the `to_multiscales` docs. Both are now satisfied, and the `Methods` page additionally links to the prose Methods guide.

## Implementation notes

- **Behavior is unchanged.** The class-based enum preserves member names, `.value` strings, definition order, value lookup (`Methods("itkwasm_gaussian")`), iteration (used by `parse_metadata.py`), and the top-level `ngff_zarr.Methods` export. The CLI path (`choices=methods_values` + `Methods(args.method)`) is unaffected.
- **Docstrings render as MyST here, not RST** (this autodoc2 config uses `autodoc2_render_plugin = "myst"` + the `fieldlist` extension). RST inline roles like `` :func:`...` `` render as broken literal text, so cross-references use MyST roles — `{py:class}`, `{py:func}`, `{doc}`. The re-export path (`ngff_zarr.Methods`) does not resolve as a target; the canonical path (`ngff_zarr.methods.Methods`) does. `E501` is in the repo's ruff `extend-ignore`, so the 88-char convention was checked manually.

## Tests (`test_methods.py`, 7 tests)

- Exact member name→value mapping — these value strings are persisted verbatim in OME-Zarr `multiscales.type` metadata, so an accidental change is a data-format regression.
- `methods` / `methods_values` stay consistent with the enum.
- Value-lookup round-trip and top-level export identity.
- An AST check that **every member has a docstring** — directly guarding against the regression that caused this issue.

## Verification

- Docs rebuilt cleanly (`pixi run -e docs build-docs`); confirmed in the generated HTML that all 8 members render with descriptions and that `to_multiscales` links to `Methods` (and the enum links back).
- `ruff check` / `ruff format` clean; all pre-commit hooks pass; `test_methods.py` (7) and `test_multiscales_type.py` (4) pass.
- CodeRabbit review: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
