### PR TITLE
feat(py,ts): add OME-Zarr v0.4 structural validation with cross-language parity

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,10 @@ extensions = [
 myst_enable_extensions = ["colon_fence", "fieldlist"]
 
 templates_path = ["_templates"]
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+# docs/validation/ is a structured DocGraph artifact (YAML front matter +
+# [[wiki-link]] cross-references) for graph navigation, not Sphinx pages, so it
+# is excluded from the MyST/Sphinx build.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "validation/*"]
 
 autodoc2_packages = [
     {

--- a/docs/validation/api.md
+++ b/docs/validation/api.md
@@ -1,0 +1,161 @@
+---
+type: reference
+title: Structural Validation API
+created: 2026-06-03
+tags:
+  - validation
+  - ome-zarr
+  - api
+  - python
+  - typescript
+related:
+  - '[[overview]]'
+  - '[[rule-reference]]'
+  - '[[parity]]'
+---
+
+<!-- SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Structural Validation API
+
+How to invoke structural validation from Python and TypeScript. For the rules
+themselves see [[rule-reference]], and for the levels and scope see
+[[overview]].
+
+On read, validation is **opt-in** and runs in two stages for v0.4+ metadata:
+schema (shape) validation first, then — at the default `strict`
+[[overview|level]] — the structural rules. Both stages are gated by the same
+flag (`validate=True` in Python, `{ validate: true }` in TypeScript); the
+flag defaults to off, so nothing extra runs unless you ask for it.
+
+## Python
+
+```python
+from ngff_zarr import (
+    validate_structural,
+    ValidationLevel,
+    ValidateOptions,
+    ValidationError,
+    SpecRule,
+)
+```
+
+`validate_structural(metadata, options=None)` runs the image/multiscales rules.
+When `options` is `None` it uses `ValidateOptions()`, i.e.
+`ValidationLevel.STRICT`. A `ValidationError` carries `.rule` (a `SpecRule`),
+`.message` (str), and `.location` (`str | None`); `str(exc)` is
+`Spec rule [<rule>] violated: <message>`.
+
+**Validate on read** with `from_ngff_zarr(store, validate=True)` (the `validate`
+keyword defaults to `False`). The `ValidationError` propagates unchanged:
+
+```python
+from ngff_zarr import from_ngff_zarr, ValidationError
+
+try:
+    multiscales = from_ngff_zarr("image.ome.zarr", validate=True)
+except ValidationError as exc:
+    print(f"rule={exc.rule.value} location={exc.location}: {exc.message}")
+```
+
+**Validate an already-parsed metadata object** directly, choosing the level:
+
+```python
+from ngff_zarr import (
+    validate_structural,
+    ValidateOptions,
+    ValidationLevel,
+    ValidationError,
+)
+
+try:
+    validate_structural(
+        multiscales.metadata,
+        ValidateOptions(level=ValidationLevel.STRICT),  # the default
+    )
+except ValidationError as exc:
+    print(exc)  # "Spec rule [<rule>] violated: <message>"
+```
+
+For HCS metadata, the companion entry points `validate_plate(plate)` and
+`validate_well(plate, well)` follow the same `strict`-by-default contract.
+`ValidationLevel.SCHEMA_ONLY` makes any orchestrator return immediately without
+running a structural rule. Because `ValidationLevel` and `SpecRule` derive from
+`str`, you can compare directly: `ValidationLevel.STRICT == "strict"` and
+`SpecRule.AXIS_COUNT == "axis-count"`.
+
+## TypeScript
+
+```typescript
+import {
+  fromOmeZarr,
+  validateStructural,
+  ValidationError,
+  ValidationLevel,
+  SpecRule,
+} from "@fideus-labs/ngff-zarr";
+```
+
+`validateStructural(metadata, options?)` runs the image/multiscales rules. When
+`options` (or its `level`) is omitted, the level resolves to
+`ValidationLevel.Strict`. A `ValidationError` carries a readonly `rule`
+(`SpecRule`) and an optional `location` (`string`); its `message` is
+`Spec rule [<rule>] violated: <message>`.
+
+**Validate an already-parsed metadata object** directly — this is the typed
+path, where `instanceof ValidationError` exposes `rule` and `location`:
+
+```typescript
+import { validateStructural, ValidationError } from "@fideus-labs/ngff-zarr";
+
+try {
+  validateStructural(metadata); // throws on the first violated SpecRule
+} catch (err) {
+  if (err instanceof ValidationError) {
+    console.error(err.rule, err.location, err.message);
+  }
+}
+```
+
+**Validate on read** with `fromOmeZarr(store, { validate: true })` (the
+`validate` option defaults to `false`). For a v0.4+ store this runs schema
+validation first, then the strict structural rules:
+
+```typescript
+import { fromOmeZarr } from "@fideus-labs/ngff-zarr";
+
+try {
+  const multiscales = await fromOmeZarr(url, { validate: true });
+  // ... use multiscales.images / multiscales.metadata
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+}
+```
+
+> **Note.** `fromOmeZarr` wraps any read failure — including a structural
+> `ValidationError` — as `Error("Failed to read OME-Zarr: <message>")`. The
+> original `rule`/`location` are therefore not recoverable via `instanceof`
+> on the read path; only the prefixed message survives. When you need the typed
+> `SpecRule` and `location`, call `validateStructural` on the parsed metadata
+> directly (the typed path above).
+
+For HCS metadata, `validatePlate(plate)` and `validateWell(plate, well)` are
+the plate/well counterparts. Pass `{ level: ValidationLevel.SchemaOnly }` to
+skip the structural rules.
+
+## Public surface summary
+
+| Symbol | Python (`ngff_zarr`) | TypeScript (`@fideus-labs/ngff-zarr`) |
+| ------ | -------------------- | ------------------------------------- |
+| Image orchestrator | `validate_structural` | `validateStructural` |
+| Plate orchestrator | `validate_plate` | `validatePlate` |
+| Well orchestrator | `validate_well` | `validateWell` |
+| Rule identifiers | `SpecRule` | `SpecRule` |
+| Levels | `ValidationLevel` | `ValidationLevel` |
+| Options | `ValidateOptions` | `ValidateOptions` |
+| Error type | `ValidationError` | `ValidationError` |
+| Validate on read | `from_ngff_zarr(store, validate=True)` | `fromOmeZarr(store, { validate: true })` |
+
+The identifier set, level set, default, and evaluation order are identical
+across both ports and locked by tests — see [[parity]].

--- a/docs/validation/overview.md
+++ b/docs/validation/overview.md
@@ -1,0 +1,110 @@
+---
+type: reference
+title: Structural Validation Overview
+created: 2026-06-03
+tags:
+  - validation
+  - ome-zarr
+  - structural-validation
+related:
+  - '[[rule-reference]]'
+  - '[[api]]'
+  - '[[parity]]'
+---
+
+<!-- SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Structural Validation Overview
+
+**Structural validation** enforces the OME-Zarr v0.4 specification MUSTs that a
+JSON Schema cannot express. It is layered conceptually on top of *schema*
+validation: where schema validation answers "is this shaped like OME-Zarr?",
+structural validation answers "does this obey the spec's structural
+invariants?" — axis counts and ordering, coordinate-transformation arity,
+finest-to-coarsest dataset ordering, OMERO channel color format, RFC 4
+anatomical orientation, and HCS plate/well consistency.
+
+The rules operate on the already-parsed metadata object (the `Metadata`,
+`Plate`, and `Well` dataclasses in Python; their equivalents in TypeScript), so
+they run even when the optional JSON Schema validator is not installed. Each
+rule has a stable, lower-kebab-case identifier (a [[rule-reference|SpecRule]])
+that is part of the observable surface — reused verbatim in error messages,
+logs, tests, and across both language ports.
+
+See [[rule-reference]] for the full rule table, [[api]] for how to invoke
+validation from Python and TypeScript, and [[parity]] for the cross-language
+equivalence guarantee.
+
+## Why JSON Schema cannot express these MUSTs
+
+A JSON Schema validates the *shape* of one node at a time. The OME-Zarr v0.4
+MUSTs enforced here are instead cross-field, ordering, positional, and
+conditional constraints that span multiple nodes:
+
+- **Cross-field** — `scale-length-mismatch` requires every `scale` and
+  `translation` vector to have exactly one entry per axis, i.e. a length equal
+  to `len(axes)`. That target lives in a sibling array, and JSON Schema's
+  `minItems`/`maxItems` are constants that cannot reference another node's size.
+- **Ordering / relational** — `dataset-order-highest-to-lowest` requires each
+  multiscale level's spatial scale to be no smaller than the previous level's,
+  a pairwise comparison across adjacent elements of the `datasets` array.
+  Schema keywords validate array elements independently of one another.
+- **Positional / stateful** — `global-coord-transform-after-per-level` requires
+  exactly one `scale` per dataset and forbids a `scale` after a `translation`;
+  an element's validity depends on the type and position of earlier elements,
+  which `prefixItems`/`contains` cannot capture.
+- **Cross-object lookup** — `plate-row-index-consistency` requires a well's
+  `rowIndex` to equal the position of the row named in its `path` within
+  `plate.rows`, a derived lookup across objects.
+- **Conditional** — `well-acquisition-missing` only applies when the plate
+  declares more than one acquisition.
+
+These imperative, multi-node dependencies are exactly why the rules are
+implemented as ordinary code layered on top of schema validation, rather than
+as schema keywords.
+
+## Validation levels
+
+Validation runs at one of two levels, expressed by the `ValidationLevel` enum.
+There are exactly two members, and `strict` is the default:
+
+| Level (`ValidationLevel`) | Wire value     | Behavior |
+| ------------------------- | -------------- | -------- |
+| `STRICT` (default)        | `"strict"`     | Runs every structural rule in canonical spec-MUST order, failing fast on the first violation. |
+| `SCHEMA_ONLY`             | `"schema_only"`| Runs no structural rule and returns immediately. Schema (shape) validation remains the separate concern of the schema validator on the raw attribute dict. |
+
+The default is applied whenever no options are passed: in Python,
+`ValidateOptions()` constructs with `level=ValidationLevel.STRICT`; in
+TypeScript, `validateStructural(metadata)` resolves the level to
+`ValidationLevel.Strict` when none is supplied.
+
+### Explicitly out of scope
+
+Deep, store-reading checks are intentionally **out of scope for both levels** —
+neither level reads array chunks. For example, confirming that each dataset's
+array actually exists on disk with the expected shape and dtype is *not* part of
+structural validation. The rules validate metadata only.
+
+## Scope and orchestrators
+
+Structural validation is dispatched through three fail-fast entry points:
+
+- **Image / multiscales** (including OMERO color and RFC 4 orientation) —
+  `validate_structural` (Python) / `validateStructural` (TypeScript).
+- **HCS plate** — `validate_plate` / `validatePlate`.
+- **HCS well** — `validate_well` / `validateWell` (validated in the context of
+  its parent plate, whose acquisition declarations govern the well rules).
+
+Each entry point raises a `ValidationError` on the first violated rule, in
+canonical spec order; later rules do not run. A `ValidationError` carries the
+offending `SpecRule`, a human-readable `message`, and an optional dotted-segment
+`location` (e.g. `multiscales[0].datasets[2].coordinateTransformations[0]`). Its
+string form is:
+
+```text
+Spec rule [<rule>] violated: <message>
+```
+
+Continue to [[rule-reference]] for every rule, or [[api]] to start using
+validation.

--- a/docs/validation/parity.md
+++ b/docs/validation/parity.md
@@ -1,0 +1,120 @@
+---
+type: reference
+title: Cross-Language Parity Guarantee
+created: 2026-06-03
+tags:
+  - validation
+  - ome-zarr
+  - parity
+  - cross-language
+  - testing
+related:
+  - '[[overview]]'
+  - '[[rule-reference]]'
+  - '[[api]]'
+---
+
+<!-- SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Cross-Language Parity Guarantee
+
+The Python and TypeScript ports expose an **identical, byte-stable**
+structural-validation surface for OME-Zarr v0.4. This page describes the
+contract and the tests that lock it. For the rules, see [[rule-reference]]; for
+usage, see [[api]].
+
+## The contract
+
+Both ports must agree on four observable dimensions:
+
+1. **Rule identifiers** — the same `SpecRule` string values, in the same
+   canonical declaration/iteration order.
+2. **Identifier format** — every value is lower-kebab-case, matching the
+   anchored pattern `[a-z]+(-[a-z]+)*`.
+3. **Levels** — `ValidationLevel` has exactly `{ "schema_only", "strict" }`,
+   with `strict` as the default applied when no options are passed.
+4. **Fail-fast evaluation order** — each image/multiscales orchestrator
+   (`validate_structural` / `validateStructural`) evaluates rules in the same
+   canonical order, so the same metadata yields the same first violation in
+   both languages.
+
+Because both test suites assert these facts against the **same literal
+identifier list**, adding, removing, renaming, or reordering a rule — or
+changing the evaluation order, the kebab format, or the level set/default — in
+only one language makes that language's suite diverge from the shared manifest
+and fails CI. Such changes must therefore be deliberate, mirrored edits in both
+ports.
+
+## The locked identifier manifest
+
+The canonical `SpecRule` set, in evaluation order:
+
+1. `axis-count`
+2. `axis-type`
+3. `axis-order`
+4. `scale-length-mismatch`
+5. `global-coord-transform-after-per-level`
+6. `dataset-order-highest-to-lowest`
+7. `omero-channel-color-format`
+8. `axis-orientation-consistent-type`
+9. `axis-orientation-completeness`
+10. `plate-row-index-consistency`
+11. `well-acquisition-missing`
+
+Each suite pins this list as a `CANONICAL_SPEC_RULE_IDS` literal — byte-identical
+between the two languages so the tests are line-for-line comparable.
+
+## The parity tests
+
+| Language   | Test file |
+| ---------- | --------- |
+| Python     | `py/test/test_structural_validation_parity.py` |
+| TypeScript | `ts/test/structural_validation_parity_test.ts` |
+
+Each suite independently locks:
+
+- **Set equality** — the full set of `SpecRule` values equals the canonical
+  manifest (no more, no fewer).
+- **Declaration/iteration order** — the ordered list of values equals the
+  manifest in exact order (Python iterates the `Enum`; TypeScript reads
+  `Object.values(SpecRule)`).
+- **No silent aliases** — the value set size equals the manifest length, so no
+  two members may share a value.
+- **Lower-kebab-case format** — every value matches the anchored pattern
+  (`re.fullmatch(r"[a-z]+(-[a-z]+)*", value)` in Python; the equivalent
+  `/^[a-z]+(-[a-z]+)*$/` in TypeScript).
+- **Level set and default** — `ValidationLevel` has exactly `schema_only` and
+  `strict`, and `strict` is the default.
+- **Fail-fast evaluation order** — driving the orchestrator with metadata that
+  violates the earliest rule plus every later rule, then repairing exactly one
+  rule per stage across ten stages, the rule raised at each stage builds a
+  sequence equal to a shared `EXPECTED_EVALUATION_ORDER`. This proves every rule
+  is evaluated strictly before all rules after it; a final, fully-repaired
+  metadata is accepted with no violation.
+
+The two HCS rules (`plate-row-index-consistency`, `well-acquisition-missing`)
+are deliberately absent from the image orchestrator's evaluation order; they are
+dispatched by the separate plate/well orchestrators (see [[rule-reference]]).
+
+## Sanctioned TypeScript-only adaptations
+
+The two ports are equivalent on the wire, with two documented, behavior-neutral
+departures in the TypeScript suite:
+
+- **Member spelling** follows each language's convention — TypeScript uses a
+  PascalCase const object (`SpecRule.AxisCount`, `ValidationLevel.Strict`),
+  Python an `UPPER_SNAKE` `str, Enum` (`SpecRule.AXIS_COUNT`,
+  `ValidationLevel.STRICT`). The `.value` strings are identical, so the
+  cross-language assertions hold.
+- **Axis-name labels and the default check** — TypeScript's ordering fixtures
+  use valid `SupportedDims` members in place of the Python helper's free-form
+  axis names, and assert the `strict` default *observably* (because the
+  TypeScript options type is a bare interface with no constructor) rather than
+  through a constructable options object. Neither alters the observed rule set
+  or evaluation order.
+
+Internal message-fidelity helpers in the TypeScript port (rendering whole-number
+scales with a trailing `.0`, Python-style quoted name lists, and `repr`-style
+strings) exist purely to keep `ValidationError` message bytes identical across
+languages; they are not part of the public surface.

--- a/docs/validation/rule-reference.md
+++ b/docs/validation/rule-reference.md
@@ -1,0 +1,80 @@
+---
+type: reference
+title: Structural Validation Rule Reference
+created: 2026-06-03
+tags:
+  - validation
+  - ome-zarr
+  - structural-validation
+  - rules
+related:
+  - '[[overview]]'
+  - '[[api]]'
+  - '[[parity]]'
+---
+
+<!-- SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Structural Validation Rule Reference
+
+This is the canonical table of OME-Zarr v0.4 structural rules. Each rule has a
+stable, lower-kebab-case identifier (the `SpecRule` value) that is identical
+across the Python and TypeScript ports — see [[parity]] for the guarantee. For
+the conceptual background and the two validation levels, see [[overview]]; for
+invocation, see [[api]].
+
+Location strings are dotted-segment, JSON-Pointer-style identifiers of the
+offending metadata node, emitted byte-for-byte identically in both languages.
+
+## Canonical rule table
+
+The rules are listed in canonical spec-MUST evaluation order — the same order
+the `SpecRule` enum declares them and the orchestrators evaluate them.
+
+| #  | Identifier | Applies to | What it checks | Spec MUST (v0.4) | Example location |
+| -- | ---------- | ---------- | -------------- | ---------------- | ---------------- |
+| 1  | `axis-count` | images/multiscales | The number of axes is within the closed range 2–5. | Between 2 and 5 axes, inclusive. | `multiscales[0].axes` |
+| 2  | `axis-type` | images/multiscales | At most one `time` axis and at most one `channel` axis. | ≤ 1 time axis and ≤ 1 channel axis. | `multiscales[0].axes` |
+| 3  | `axis-order` | images/multiscales | Axes ordered time → channel → space; at most 3 space axes; the space-axis names are the length-N suffix of `(z, y, x)`. | Axes ordered time, then channel, then space, with spatial names a suffix of `(z, y, x)`. | `multiscales[0].axes[1]` |
+| 4  | `scale-length-mismatch` | images/multiscales | Every `scale`/`translation` vector length equals the axis count, for both the global and per-dataset transforms. | Each scale/translation has exactly one entry per axis. | `multiscales[0].datasets[2].coordinateTransformations[0]` |
+| 5  | `global-coord-transform-after-per-level` | images/multiscales | Exactly one `scale` per dataset, and a `translation` must follow — not precede — its `scale`. | Each dataset defines exactly one scale; a translation follows its scale. | `multiscales[0].datasets[1].coordinateTransformations` |
+| 6  | `dataset-order-highest-to-lowest` | images/multiscales | Datasets ordered finest → coarsest; the spatial scale must not decrease as the level index rises. | Multiscale datasets ordered from highest to lowest resolution. | `multiscales[0].datasets[2]` |
+| 7  | `omero-channel-color-format` | OMERO | Each OMERO channel `color` is exactly six hexadecimal digits (RGB). | OMERO channel color is 6 hex digits. | `multiscales[0].omero.channels[0].color` |
+| 8  | `axis-orientation-consistent-type` | RFC 4 orientation | All spatial-axis anatomical orientations share one `type`. | RFC 4: all spatial-axis orientations share one type. | `multiscales[0].axes` |
+| 9  | `axis-orientation-completeness` | RFC 4 orientation | If any spatial axis declares an orientation, all spatial axes must. | RFC 4: orientation is all-or-none across spatial axes. | `multiscales[0].axes` |
+| 10 | `plate-row-index-consistency` | HCS plate | Each well's `path` is `<row>/<column>`, naming declared row/column entries, with `rowIndex`/`columnIndex` equal to those entries' positions. | Well `rowIndex`/`columnIndex` match the named row/column positions in `plate.rows`/`plate.columns`. | `plate.wells[3]` |
+| 11 | `well-acquisition-missing` | HCS well | When the plate declares more than one acquisition, every well image references one via `acquisition`. | With multiple acquisitions, each well image references an acquisition. | `well.images[0].acquisition` |
+
+## Evaluation order and orchestrators
+
+The rules are evaluated fail-fast: the first violation raises a
+`ValidationError` and later rules do not run. Three orchestrators dispatch the
+rules:
+
+- **`validate_structural` / `validateStructural`** evaluates rules **1–9** (the
+  image/multiscales rules, including the OMERO color check and the RFC 4
+  orientation checks). Rules 3 and 5 each have two internal enforcement points
+  that share a single identifier — axis class-ordering then spatial-name
+  ordering for `axis-order`; per-dataset scale-count then transform-ordering for
+  `global-coord-transform-after-per-level` — so the observed evaluation order
+  is a 10-step sequence over these nine identifiers.
+- **`validate_plate` / `validatePlate`** evaluates rule **10**
+  (`plate-row-index-consistency`).
+- **`validate_well` / `validateWell`** evaluates rule **11**
+  (`well-acquisition-missing`), in the context of its parent plate.
+
+The two HCS rules (10 and 11) are deliberately absent from the image
+orchestrator's order; they operate on separate metadata objects. The exact
+fail-fast sequence is locked by the parity tests described in [[parity]].
+
+## Rule categories at a glance
+
+- **Image / multiscales** — `axis-count`, `axis-type`, `axis-order`,
+  `scale-length-mismatch`, `global-coord-transform-after-per-level`,
+  `dataset-order-highest-to-lowest`.
+- **OMERO** — `omero-channel-color-format`.
+- **RFC 4 orientation** — `axis-orientation-consistent-type`,
+  `axis-orientation-completeness`.
+- **HCS plate / well** — `plate-row-index-consistency`,
+  `well-acquisition-missing`.

--- a/py/examples/validate_structural_demo.py
+++ b/py/examples/validate_structural_demo.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""End-to-end demo of OME-Zarr v0.4 structural validation.
+
+Proves :func:`ngff_zarr.structural_validation.validate_structural` works on
+hand-built :class:`~ngff_zarr.v04.zarr_metadata.Metadata` objects with no
+network access and no test fixtures.
+
+It first builds a fully valid ``[c, y, x]`` two-level multiscales metadata and
+confirms it passes. It then builds a deliberately broken copy for each
+image-metadata rule ``validate_structural`` enforces over plain multiscales
+metadata -- axis count, axis type, axis order, scale-vector length, per-level
+coordinate-transform ordering, dataset ordering, and OMERO channel color --
+each mutating a single field, and confirms ``validate_structural`` raises the
+expected :class:`~ngff_zarr.structural_validation.SpecRule`, printing the
+caught rule identifier, location, and message for each.
+
+Out of this demo's scope: the two RFC 4 anatomical-orientation rules (which
+additionally pull in the optional ``jsonschema`` dependency) and the two HCS
+plate/well rules (enforced through the separate ``validate_plate`` /
+``validate_well`` orchestrators).
+
+Run from the ``py/`` directory:
+
+    pixi run --as-is -e test python examples/validate_structural_demo.py
+
+The process exits non-zero if the valid metadata is rejected, if any broken
+copy fails to raise, or if a raised rule does not match the expected one, so
+the script doubles as a self-checking smoke test.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from ngff_zarr.structural_validation import (
+    SpecRule,
+    ValidationError,
+    validate_structural,
+)
+from ngff_zarr.v04.zarr_metadata import (
+    Axis,
+    Dataset,
+    Metadata,
+    Omero,
+    OmeroChannel,
+    OmeroWindow,
+    Scale,
+    Translation,
+)
+
+
+def build_valid_metadata() -> Metadata:
+    """Return a fully valid v0.4 ``[c, y, x]`` two-level multiscales metadata.
+
+    Three axes (one channel, two space); two datasets, each with a single
+    length-3 ``scale``; the second level is coarser (larger spatial scale) than
+    the first, as the spec requires.
+    """
+    return Metadata(
+        axes=[
+            Axis(name="c", type="channel"),
+            Axis(name="y", type="space"),
+            Axis(name="x", type="space"),
+        ],
+        datasets=[
+            Dataset(
+                path="0",
+                coordinateTransformations=[Scale([1.0, 1.0, 1.0])],
+            ),
+            Dataset(
+                path="1",
+                coordinateTransformations=[Scale([1.0, 2.0, 2.0])],
+            ),
+        ],
+        coordinateTransformations=None,
+    )
+
+
+def build_invalid_cases() -> list[tuple[str, SpecRule, Metadata]]:
+    """Build one broken copy for each image-metadata rule the demo covers.
+
+    Each case mutates exactly one field of the valid baseline so that the named
+    rule is the first (and only) one violated, given the orchestrator's
+    fail-fast spec-MUST ordering. The RFC 4 orientation rules and the HCS
+    plate/well rules are out of scope; see the module docstring.
+    """
+    cases: list[tuple[str, SpecRule, Metadata]] = []
+
+    # Six axes: the count is outside the permitted 2..=5 range.
+    metadata = build_valid_metadata()
+    metadata.axes = [
+        Axis(name="t", type="time"),
+        Axis(name="c", type="channel"),
+        Axis(name="z", type="space"),
+        Axis(name="y", type="space"),
+        Axis(name="x", type="space"),
+        Axis(name="x", type="space"),
+    ]
+    cases.append(("six axes (count out of 2..=5)", SpecRule.AXIS_COUNT, metadata))
+
+    # Two channel axes: at most one is permitted.
+    metadata = build_valid_metadata()
+    metadata.axes = [
+        Axis(name="c", type="channel"),
+        Axis(name="c", type="channel"),
+        Axis(name="y", type="space"),
+        Axis(name="x", type="space"),
+    ]
+    cases.append(("two channel axes", SpecRule.AXIS_TYPE, metadata))
+
+    # Spatial axes in (x, y) order: names must be a suffix of (z, y, x).
+    metadata = build_valid_metadata()
+    metadata.axes = [
+        Axis(name="c", type="channel"),
+        Axis(name="x", type="space"),
+        Axis(name="y", type="space"),
+    ]
+    cases.append(("spatial axes in x, y order", SpecRule.AXIS_ORDER, metadata))
+
+    # A dataset scale vector of length 2 against 3 axes.
+    metadata = build_valid_metadata()
+    metadata.datasets[0].coordinateTransformations = [Scale([1.0, 1.0])]
+    cases.append(("length-2 scale vector", SpecRule.SCALE_LENGTH_MISMATCH, metadata))
+
+    # A translation that precedes its scale within a dataset.
+    metadata = build_valid_metadata()
+    metadata.datasets[1].coordinateTransformations = [
+        Translation([0.0, 0.0, 0.0]),
+        Scale([1.0, 2.0, 2.0]),
+    ]
+    cases.append(
+        (
+            "translation before scale",
+            SpecRule.GLOBAL_COORD_TRANSFORM_AFTER_PER_LEVEL,
+            metadata,
+        )
+    )
+
+    # A coarser level whose spatial scale is finer than the level above it.
+    metadata = build_valid_metadata()
+    metadata.datasets[0].coordinateTransformations = [Scale([1.0, 2.0, 2.0])]
+    metadata.datasets[1].coordinateTransformations = [Scale([1.0, 1.0, 1.0])]
+    cases.append(
+        (
+            "coarser level with finer scale",
+            SpecRule.DATASET_ORDER_HIGHEST_TO_LOWEST,
+            metadata,
+        )
+    )
+
+    # An OMERO channel color that is not exactly six hex digits.
+    metadata = build_valid_metadata()
+    metadata.omero = Omero(
+        channels=[
+            OmeroChannel(
+                color="xyz",
+                window=OmeroWindow(min=0.0, max=255.0, start=0.0, end=255.0),
+            )
+        ]
+    )
+    cases.append(
+        ("omero channel color 'xyz'", SpecRule.OMERO_CHANNEL_COLOR_FORMAT, metadata)
+    )
+
+    return cases
+
+
+def main() -> int:
+    """Run the demo; return a process exit code (0 on full success)."""
+    print("OME-Zarr v0.4 structural validation demo")
+    print("=" * 64)
+
+    valid = build_valid_metadata()
+    try:
+        validate_structural(valid)
+    except ValidationError as exc:
+        print(f"UNEXPECTED: valid metadata was rejected: {exc}")
+        return 1
+    print("valid [c, y, x] two-level metadata: passed validate_structural")
+    print("-" * 64)
+
+    cases = build_invalid_cases()
+    caught = 0
+    for label, expected_rule, metadata in cases:
+        try:
+            validate_structural(metadata)
+        except ValidationError as exc:
+            if exc.rule != expected_rule:
+                print(
+                    f"UNEXPECTED rule for {label!r}: got [{exc.rule.value}], "
+                    f"expected [{expected_rule.value}]"
+                )
+                return 1
+            caught += 1
+            print(f"caught [{exc.rule.value}] at {exc.location}")
+            print(f"    {label}: {exc.message}")
+        else:
+            print(f"UNEXPECTED: {label!r} did not raise ValidationError")
+            return 1
+
+    print("-" * 64)
+    total = len(cases)
+    print(f"caught {caught}/{total} expected violations")
+    return 0 if caught == total else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/py/ngff_zarr/__init__.py
+++ b/py/ngff_zarr/__init__.py
@@ -57,6 +57,15 @@ from .rfc9_zip import (
     read_ozx_version,
     write_store_to_zip,
 )
+from .structural_validation import (
+    SpecRule,
+    ValidateOptions,
+    ValidationError,
+    ValidationLevel,
+    validate_plate,
+    validate_structural,
+    validate_well,
+)
 from .task_count import task_count
 from .tiff_to_ngff_image import (
     tiff_file_to_ngff_images,
@@ -121,6 +130,14 @@ __all__ = [
     "ConversionBackend",
     "cli_input_to_ngff_image",
     "validate",
+    # Structural validation (v0.4 spec MUSTs beyond JSON Schema)
+    "validate_structural",
+    "validate_plate",
+    "validate_well",
+    "SpecRule",
+    "ValidationLevel",
+    "ValidateOptions",
+    "ValidationError",
     # Codec utilities
     "codec_from_name",
     "get_available_codecs",

--- a/py/ngff_zarr/hcs.py
+++ b/py/ngff_zarr/hcs.py
@@ -103,10 +103,12 @@ class HCSPlate:
         plate_metadata: Plate,
         well_cache_size: int | None = None,
         image_cache_size: int | None = None,
+        validate: bool = False,
     ):
         self.store = store
         self.metadata = plate_metadata
         self.image_cache_size = image_cache_size
+        self._validate = validate
 
         # Use bounded cache for wells to prevent memory issues with large plates
         from .config import config
@@ -154,9 +156,26 @@ class HCSPlate:
 
         # Cache wells to avoid reloading - using bounded cache now
         if well_path not in self._wells:
-            self._wells[well_path] = HCSWell.from_store(
+            hcs_well = HCSWell.from_store(
                 self.store, well_path, well_meta, self.image_cache_size
             )
+            if self._validate:
+                # Strict structural validation of the well's own metadata, in
+                # the context of this plate, performed where each well is first
+                # loaded (mirrors the schema/structural split in from_hcs_zarr).
+                # Imported lazily so the default validate=False path is unchanged.
+                from .structural_validation import (
+                    ValidateOptions,
+                    ValidationLevel,
+                    validate_well,
+                )
+
+                validate_well(
+                    self.metadata,
+                    hcs_well.metadata,
+                    ValidateOptions(level=ValidationLevel.STRICT),
+                )
+            self._wells[well_path] = hcs_well
 
         return self._wells[well_path]
 
@@ -350,7 +369,10 @@ def from_hcs_zarr(
     store
         Store or path to directory in file system. Can be a .ozx file.
     validate : bool
-        If True, validate the NGFF metadata against the schema.
+        If True, validate the plate metadata against the schema and then run the
+        strict structural plate rules (raising ``ValidationError`` on failure).
+        Per-well structural rules run lazily as each well is loaded via
+        ``get_well``.
     well_cache_size : int, optional
         Maximum number of wells to cache. If None, uses config default.
     image_cache_size : int, optional
@@ -486,7 +508,26 @@ def from_hcs_zarr(
         name=name,
     )
 
-    return HCSPlate(store, plate_metadata, well_cache_size, image_cache_size)
+    if validate:
+        # Strict structural validation of the parsed plate, layered after the
+        # schema pass above (schema first, then structural). Per-well image
+        # rules run lazily in HCSPlate.get_well, where each well's own metadata
+        # is loaded. Imported lazily so the default validate=False path incurs
+        # no extra import cost. Unlike the image reader's structural pass, no
+        # >=0.4 version gate is needed here: these plate/well rules are
+        # version-agnostic and from_hcs_zarr only reads v0.4/v0.5 plates (there
+        # is no pre-0.4 plate layout to exempt).
+        from .structural_validation import (
+            ValidateOptions,
+            ValidationLevel,
+            validate_plate,
+        )
+
+        validate_plate(plate_metadata, ValidateOptions(level=ValidationLevel.STRICT))
+
+    return HCSPlate(
+        store, plate_metadata, well_cache_size, image_cache_size, validate=validate
+    )
 
 
 def to_hcs_zarr(plate: HCSPlate, store) -> None:

--- a/py/ngff_zarr/rfc4_validation.py
+++ b/py/ngff_zarr/rfc4_validation.py
@@ -39,7 +39,15 @@ def validate_rfc4_orientation(axes: list[dict[str, Any]]) -> None:
     jsonschema.ValidationError
         If the orientation metadata is invalid
     ValueError
-        If orientation is inconsistently defined across spatial axes
+        If orientation is inconsistently defined across spatial axes. The two
+        messages carry stable marker substrings -- ``"same type"`` for a
+        mixed-``type`` failure and ``"all spatial axes"`` for the all-or-none
+        completeness failure -- that
+        :func:`ngff_zarr.structural_validation.validate_axis_orientation` reads
+        to map each failure onto its :class:`SpecRule`. These markers are a
+        load-bearing contract pinned by a message-stability test
+        (``test_rfc4_orientation_messages_carry_mapping_markers``) so the
+        mapping cannot silently break if the wording is later edited.
     """
     try:
         from jsonschema import Draft202012Validator

--- a/py/ngff_zarr/structural_validation.py
+++ b/py/ngff_zarr/structural_validation.py
@@ -1,0 +1,819 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Structural validation for OME-Zarr v0.4 image/multiscales metadata.
+
+This module implements the OME-Zarr v0.4 specification MUSTs that a JSON
+Schema cannot express, layered conceptually on top of the schema validation
+performed by :mod:`ngff_zarr.validate` (which checks the raw attribute dict).
+Where schema validation answers "is this shaped like OME-Zarr?", the rules
+here answer "does this obey the spec's structural invariants?" -- e.g. axis
+counts, axis ordering, coordinate-transformation arity, finest-to-coarsest
+dataset ordering, and OMERO channel color format.
+
+The rules are pure Python (standard library only) and operate on the already
+parsed :class:`~ngff_zarr.v04.zarr_metadata.Metadata` dataclass, so they work
+even when the optional ``[validate]`` extra (``jsonschema``) is not installed.
+
+Each rule is identified by a stable, kebab-case :class:`SpecRule` value that
+is part of the observable surface (reused verbatim in logs, tests, and the
+TypeScript port). Rules fail fast: the orchestrator
+(:func:`validate_structural`) raises a :class:`ValidationError` on the first
+violation, in canonical spec-MUST order.
+"""
+
+# Canonical rule table (maintainers: keep in sync with SpecRule and the
+# orchestrator's call order). Location strings use dotted-segment,
+# JSON-Pointer-style intent, identifying the offending metadata node.
+#
+#   axis-count
+#       axis count within 2..=5
+#       e.g. multiscales[0].axes
+#   axis-type
+#       <=1 time axis and <=1 channel axis
+#       e.g. multiscales[0].axes
+#   axis-order
+#       time before channel before space; space names a suffix of (z, y, x)
+#       e.g. multiscales[0].axes[1]
+#   scale-length-mismatch
+#       every scale/translation length == axis count (global + per-dataset)
+#       e.g. multiscales[0].datasets[2].coordinateTransformations[0]
+#   global-coord-transform-after-per-level
+#       exactly one scale per dataset; a translation must follow its scale
+#       e.g. multiscales[0].datasets[1].coordinateTransformations
+#   dataset-order-highest-to-lowest
+#       datasets ordered finest->coarsest (spatial scale must not decrease)
+#       e.g. multiscales[0].datasets[2]
+#   omero-channel-color-format
+#       each OMERO channel color is exactly 6 hex digits
+#       e.g. multiscales[0].omero.channels[0].color
+#   axis-orientation-consistent-type
+#       all spatial-axis RFC 4 orientations share one type
+#       e.g. multiscales[0].axes
+#   axis-orientation-completeness
+#       if any spatial axis has orientation, all spatial axes do
+#       e.g. multiscales[0].axes
+#   plate-row-index-consistency
+#       each well's rowIndex/columnIndex matches the row/column named in its path
+#       e.g. plate.wells[3]
+#   well-acquisition-missing
+#       each well image references an acquisition when the plate declares many
+#       e.g. well.images[0].acquisition
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .v04.zarr_metadata import Axis, Dataset, Metadata, Plate, Transform, Well
+
+
+class SpecRule(str, Enum):
+    """Stable, kebab-case identifiers for the structural spec rules.
+
+    Inheriting from :class:`str` makes the kebab-case identifier the member's
+    value, so it can be compared and logged directly
+    (``SpecRule.AXIS_COUNT == "axis-count"``) for stable assertions. Members
+    are listed in canonical spec-MUST evaluation order.
+    """
+
+    AXIS_COUNT = "axis-count"
+    AXIS_TYPE = "axis-type"
+    AXIS_ORDER = "axis-order"
+    SCALE_LENGTH_MISMATCH = "scale-length-mismatch"
+    GLOBAL_COORD_TRANSFORM_AFTER_PER_LEVEL = "global-coord-transform-after-per-level"
+    DATASET_ORDER_HIGHEST_TO_LOWEST = "dataset-order-highest-to-lowest"
+    OMERO_CHANNEL_COLOR_FORMAT = "omero-channel-color-format"
+    AXIS_ORIENTATION_CONSISTENT_TYPE = "axis-orientation-consistent-type"
+    AXIS_ORIENTATION_COMPLETENESS = "axis-orientation-completeness"
+    PLATE_ROW_INDEX_CONSISTENCY = "plate-row-index-consistency"
+    WELL_ACQUISITION_MISSING = "well-acquisition-missing"
+
+
+class ValidationLevel(str, Enum):
+    """How much validation :func:`validate_structural` performs.
+
+    ``STRICT`` is the default and runs every structural image/multiscales rule
+    in this module. ``SCHEMA_ONLY`` skips them (schema validation is handled
+    separately by :mod:`ngff_zarr.validate` on the raw attribute dict). Deep,
+    store-reading checks (e.g. confirming each dataset array exists with the
+    expected shape) are intentionally out of scope for both levels.
+    """
+
+    SCHEMA_ONLY = "schema_only"
+    STRICT = "strict"
+
+
+@dataclass
+class ValidateOptions:
+    """Options controlling structural validation.
+
+    Attributes
+    ----------
+    level:
+        Validation level to run. Defaults to :attr:`ValidationLevel.STRICT`.
+    allow_unknown_fields:
+        Whether unknown metadata fields are tolerated. Defaults to ``True`` to
+        mirror the parser, which warns on (rather than rejects) unknown fields.
+    """
+
+    level: ValidationLevel = ValidationLevel.STRICT
+    allow_unknown_fields: bool = True
+
+
+class ValidationError(Exception):
+    """Raised when a structural spec rule is violated.
+
+    Carries the offending :class:`SpecRule`, a human-readable ``message``, and
+    an optional ``location`` identifying the offending metadata node in
+    dotted-segment (JSON-Pointer-style) form, e.g.
+    ``multiscales[0].datasets[2].coordinateTransformations[0]``.
+    """
+
+    def __init__(
+        self, rule: SpecRule, message: str, location: str | None = None
+    ) -> None:
+        self.rule = rule
+        self.message = message
+        self.location = location
+        super().__init__(message)
+
+    def __str__(self) -> str:
+        return f"Spec rule [{self.rule.value}] violated: {self.message}"
+
+
+def _transform_len_mismatch(
+    transform: Transform, axes_len: int
+) -> tuple[str, int] | None:
+    """Check one coordinate transform's vector length against the axis count.
+
+    Centralizes the length invariant shared by the global and per-dataset
+    coordinate-transformation checks (see
+    :attr:`SpecRule.SCALE_LENGTH_MISMATCH`), so the rule lives in one place.
+
+    Returns ``("scale", actual_len)`` or ``("translation", actual_len)`` when
+    the transform's vector length disagrees with ``axes_len``; otherwise
+    returns ``None``. Transforms that carry no length-bearing vector (e.g.
+    ``identity``) are ignored and return ``None``.
+    """
+    if transform.type == "scale":
+        actual_len = len(transform.scale)
+        if actual_len != axes_len:
+            return ("scale", actual_len)
+    elif transform.type == "translation":
+        actual_len = len(transform.translation)
+        if actual_len != axes_len:
+            return ("translation", actual_len)
+    return None
+
+
+def _first_scale_vector(dataset: Dataset) -> list[float] | None:
+    """Return the first ``scale`` vector in a dataset, or ``None`` if absent.
+
+    Used by :func:`validate_dataset_order` to compare adjacent multiscale
+    levels without re-deriving the per-dataset ``scale`` lookup.
+    """
+    for transform in dataset.coordinateTransformations:
+        if transform.type == "scale":
+            return transform.scale
+    return None
+
+
+# Class-ordering rank for axis types: a ``time`` axis must precede a
+# ``channel`` axis, which must precede any ``space`` axis. Lower rank must
+# never follow higher rank (see ``validate_axis_order``).
+_AXIS_TYPE_RANK = {"time": 0, "channel": 1, "space": 2}
+
+# Spatial axis names in canonical order. A valid set of ``space`` axis names
+# is the matching-length suffix of this tuple: 1 -> ("x",), 2 -> ("y", "x"),
+# 3 -> ("z", "y", "x") (see ``validate_spatial_axis_order``).
+_SPATIAL_AXIS_NAMES = ("z", "y", "x")
+
+
+def validate_axis_count(metadata: Metadata) -> None:
+    """Validate that the axis count is within the v0.4-permitted range.
+
+    OME-Zarr v0.4 requires between 2 and 5 axes, inclusive.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.AXIS_COUNT` when ``len(metadata.axes)`` lies
+        outside ``2..=5``; location ``multiscales[0].axes``.
+    """
+    count = len(metadata.axes)
+    if not (2 <= count <= 5):
+        raise ValidationError(
+            SpecRule.AXIS_COUNT,
+            f"OME-Zarr v0.4 requires between 2 and 5 axes, inclusive; found {count}.",
+            "multiscales[0].axes",
+        )
+
+
+def validate_axis_type(metadata: Metadata) -> None:
+    """Validate axis-type multiplicity.
+
+    At most one ``time`` axis and at most one ``channel`` axis may be present.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.AXIS_TYPE` when more than one ``time`` axis or
+        more than one ``channel`` axis is present; location
+        ``multiscales[0].axes``.
+    """
+    time_count = sum(1 for ax in metadata.axes if ax.type == "time")
+    if time_count > 1:
+        raise ValidationError(
+            SpecRule.AXIS_TYPE,
+            f"At most one 'time' axis is permitted; found {time_count}.",
+            "multiscales[0].axes",
+        )
+    channel_count = sum(1 for ax in metadata.axes if ax.type == "channel")
+    if channel_count > 1:
+        raise ValidationError(
+            SpecRule.AXIS_TYPE,
+            f"At most one 'channel' axis is permitted; found {channel_count}.",
+            "multiscales[0].axes",
+        )
+
+
+def validate_axis_order(metadata: Metadata) -> None:
+    """Validate the class ordering of axes.
+
+    Axes are ranked by type (``time`` < ``channel`` < ``space``) and must be
+    listed in non-decreasing rank order: every ``time`` axis precedes every
+    ``channel`` axis, which precedes every ``space`` axis. The first adjacent
+    pair that inverts this ranking is reported.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.AXIS_ORDER` for the first adjacent pair where a
+        lower-ranked axis type follows a higher-ranked one; location
+        ``multiscales[0].axes[i+1]``.
+    """
+    axes = metadata.axes
+    for i in range(len(axes) - 1):
+        current = axes[i]
+        following = axes[i + 1]
+        current_rank = _AXIS_TYPE_RANK.get(current.type)
+        following_rank = _AXIS_TYPE_RANK.get(following.type)
+        if current_rank is None or following_rank is None:
+            continue
+        if following_rank < current_rank:
+            raise ValidationError(
+                SpecRule.AXIS_ORDER,
+                f"Axis '{following.name}' of type '{following.type}' must not "
+                f"follow axis '{current.name}' of type '{current.type}'; axes "
+                f"must be ordered time, then channel, then space.",
+                f"multiscales[0].axes[{i + 1}]",
+            )
+
+
+def validate_spatial_axis_order(metadata: Metadata) -> None:
+    """Validate the count and names of spatial axes.
+
+    The ``space`` axes, taken in order, must be the matching-length suffix of
+    ``(z, y, x)``: one spatial axis must be ``(x,)``, two must be
+    ``(y, x)``, and three must be ``(z, y, x)``. At most three ``space`` axes
+    are permitted.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.AXIS_ORDER` when there are more than three
+        ``space`` axes, or when their names are not the expected suffix of
+        ``(z, y, x)``.
+    """
+    space_indices = [i for i, ax in enumerate(metadata.axes) if ax.type == "space"]
+    count = len(space_indices)
+    if count > 3:
+        raise ValidationError(
+            SpecRule.AXIS_ORDER,
+            f"OME-Zarr v0.4 permits at most 3 'space' axes; found {count}.",
+            "multiscales[0].axes",
+        )
+    expected = _SPATIAL_AXIS_NAMES[len(_SPATIAL_AXIS_NAMES) - count :]
+    actual = tuple(metadata.axes[i].name for i in space_indices)
+    if actual != expected:
+        mismatch = next((j for j in range(count) if actual[j] != expected[j]), 0)
+        raise ValidationError(
+            SpecRule.AXIS_ORDER,
+            f"Spatial axis names {list(actual)} must be the length-{count} "
+            f"suffix of (z, y, x): {list(expected)}.",
+            f"multiscales[0].axes[{space_indices[mismatch]}]",
+        )
+
+
+def validate_per_dataset_scale_count(metadata: Metadata) -> None:
+    """Validate that each dataset defines exactly one ``scale`` transform.
+
+    Every dataset's ``coordinateTransformations`` must contain exactly one
+    ``scale`` (the per-level voxel size). This shares the per-dataset
+    coordinate-transform-shape rule identifier
+    (:attr:`SpecRule.GLOBAL_COORD_TRANSFORM_AFTER_PER_LEVEL`); there is no
+    dedicated identifier for the scale count.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.GLOBAL_COORD_TRANSFORM_AFTER_PER_LEVEL` when a
+        dataset has zero or more than one ``scale`` transform; location
+        ``multiscales[0].datasets[i].coordinateTransformations``.
+    """
+    for i, dataset in enumerate(metadata.datasets):
+        scale_count = sum(
+            1 for t in dataset.coordinateTransformations if t.type == "scale"
+        )
+        if scale_count != 1:
+            raise ValidationError(
+                SpecRule.GLOBAL_COORD_TRANSFORM_AFTER_PER_LEVEL,
+                f"Each dataset must define exactly one 'scale' coordinate "
+                f"transformation; dataset {i} has {scale_count}.",
+                f"multiscales[0].datasets[{i}].coordinateTransformations",
+            )
+
+
+def validate_scale_length(metadata: Metadata) -> None:
+    """Validate coordinate-transform vector lengths against the axis count.
+
+    Every ``scale`` and ``translation`` vector -- in the global
+    ``coordinateTransformations`` (if present) and in each dataset -- must have
+    exactly one entry per axis. The first mismatch, scanned global-then-
+    per-dataset, is reported. The length invariant itself lives in
+    :func:`_transform_len_mismatch`.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.SCALE_LENGTH_MISMATCH` for the first transform
+        whose vector length disagrees with ``len(metadata.axes)``; location
+        identifies the offending transform.
+    """
+    axes_len = len(metadata.axes)
+    if metadata.coordinateTransformations:
+        for j, transform in enumerate(metadata.coordinateTransformations):
+            mismatch = _transform_len_mismatch(transform, axes_len)
+            if mismatch is not None:
+                kind, actual_len = mismatch
+                raise ValidationError(
+                    SpecRule.SCALE_LENGTH_MISMATCH,
+                    f"Global '{kind}' transform has length {actual_len}, but "
+                    f"there are {axes_len} axes; lengths must match.",
+                    f"multiscales[0].coordinateTransformations[{j}]",
+                )
+    for i, dataset in enumerate(metadata.datasets):
+        for j, transform in enumerate(dataset.coordinateTransformations):
+            mismatch = _transform_len_mismatch(transform, axes_len)
+            if mismatch is not None:
+                kind, actual_len = mismatch
+                raise ValidationError(
+                    SpecRule.SCALE_LENGTH_MISMATCH,
+                    f"Dataset {i} '{kind}' transform has length {actual_len}, "
+                    f"but there are {axes_len} axes; lengths must match.",
+                    f"multiscales[0].datasets[{i}].coordinateTransformations[{j}]",
+                )
+
+
+def validate_transform_order(metadata: Metadata) -> None:
+    """Validate coordinate-transform ordering within each dataset.
+
+    Within a dataset's ``coordinateTransformations``, a ``translation`` (if
+    present) must follow its ``scale`` -- a ``scale`` must never appear after a
+    ``translation``.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.GLOBAL_COORD_TRANSFORM_AFTER_PER_LEVEL` for the
+        first dataset where a ``scale`` follows a ``translation``; location
+        identifies the offending ``scale``.
+    """
+    for i, dataset in enumerate(metadata.datasets):
+        seen_translation = False
+        for j, transform in enumerate(dataset.coordinateTransformations):
+            if transform.type == "translation":
+                seen_translation = True
+            elif transform.type == "scale" and seen_translation:
+                raise ValidationError(
+                    SpecRule.GLOBAL_COORD_TRANSFORM_AFTER_PER_LEVEL,
+                    f"In dataset {i}, a 'scale' transform must not follow a "
+                    f"'translation'; a translation must follow its scale.",
+                    f"multiscales[0].datasets[{i}].coordinateTransformations[{j}]",
+                )
+
+
+def validate_dataset_order(metadata: Metadata) -> None:
+    """Validate that datasets are ordered finest to coarsest.
+
+    Multiscale datasets must be listed from highest resolution (finest, i.e.
+    smallest spatial ``scale``) to lowest (coarsest). For each adjacent pair,
+    the later level's ``scale`` must not be smaller than the earlier level's on
+    any ``space`` axis. Pairs whose ``scale`` vectors are missing or too short
+    to index a spatial axis are skipped -- those shapes are the concern of
+    :func:`validate_per_dataset_scale_count` and :func:`validate_scale_length`
+    -- so this rule never raises ``IndexError``.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.DATASET_ORDER_HIGHEST_TO_LOWEST` for the first
+        adjacent pair whose later (coarser) level has a smaller spatial scale;
+        location ``multiscales[0].datasets[i+1]``.
+    """
+    space_indices = [i for i, ax in enumerate(metadata.axes) if ax.type == "space"]
+    datasets = metadata.datasets
+    for i in range(len(datasets) - 1):
+        finer = _first_scale_vector(datasets[i])
+        coarser = _first_scale_vector(datasets[i + 1])
+        if finer is None or coarser is None:
+            continue
+        for axis_index in space_indices:
+            if axis_index >= len(finer) or axis_index >= len(coarser):
+                # Scale too short to compare this axis: another rule's
+                # concern. Skip so we never raise IndexError here.
+                continue
+            if coarser[axis_index] < finer[axis_index]:
+                axis_name = metadata.axes[axis_index].name
+                raise ValidationError(
+                    SpecRule.DATASET_ORDER_HIGHEST_TO_LOWEST,
+                    f"Datasets must be ordered finest to coarsest; dataset "
+                    f"{i + 1} has spatial scale {coarser[axis_index]} on axis "
+                    f"'{axis_name}', smaller than dataset {i}'s "
+                    f"{finer[axis_index]}.",
+                    f"multiscales[0].datasets[{i + 1}]",
+                )
+
+
+def validate_omero_color_hex(metadata: Metadata) -> None:
+    """Validate the color format of each OMERO channel.
+
+    When OMERO rendering metadata is present, every channel ``color`` must be
+    exactly six hexadecimal digits (RGB). This reuses the existing
+    :meth:`~ngff_zarr.v04.zarr_metadata.OmeroChannel.validate_color` predicate
+    rather than re-implementing the format check.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.OMERO_CHANNEL_COLOR_FORMAT` for the first channel
+        whose ``color`` is not six hex digits; location
+        ``multiscales[0].omero.channels[i].color``.
+    """
+    if metadata.omero is None:
+        return
+    for i, channel in enumerate(metadata.omero.channels):
+        try:
+            channel.validate_color()
+        except ValueError as exc:
+            raise ValidationError(
+                SpecRule.OMERO_CHANNEL_COLOR_FORMAT,
+                str(exc),
+                f"multiscales[0].omero.channels[{i}].color",
+            ) from exc
+
+
+def _axis_to_validation_dict(axis: Axis) -> dict[str, Any]:
+    """Render a parsed :class:`Axis` back to the dict form RFC 4 consumes.
+
+    Emits only the fields the RFC 4 helpers inspect -- ``name``, ``type``, and
+    (for a spatial axis that declares it) ``orientation`` as a
+    ``{"type", "value"}`` dict. A stored ``orientation`` may be a raw dict (the
+    image read path builds axes via ``Axis(**axis_dict)``, so no coercion
+    happens) or an :class:`~ngff_zarr.rfc4.AnatomicalOrientation` dataclass; an
+    enum ``value`` is reduced to its string, mirroring the package's
+    ``hasattr(..., "value")`` convention.
+    """
+    axis_dict: dict[str, Any] = {"name": axis.name, "type": axis.type}
+    orientation = axis.orientation
+    if orientation is not None:
+        if isinstance(orientation, dict):
+            orientation_type = orientation.get("type")
+            orientation_value = orientation.get("value")
+        else:
+            orientation_type = getattr(orientation, "type", None)
+            orientation_value = getattr(orientation, "value", None)
+        if hasattr(orientation_value, "value"):
+            orientation_value = orientation_value.value
+        axis_dict["orientation"] = {
+            "type": orientation_type,
+            "value": orientation_value,
+        }
+    return axis_dict
+
+
+def validate_axis_orientation(metadata: Metadata) -> None:
+    """Validate RFC 4 anatomical-orientation metadata on the spatial axes.
+
+    This rule does not reimplement RFC 4; it wraps the package's existing logic
+    -- :func:`~ngff_zarr.rfc4_validation.has_rfc4_orientation_metadata` and
+    :func:`~ngff_zarr.rfc4_validation.validate_rfc4_orientation` -- and surfaces
+    its failures through the unified :class:`ValidationError` channel. The parsed
+    :class:`~ngff_zarr.v04.zarr_metadata.Axis` objects are first rendered back to
+    the axis-dict form those helpers expect (see :func:`_axis_to_validation_dict`).
+
+    Orientation is optional in RFC 4, so when no spatial axis carries it the rule
+    is a no-op and the comparatively heavy ``jsonschema`` import inside
+    :func:`validate_rfc4_orientation` is never triggered.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.AXIS_ORIENTATION_CONSISTENT_TYPE` when the spatial
+        axes' orientations do not all share one ``type``, or
+        :attr:`SpecRule.AXIS_ORIENTATION_COMPLETENESS` when orientation is defined
+        for some but not all spatial axes; location ``multiscales[0].axes``. The
+        original RFC 4 message text is preserved.
+    jsonschema.exceptions.ValidationError
+        Propagated unchanged when an orientation value is outside the RFC 4
+        vocabulary -- a schema-level concern with no dedicated structural rule.
+    """
+    from .rfc4_validation import (
+        has_rfc4_orientation_metadata,
+        validate_rfc4_orientation,
+    )
+
+    axes_dicts = [_axis_to_validation_dict(axis) for axis in metadata.axes]
+    if not has_rfc4_orientation_metadata(axes_dicts):
+        return
+    try:
+        validate_rfc4_orientation(axes_dicts)
+    except ValueError as exc:
+        # validate_rfc4_orientation raises exactly two ValueErrors: a spatial
+        # orientation "same type" mismatch and the all-or-none completeness
+        # failure. jsonschema's ValidationError (raised for an out-of-vocabulary
+        # orientation value) is not a ValueError, so it -- like ImportError when
+        # jsonschema is absent -- propagates untouched; no structural rule covers
+        # those schema-level concerns.
+        #
+        # The "same type" / "all spatial axes" substrings below are a
+        # load-bearing contract with validate_rfc4_orientation's message text:
+        # an unrecognized ValueError falls through to the bare ``raise`` and is
+        # surfaced as a plain ValueError rather than a ValidationError. The
+        # message-stability test test_rfc4_orientation_messages_carry_mapping_markers
+        # pins both markers so editing that wording fails CI loudly instead of
+        # silently breaking this mapping.
+        message = str(exc)
+        if "same type" in message:
+            raise ValidationError(
+                SpecRule.AXIS_ORIENTATION_CONSISTENT_TYPE,
+                message,
+                "multiscales[0].axes",
+            ) from exc
+        if "all spatial axes" in message:
+            raise ValidationError(
+                SpecRule.AXIS_ORIENTATION_COMPLETENESS,
+                message,
+                "multiscales[0].axes",
+            ) from exc
+        raise
+
+
+def validate_plate_well_index_consistency(plate: Plate) -> None:
+    """Validate each plate well's recorded indices against its ``path``.
+
+    Every :class:`~ngff_zarr.v04.zarr_metadata.PlateWell` records a ``path`` of
+    the form ``"<row>/<column>"`` (e.g. ``"B/03"``) alongside numeric
+    ``rowIndex`` and ``columnIndex`` fields. OME-Zarr v0.4 requires these to
+    agree: the row segment must name an entry in ``plate.rows`` whose position
+    equals ``rowIndex``, and the column segment must name an entry in
+    ``plate.columns`` whose position equals ``columnIndex``. The first
+    offending well, scanned in order, is reported.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.PLATE_ROW_INDEX_CONSISTENCY` for the first well
+        whose ``path`` is not ``"<row>/<column>"``, whose row/column segment is
+        absent from ``plate.rows``/``plate.columns``, or whose recorded
+        ``rowIndex``/``columnIndex`` disagrees with that segment's position;
+        location ``plate.wells[i]``.
+    """
+    row_index_by_name = {row.name: i for i, row in enumerate(plate.rows)}
+    column_index_by_name = {col.name: i for i, col in enumerate(plate.columns)}
+    for i, well in enumerate(plate.wells):
+        location = f"plate.wells[{i}]"
+        parts = well.path.split("/")
+        if len(parts) != 2:
+            raise ValidationError(
+                SpecRule.PLATE_ROW_INDEX_CONSISTENCY,
+                f"Well path {well.path!r} must have the form '<row>/<column>'.",
+                location,
+            )
+        row_name, column_name = parts
+        if row_name not in row_index_by_name:
+            raise ValidationError(
+                SpecRule.PLATE_ROW_INDEX_CONSISTENCY,
+                f"Well path {well.path!r} names row {row_name!r}, which is not "
+                f"declared in plate.rows.",
+                location,
+            )
+        if column_name not in column_index_by_name:
+            raise ValidationError(
+                SpecRule.PLATE_ROW_INDEX_CONSISTENCY,
+                f"Well path {well.path!r} names column {column_name!r}, which is "
+                f"not declared in plate.columns.",
+                location,
+            )
+        expected_row = row_index_by_name[row_name]
+        if well.rowIndex != expected_row:
+            raise ValidationError(
+                SpecRule.PLATE_ROW_INDEX_CONSISTENCY,
+                f"Well {well.path!r} has rowIndex {well.rowIndex}, but row "
+                f"{row_name!r} is at index {expected_row} in plate.rows.",
+                location,
+            )
+        expected_column = column_index_by_name[column_name]
+        if well.columnIndex != expected_column:
+            raise ValidationError(
+                SpecRule.PLATE_ROW_INDEX_CONSISTENCY,
+                f"Well {well.path!r} has columnIndex {well.columnIndex}, but "
+                f"column {column_name!r} is at index {expected_column} in "
+                f"plate.columns.",
+                location,
+            )
+
+
+def validate_well_acquisition(plate: Plate, well: Well) -> None:
+    """Validate that well images reference an acquisition when required.
+
+    When a plate declares more than one acquisition, every image in each of its
+    wells must carry an ``acquisition`` reference so the field can be attributed
+    to a specific acquisition. Plates with zero or one acquisition impose no
+    such requirement, so this rule is a no-op for them. The first image missing
+    its reference, scanned in order, is reported.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.WELL_ACQUISITION_MISSING` for the first
+        :class:`~ngff_zarr.v04.zarr_metadata.WellImage` whose ``acquisition`` is
+        ``None`` while the plate declares multiple acquisitions; location
+        ``well.images[i].acquisition``.
+    """
+    acquisitions = plate.acquisitions
+    if acquisitions is None or len(acquisitions) <= 1:
+        return
+    for i, image in enumerate(well.images):
+        if image.acquisition is None:
+            raise ValidationError(
+                SpecRule.WELL_ACQUISITION_MISSING,
+                f"Plate declares {len(acquisitions)} acquisitions, so well "
+                f"image {i} must reference one via 'acquisition'.",
+                f"well.images[{i}].acquisition",
+            )
+
+
+def validate_structural(
+    metadata: Metadata, options: ValidateOptions | None = None
+) -> None:
+    """Run the structural image/multiscales rules in canonical spec order.
+
+    Orchestrates the per-rule ``validate_*`` functions in this module. It is
+    fail-fast: the rules run in canonical spec-MUST order and the first
+    :class:`ValidationError` raised propagates to the caller -- later rules do
+    not run.
+
+    The rules run in this order:
+
+    1. :func:`validate_axis_count`
+    2. :func:`validate_axis_type`
+    3. :func:`validate_axis_order`
+    4. :func:`validate_spatial_axis_order`
+    5. :func:`validate_per_dataset_scale_count`
+    6. :func:`validate_scale_length`
+    7. :func:`validate_transform_order`
+    8. :func:`validate_dataset_order`
+    9. :func:`validate_omero_color_hex`
+    10. :func:`validate_axis_orientation`
+
+    Parameters
+    ----------
+    metadata:
+        The parsed OME-Zarr v0.4 multiscales metadata to validate.
+    options:
+        Validation options. Defaults to :class:`ValidateOptions`, i.e.
+        :attr:`ValidationLevel.STRICT`. Under
+        :attr:`ValidationLevel.SCHEMA_ONLY` this function returns immediately
+        without running any structural rule -- shape/schema validation is the
+        separate concern of :mod:`ngff_zarr.validate`, which checks the raw
+        attribute dict.
+
+    Raises
+    ------
+    ValidationError
+        For the first structural rule violated, carrying the offending
+        :class:`SpecRule` and ``location``. Never raised under
+        :attr:`ValidationLevel.SCHEMA_ONLY`, which runs no structural rule.
+
+    Notes
+    -----
+    This orchestrator covers the image/multiscales rules, including the RFC 4
+    anatomical-orientation checks (:func:`validate_axis_orientation`, a no-op
+    when no axis declares orientation). The HCS plate/well structural rules
+    operate on separate metadata objects and are dispatched by the companion
+    :func:`validate_plate` and :func:`validate_well` entry points.
+    """
+    if options is None:
+        options = ValidateOptions()
+    if options.level == ValidationLevel.SCHEMA_ONLY:
+        return
+    validate_axis_count(metadata)
+    validate_axis_type(metadata)
+    validate_axis_order(metadata)
+    validate_spatial_axis_order(metadata)
+    validate_per_dataset_scale_count(metadata)
+    validate_scale_length(metadata)
+    validate_transform_order(metadata)
+    validate_dataset_order(metadata)
+    validate_omero_color_hex(metadata)
+    validate_axis_orientation(metadata)
+
+
+def validate_plate(plate: Plate, options: ValidateOptions | None = None) -> None:
+    """Run the structural HCS plate rules in canonical spec order.
+
+    The plate-level counterpart to :func:`validate_structural`: it orchestrates
+    the structural rules that operate on a parsed
+    :class:`~ngff_zarr.v04.zarr_metadata.Plate`. Like its image/multiscales
+    sibling it is fail-fast -- the first :class:`ValidationError` propagates to
+    the caller and later rules do not run.
+
+    The rules run in this order:
+
+    1. :func:`validate_plate_well_index_consistency`
+
+    Per-well image rules (e.g. acquisition references) are the separate concern
+    of :func:`validate_well`, which is called where each well's own metadata is
+    loaded.
+
+    Parameters
+    ----------
+    plate:
+        The parsed OME-Zarr v0.4 plate metadata to validate.
+    options:
+        Validation options. Defaults to :class:`ValidateOptions`, i.e.
+        :attr:`ValidationLevel.STRICT`. Under
+        :attr:`ValidationLevel.SCHEMA_ONLY` this function returns immediately
+        without running any structural rule -- shape/schema validation is the
+        separate concern of :mod:`ngff_zarr.validate`, which checks the raw
+        attribute dict.
+
+    Raises
+    ------
+    ValidationError
+        For the first structural plate rule violated, carrying the offending
+        :class:`SpecRule` and ``location``. Never raised under
+        :attr:`ValidationLevel.SCHEMA_ONLY`, which runs no structural rule.
+    """
+    if options is None:
+        options = ValidateOptions()
+    if options.level == ValidationLevel.SCHEMA_ONLY:
+        return
+    validate_plate_well_index_consistency(plate)
+
+
+def validate_well(
+    plate: Plate, well: Well, options: ValidateOptions | None = None
+) -> None:
+    """Run the structural HCS well rules in canonical spec order.
+
+    Validates a single :class:`~ngff_zarr.v04.zarr_metadata.Well` in the context
+    of its parent :class:`~ngff_zarr.v04.zarr_metadata.Plate` -- the plate's
+    acquisition declarations govern whether each well image must reference an
+    acquisition. Fail-fast, like :func:`validate_structural` and
+    :func:`validate_plate`.
+
+    The rules run in this order:
+
+    1. :func:`validate_well_acquisition`
+
+    Parameters
+    ----------
+    plate:
+        The parsed plate metadata that owns ``well``; supplies the acquisition
+        context the well rules consult.
+    well:
+        The parsed well metadata to validate.
+    options:
+        Validation options. Defaults to :class:`ValidateOptions`, i.e.
+        :attr:`ValidationLevel.STRICT`. Under
+        :attr:`ValidationLevel.SCHEMA_ONLY` this function returns immediately
+        without running any structural rule -- shape/schema validation is the
+        separate concern of :mod:`ngff_zarr.validate`, which checks the raw
+        attribute dict.
+
+    Raises
+    ------
+    ValidationError
+        For the first structural well rule violated, carrying the offending
+        :class:`SpecRule` and ``location``. Never raised under
+        :attr:`ValidationLevel.SCHEMA_ONLY`, which runs no structural rule.
+    """
+    if options is None:
+        options = ValidateOptions()
+    if options.level == ValidationLevel.SCHEMA_ONLY:
+        return
+    validate_well_acquisition(plate, well)

--- a/py/ngff_zarr/v04/zarr_metadata.py
+++ b/py/ngff_zarr/v04/zarr_metadata.py
@@ -524,6 +524,27 @@ class Metadata:
             coordinateTransformations=root_attrs.get("coordinateTransformations", None),
         )
 
+        if validate:
+            # Strict structural validation of the parsed Metadata, layered after
+            # the schema pass and RFC 4 dict check above. The structural rules
+            # encode the v0.4+ metadata model (typed axes and per-dataset
+            # coordinate transformations); the legacy v0.1-0.3 layouts predate
+            # it, so the rules are scoped to v0.4 and newer. Imported lazily so
+            # the default validate=False read path incurs no extra import cost.
+            import packaging.version
+
+            from ..structural_validation import (
+                ValidateOptions,
+                ValidationLevel,
+                validate_structural,
+            )
+
+            spec_version = packaging.version.parse(str(metadata.version))
+            if spec_version >= packaging.version.parse("0.4"):
+                validate_structural(
+                    metadata, ValidateOptions(level=ValidationLevel.STRICT)
+                )
+
         return metadata, images
 
     @property

--- a/py/test/test_rfc4_validation.py
+++ b/py/test/test_rfc4_validation.py
@@ -209,16 +209,18 @@ def test_from_ngff_zarr_with_rfc4_validation():
     else:
         root.create_dataset("0", shape=(10, 10, 10), dtype="uint8")
 
-    # Add OME-NGFF metadata with RFC 4 orientation
+    # Add OME-NGFF metadata with RFC 4 orientation. Spatial axes are ordered
+    # (z, y, x) -- the suffix of (z, y, x) required by the v0.4 axis-order MUST
+    # now enforced on read -- with each orientation kept on its named axis.
     multiscales_metadata = {
         "version": "0.4",
         "name": "test",
         "axes": [
             {
-                "name": "x",
+                "name": "z",
                 "type": "space",
                 "unit": "micrometer",
-                "orientation": {"type": "anatomical", "value": "right-to-left"},
+                "orientation": {"type": "anatomical", "value": "inferior-to-superior"},
             },
             {
                 "name": "y",
@@ -227,10 +229,10 @@ def test_from_ngff_zarr_with_rfc4_validation():
                 "orientation": {"type": "anatomical", "value": "anterior-to-posterior"},
             },
             {
-                "name": "z",
+                "name": "x",
                 "type": "space",
                 "unit": "micrometer",
-                "orientation": {"type": "anatomical", "value": "inferior-to-superior"},
+                "orientation": {"type": "anatomical", "value": "right-to-left"},
             },
         ],
         "datasets": [

--- a/py/test/test_structural_validation.py
+++ b/py/test/test_structural_validation.py
@@ -1,0 +1,364 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Unit tests for :mod:`ngff_zarr.structural_validation`.
+
+One paired pass/fail test per structural rule: a shared, fully valid
+``[c, y, x]`` two-level baseline (:func:`build_valid_metadata`) is mutated in
+exactly one field to trip exactly one rule, asserting the raised
+:class:`~ngff_zarr.structural_validation.ValidationError` carries the expected
+:class:`~ngff_zarr.structural_validation.SpecRule` and a populated ``location``.
+Each rule function is exercised directly so the violation is isolated to that
+rule. Additional tests cover the public surface (enum values, option defaults,
+error formatting) and the orchestrator's fail-fast ordering and the
+``SCHEMA_ONLY`` short-circuit.
+"""
+
+import pytest
+from ngff_zarr.structural_validation import (
+    SpecRule,
+    ValidateOptions,
+    ValidationError,
+    ValidationLevel,
+    validate_axis_count,
+    validate_axis_order,
+    validate_axis_type,
+    validate_dataset_order,
+    validate_omero_color_hex,
+    validate_per_dataset_scale_count,
+    validate_scale_length,
+    validate_spatial_axis_order,
+    validate_structural,
+    validate_transform_order,
+)
+from ngff_zarr.v04.zarr_metadata import (
+    Axis,
+    Dataset,
+    Metadata,
+    Omero,
+    OmeroChannel,
+    OmeroWindow,
+    Scale,
+    Translation,
+)
+
+
+def build_valid_metadata() -> Metadata:
+    """Return a fully valid v0.4 ``[c, y, x]`` two-level multiscales metadata.
+
+    Three axes (one channel, two space); two datasets, each with a single
+    length-3 ``scale``; the second level is coarser than the first. This
+    baseline passes every structural rule, so each test mutates exactly one
+    field of a fresh copy to trip exactly one rule.
+    """
+    return Metadata(
+        axes=[
+            Axis(name="c", type="channel"),
+            Axis(name="y", type="space"),
+            Axis(name="x", type="space"),
+        ],
+        datasets=[
+            Dataset(
+                path="0",
+                coordinateTransformations=[Scale([1.0, 1.0, 1.0])],
+            ),
+            Dataset(
+                path="1",
+                coordinateTransformations=[Scale([1.0, 2.0, 2.0])],
+            ),
+        ],
+        coordinateTransformations=None,
+    )
+
+
+@pytest.fixture
+def valid_metadata() -> Metadata:
+    """A fresh, fully valid baseline metadata for each test."""
+    return build_valid_metadata()
+
+
+def _omero(color: str) -> Omero:
+    """Build a single-channel OMERO block with the given channel ``color``."""
+    return Omero(
+        channels=[
+            OmeroChannel(
+                color=color,
+                window=OmeroWindow(min=0.0, max=255.0, start=0.0, end=255.0),
+            )
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-rule paired pass/fail tests
+# ---------------------------------------------------------------------------
+
+
+def test_axis_count_valid(valid_metadata):
+    validate_axis_count(valid_metadata)
+
+
+@pytest.mark.parametrize("count", [1, 6])
+def test_axis_count_invalid(valid_metadata, count):
+    valid_metadata.axes = [Axis(name="x", type="space") for _ in range(count)]
+    with pytest.raises(ValidationError) as exc_info:
+        validate_axis_count(valid_metadata)
+    assert exc_info.value.rule == SpecRule.AXIS_COUNT
+    assert exc_info.value.location == "multiscales[0].axes"
+
+
+def test_axis_type_valid(valid_metadata):
+    validate_axis_type(valid_metadata)
+
+
+@pytest.mark.parametrize("axis_type", ["time", "channel"])
+def test_axis_type_invalid(valid_metadata, axis_type):
+    # Two axes of the same singleton type (time or channel) is not allowed.
+    name = "t" if axis_type == "time" else "c"
+    valid_metadata.axes = [
+        Axis(name=name, type=axis_type),
+        Axis(name=name, type=axis_type),
+        Axis(name="y", type="space"),
+        Axis(name="x", type="space"),
+    ]
+    with pytest.raises(ValidationError) as exc_info:
+        validate_axis_type(valid_metadata)
+    assert exc_info.value.rule == SpecRule.AXIS_TYPE
+    assert exc_info.value.location == "multiscales[0].axes"
+
+
+def test_axis_order_class_valid(valid_metadata):
+    validate_axis_order(valid_metadata)
+
+
+def test_axis_order_class_invalid(valid_metadata):
+    # A 'time' axis after a 'channel' axis inverts the time < channel ranking.
+    valid_metadata.axes = [
+        Axis(name="c", type="channel"),
+        Axis(name="t", type="time"),
+        Axis(name="y", type="space"),
+        Axis(name="x", type="space"),
+    ]
+    with pytest.raises(ValidationError) as exc_info:
+        validate_axis_order(valid_metadata)
+    assert exc_info.value.rule == SpecRule.AXIS_ORDER
+    assert exc_info.value.location == "multiscales[0].axes[1]"
+
+
+def test_spatial_axis_order_valid(valid_metadata):
+    validate_spatial_axis_order(valid_metadata)
+
+
+@pytest.mark.parametrize(
+    "case, location",
+    [
+        ("suffix-mismatch", "multiscales[0].axes[1]"),
+        ("too-many-spatial", "multiscales[0].axes"),
+    ],
+)
+def test_spatial_axis_order_invalid(valid_metadata, case, location):
+    if case == "suffix-mismatch":
+        # (x, y) is not the (y, x) suffix of (z, y, x).
+        valid_metadata.axes = [
+            Axis(name="c", type="channel"),
+            Axis(name="x", type="space"),
+            Axis(name="y", type="space"),
+        ]
+    else:
+        # Four space axes exceed the v0.4 maximum of three.
+        valid_metadata.axes = [
+            Axis(name="z", type="space"),
+            Axis(name="z", type="space"),
+            Axis(name="y", type="space"),
+            Axis(name="x", type="space"),
+        ]
+    with pytest.raises(ValidationError) as exc_info:
+        validate_spatial_axis_order(valid_metadata)
+    assert exc_info.value.rule == SpecRule.AXIS_ORDER
+    assert exc_info.value.location == location
+
+
+def test_per_dataset_scale_count_valid(valid_metadata):
+    validate_per_dataset_scale_count(valid_metadata)
+
+
+@pytest.mark.parametrize("case", ["zero-scales", "two-scales"])
+def test_per_dataset_scale_count_invalid(valid_metadata, case):
+    if case == "zero-scales":
+        valid_metadata.datasets[0].coordinateTransformations = [
+            Translation([0.0, 0.0, 0.0]),
+        ]
+    else:
+        valid_metadata.datasets[0].coordinateTransformations = [
+            Scale([1.0, 1.0, 1.0]),
+            Scale([1.0, 1.0, 1.0]),
+        ]
+    with pytest.raises(ValidationError) as exc_info:
+        validate_per_dataset_scale_count(valid_metadata)
+    assert exc_info.value.rule == SpecRule.GLOBAL_COORD_TRANSFORM_AFTER_PER_LEVEL
+    assert (
+        exc_info.value.location
+        == "multiscales[0].datasets[0].coordinateTransformations"
+    )
+
+
+def test_scale_length_valid(valid_metadata):
+    validate_scale_length(valid_metadata)
+    # A correctly sized global scale (length == axis count) is also accepted.
+    valid_metadata.coordinateTransformations = [Scale([1.0, 1.0, 1.0])]
+    validate_scale_length(valid_metadata)
+
+
+def test_scale_length_invalid_per_dataset(valid_metadata):
+    # A length-2 dataset scale against 3 axes.
+    valid_metadata.datasets[0].coordinateTransformations = [Scale([1.0, 1.0])]
+    with pytest.raises(ValidationError) as exc_info:
+        validate_scale_length(valid_metadata)
+    assert exc_info.value.rule == SpecRule.SCALE_LENGTH_MISMATCH
+    assert (
+        exc_info.value.location
+        == "multiscales[0].datasets[0].coordinateTransformations[0]"
+    )
+
+
+def test_scale_length_invalid_global(valid_metadata):
+    # A length-2 global scale against 3 axes.
+    valid_metadata.coordinateTransformations = [Scale([1.0, 1.0])]
+    with pytest.raises(ValidationError) as exc_info:
+        validate_scale_length(valid_metadata)
+    assert exc_info.value.rule == SpecRule.SCALE_LENGTH_MISMATCH
+    assert exc_info.value.location == "multiscales[0].coordinateTransformations[0]"
+
+
+def test_transform_order_valid(valid_metadata):
+    validate_transform_order(valid_metadata)
+    # A translation following its scale is valid.
+    valid_metadata.datasets[0].coordinateTransformations = [
+        Scale([1.0, 1.0, 1.0]),
+        Translation([0.0, 0.0, 0.0]),
+    ]
+    validate_transform_order(valid_metadata)
+
+
+def test_transform_order_invalid(valid_metadata):
+    # A scale after a translation: a translation must follow its scale.
+    valid_metadata.datasets[0].coordinateTransformations = [
+        Translation([0.0, 0.0, 0.0]),
+        Scale([1.0, 1.0, 1.0]),
+    ]
+    with pytest.raises(ValidationError) as exc_info:
+        validate_transform_order(valid_metadata)
+    assert exc_info.value.rule == SpecRule.GLOBAL_COORD_TRANSFORM_AFTER_PER_LEVEL
+    assert (
+        exc_info.value.location
+        == "multiscales[0].datasets[0].coordinateTransformations[1]"
+    )
+
+
+def test_dataset_order_valid(valid_metadata):
+    validate_dataset_order(valid_metadata)
+
+
+def test_dataset_order_invalid(valid_metadata):
+    # The second (coarser) level has a finer spatial scale than the first.
+    valid_metadata.datasets[0].coordinateTransformations = [Scale([1.0, 2.0, 2.0])]
+    valid_metadata.datasets[1].coordinateTransformations = [Scale([1.0, 1.0, 1.0])]
+    with pytest.raises(ValidationError) as exc_info:
+        validate_dataset_order(valid_metadata)
+    assert exc_info.value.rule == SpecRule.DATASET_ORDER_HIGHEST_TO_LOWEST
+    assert exc_info.value.location == "multiscales[0].datasets[1]"
+    # Float scales render as `1.0`/`2.0` (not `1`/`2`); the TypeScript port
+    # matches this byte-for-byte via its pyFloat() helper (locks parity).
+    assert exc_info.value.message == (
+        "Datasets must be ordered finest to coarsest; dataset 1 has spatial "
+        "scale 1.0 on axis 'y', smaller than dataset 0's 2.0."
+    )
+
+
+def test_omero_color_valid(valid_metadata):
+    validate_omero_color_hex(valid_metadata)  # omero is None
+    valid_metadata.omero = _omero("00FF88")
+    validate_omero_color_hex(valid_metadata)
+
+
+def test_omero_color_invalid(valid_metadata):
+    valid_metadata.omero = _omero("xyz")
+    with pytest.raises(ValidationError) as exc_info:
+        validate_omero_color_hex(valid_metadata)
+    assert exc_info.value.rule == SpecRule.OMERO_CHANNEL_COLOR_FORMAT
+    assert exc_info.value.location == "multiscales[0].omero.channels[0].color"
+
+
+# ---------------------------------------------------------------------------
+# Public-surface tests
+# ---------------------------------------------------------------------------
+
+
+def test_spec_rule_values():
+    assert SpecRule.AXIS_COUNT.value == "axis-count"
+    assert SpecRule.AXIS_TYPE.value == "axis-type"
+    assert SpecRule.AXIS_ORDER.value == "axis-order"
+    assert SpecRule.SCALE_LENGTH_MISMATCH.value == "scale-length-mismatch"
+    assert (
+        SpecRule.GLOBAL_COORD_TRANSFORM_AFTER_PER_LEVEL.value
+        == "global-coord-transform-after-per-level"
+    )
+    assert (
+        SpecRule.DATASET_ORDER_HIGHEST_TO_LOWEST.value
+        == "dataset-order-highest-to-lowest"
+    )
+    assert SpecRule.OMERO_CHANNEL_COLOR_FORMAT.value == "omero-channel-color-format"
+    # Inheriting from str makes the kebab identifier the value for comparison.
+    assert SpecRule.AXIS_COUNT == "axis-count"
+
+
+def test_validation_level_default_is_strict():
+    assert ValidateOptions().level == ValidationLevel.STRICT
+    assert ValidationLevel.STRICT.value == "strict"
+    assert ValidationLevel.SCHEMA_ONLY.value == "schema_only"
+
+
+def test_validate_options_defaults():
+    options = ValidateOptions()
+    assert options.level == ValidationLevel.STRICT
+    assert options.allow_unknown_fields is True
+
+
+def test_validation_error_str():
+    err = ValidationError(SpecRule.AXIS_COUNT, "found 6 axes", "multiscales[0].axes")
+    assert str(err) == "Spec rule [axis-count] violated: found 6 axes"
+    assert err.rule == SpecRule.AXIS_COUNT
+    assert err.message == "found 6 axes"
+    assert err.location == "multiscales[0].axes"
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator tests
+# ---------------------------------------------------------------------------
+
+
+def test_validate_structural_accepts_valid(valid_metadata):
+    # Default options (STRICT) and an explicit STRICT both accept the baseline.
+    validate_structural(valid_metadata)
+    validate_structural(valid_metadata, ValidateOptions(level=ValidationLevel.STRICT))
+
+
+def test_validate_structural_fail_fast_order(valid_metadata):
+    # Two independent violations: dataset-order (rule 8) and omero-color (9).
+    valid_metadata.datasets[0].coordinateTransformations = [Scale([1.0, 2.0, 2.0])]
+    valid_metadata.datasets[1].coordinateTransformations = [Scale([1.0, 1.0, 1.0])]
+    valid_metadata.omero = _omero("xyz")
+    with pytest.raises(ValidationError) as exc_info:
+        validate_structural(valid_metadata)
+    # Fail-fast reports the earlier-ordered rule, not the OMERO color.
+    assert exc_info.value.rule == SpecRule.DATASET_ORDER_HIGHEST_TO_LOWEST
+
+
+def test_validate_structural_schema_only_skips(valid_metadata):
+    # A single axis is a clear axis-count violation under STRICT...
+    valid_metadata.axes = [Axis(name="x", type="space")]
+    with pytest.raises(ValidationError):
+        validate_structural(valid_metadata)
+    # ...but SCHEMA_ONLY runs no structural rule, so the same metadata passes.
+    validate_structural(
+        valid_metadata, ValidateOptions(level=ValidationLevel.SCHEMA_ONLY)
+    )

--- a/py/test/test_structural_validation_hcs.py
+++ b/py/test/test_structural_validation_hcs.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Unit tests for the HCS structural rules in :mod:`ngff_zarr.structural_validation`.
+
+Paired pass/fail tests for the two plate/well structural rules added this phase:
+
+* :func:`~ngff_zarr.structural_validation.validate_plate_well_index_consistency`
+  -- a small 2x2 plate (:func:`build_valid_plate`) is mutated in exactly one
+  field so a well's recorded ``rowIndex``/``columnIndex`` (or its ``path``)
+  disagrees with the row/column named in its ``path``.
+* :func:`~ngff_zarr.structural_validation.validate_well_acquisition` -- a
+  multi-acquisition plate whose well image omits its ``acquisition`` reference.
+
+Each rule function is exercised directly so the violation is isolated to that
+rule, asserting the raised :class:`~ngff_zarr.structural_validation.ValidationError`
+carries the expected :class:`~ngff_zarr.structural_validation.SpecRule` and a
+populated ``location``. The companion :func:`validate_plate`/:func:`validate_well`
+orchestrators are also checked for their ``STRICT``/``SCHEMA_ONLY`` behavior.
+"""
+
+import pytest
+from ngff_zarr.structural_validation import (
+    SpecRule,
+    ValidateOptions,
+    ValidationError,
+    ValidationLevel,
+    validate_plate,
+    validate_plate_well_index_consistency,
+    validate_well,
+    validate_well_acquisition,
+)
+from ngff_zarr.v04.zarr_metadata import (
+    Plate,
+    PlateAcquisition,
+    PlateColumn,
+    PlateRow,
+    PlateWell,
+    Well,
+    WellImage,
+)
+
+
+def build_valid_plate() -> Plate:
+    """Return a small, fully consistent 2x2 plate.
+
+    Rows ``A`` (index 0) and ``B`` (index 1); columns ``1`` (index 0) and ``2``
+    (index 1); two wells whose ``path`` and recorded indices agree. This baseline
+    passes the index-consistency rule, so each test mutates exactly one field of a
+    fresh copy to trip it.
+    """
+    return Plate(
+        columns=[PlateColumn(name="1"), PlateColumn(name="2")],
+        rows=[PlateRow(name="A"), PlateRow(name="B")],
+        wells=[
+            PlateWell(path="A/1", rowIndex=0, columnIndex=0),
+            PlateWell(path="B/2", rowIndex=1, columnIndex=1),
+        ],
+    )
+
+
+def build_multi_acquisition_plate() -> Plate:
+    """Return :func:`build_valid_plate` extended with two acquisitions.
+
+    With more than one acquisition declared, every well image must reference one.
+    """
+    plate = build_valid_plate()
+    plate.acquisitions = [PlateAcquisition(id=0), PlateAcquisition(id=1)]
+    return plate
+
+
+# ---------------------------------------------------------------------------
+# plate-row-index-consistency
+# ---------------------------------------------------------------------------
+
+
+def test_plate_well_index_consistency_valid():
+    validate_plate_well_index_consistency(build_valid_plate())
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "row-index-mismatch",
+        "column-index-mismatch",
+        "unknown-row",
+        "unknown-column",
+        "malformed-path",
+    ],
+)
+def test_plate_well_index_consistency_invalid(case):
+    plate = build_valid_plate()
+    if case == "row-index-mismatch":
+        # path "A/1" => row "A" is index 0, but rowIndex claims 1.
+        plate.wells[0].rowIndex = 1
+    elif case == "column-index-mismatch":
+        # path "A/1" => column "1" is index 0, but columnIndex claims 1.
+        plate.wells[0].columnIndex = 1
+    elif case == "unknown-row":
+        # Row "Z" is not declared in plate.rows.
+        plate.wells[0] = PlateWell(path="Z/1", rowIndex=0, columnIndex=0)
+    elif case == "unknown-column":
+        # Column "9" is not declared in plate.columns.
+        plate.wells[0] = PlateWell(path="A/9", rowIndex=0, columnIndex=0)
+    else:  # malformed-path
+        # A path that is not "<row>/<column>".
+        plate.wells[0] = PlateWell(path="A-1", rowIndex=0, columnIndex=0)
+    with pytest.raises(ValidationError) as exc_info:
+        validate_plate_well_index_consistency(plate)
+    assert exc_info.value.rule == SpecRule.PLATE_ROW_INDEX_CONSISTENCY
+    assert exc_info.value.location == "plate.wells[0]"
+
+
+# ---------------------------------------------------------------------------
+# well-acquisition-missing
+# ---------------------------------------------------------------------------
+
+
+def test_well_acquisition_valid_no_or_single_acquisition():
+    # Zero or one acquisition imposes no requirement, so a missing reference is OK.
+    well = Well(images=[WellImage(path="0")])
+    validate_well_acquisition(build_valid_plate(), well)  # acquisitions is None
+    single = build_valid_plate()
+    single.acquisitions = [PlateAcquisition(id=0)]
+    validate_well_acquisition(single, well)
+
+
+def test_well_acquisition_valid_multi_with_references():
+    plate = build_multi_acquisition_plate()
+    well = Well(
+        images=[
+            WellImage(path="0", acquisition=0),
+            WellImage(path="1", acquisition=1),
+        ]
+    )
+    validate_well_acquisition(plate, well)
+
+
+def test_well_acquisition_invalid_missing_reference():
+    plate = build_multi_acquisition_plate()
+    # The second image omits its acquisition reference; the first is fine.
+    well = Well(
+        images=[
+            WellImage(path="0", acquisition=0),
+            WellImage(path="1"),
+        ]
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        validate_well_acquisition(plate, well)
+    assert exc_info.value.rule == SpecRule.WELL_ACQUISITION_MISSING
+    assert exc_info.value.location == "well.images[1].acquisition"
+
+
+# ---------------------------------------------------------------------------
+# Orchestrators: validate_plate / validate_well
+# ---------------------------------------------------------------------------
+
+
+def test_validate_plate_strict_and_schema_only():
+    plate = build_valid_plate()
+    plate.wells[0].rowIndex = 1  # trip plate-row-index-consistency
+    with pytest.raises(ValidationError) as exc_info:
+        validate_plate(plate)  # STRICT by default
+    assert exc_info.value.rule == SpecRule.PLATE_ROW_INDEX_CONSISTENCY
+    # SCHEMA_ONLY runs no structural rule, so the same plate passes.
+    validate_plate(plate, ValidateOptions(level=ValidationLevel.SCHEMA_ONLY))
+
+
+def test_validate_well_strict_and_schema_only():
+    plate = build_multi_acquisition_plate()
+    well = Well(images=[WellImage(path="0")])  # missing acquisition reference
+    with pytest.raises(ValidationError) as exc_info:
+        validate_well(plate, well)  # STRICT by default
+    assert exc_info.value.rule == SpecRule.WELL_ACQUISITION_MISSING
+    # SCHEMA_ONLY runs no structural rule, so the same well passes.
+    validate_well(plate, well, ValidateOptions(level=ValidationLevel.SCHEMA_ONLY))

--- a/py/test/test_structural_validation_orientation.py
+++ b/py/test/test_structural_validation_orientation.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Unit tests for the RFC 4 orientation rule in :mod:`ngff_zarr.structural_validation`.
+
+Pass/fail tests for
+:func:`~ngff_zarr.structural_validation.validate_axis_orientation`, the wrapper
+that surfaces the package's RFC 4 anatomical-orientation checks through the
+unified :class:`~ngff_zarr.structural_validation.ValidationError` channel.
+
+Coverage:
+
+* no spatial axis carries orientation -> no-op (the heavy ``jsonschema`` import is
+  never triggered);
+* a fully specified, consistent orientation passes for *both* stored shapes -- a
+  raw ``dict`` (image read path) and an
+  :class:`~ngff_zarr.rfc4.AnatomicalOrientation` dataclass (write path);
+* mixed orientation ``type`` -> :attr:`SpecRule.AXIS_ORIENTATION_CONSISTENT_TYPE`;
+* orientation on some but not all spatial axes ->
+  :attr:`SpecRule.AXIS_ORIENTATION_COMPLETENESS`.
+
+Each failing case asserts the expected :class:`SpecRule` and the
+``multiscales[0].axes`` location.
+"""
+
+import pytest
+from ngff_zarr.rfc4 import AnatomicalOrientation, AnatomicalOrientationValues
+from ngff_zarr.structural_validation import (
+    SpecRule,
+    ValidationError,
+    validate_axis_orientation,
+)
+from ngff_zarr.v04.zarr_metadata import Axis, Dataset, Metadata, Scale
+
+
+def _metadata_with_axes(axes: list[Axis]) -> Metadata:
+    """Wrap the given axes in an otherwise-valid single-level metadata.
+
+    :func:`validate_axis_orientation` inspects only the axes, so the dataset's
+    ``scale`` is a placeholder sized to the axis count.
+    """
+    return Metadata(
+        axes=axes,
+        datasets=[
+            Dataset(
+                path="0",
+                coordinateTransformations=[Scale([1.0] * len(axes))],
+            )
+        ],
+        coordinateTransformations=None,
+    )
+
+
+def _orientation_dict(value: str) -> dict:
+    """Render an anatomical orientation as the raw dict an image read produces."""
+    return {"type": "anatomical", "value": value}
+
+
+# Canonical (z, y, x) LPS orientation values, in axis order.
+_LPS_VALUES = ("inferior-to-superior", "anterior-to-posterior", "right-to-left")
+_LPS_ENUM = (
+    AnatomicalOrientationValues.inferior_to_superior,
+    AnatomicalOrientationValues.anterior_to_posterior,
+    AnatomicalOrientationValues.right_to_left,
+)
+
+
+def test_axis_orientation_no_orientation_is_noop():
+    # No spatial axis declares orientation: the rule is a no-op (no raise).
+    metadata = _metadata_with_axes(
+        [
+            Axis(name="z", type="space"),
+            Axis(name="y", type="space"),
+            Axis(name="x", type="space"),
+        ]
+    )
+    validate_axis_orientation(metadata)
+
+
+@pytest.mark.parametrize("shape", ["dict", "dataclass"])
+def test_axis_orientation_valid_consistent(shape):
+    if shape == "dict":
+        orientations = [_orientation_dict(v) for v in _LPS_VALUES]
+    else:
+        orientations = [AnatomicalOrientation(value=v) for v in _LPS_ENUM]
+    metadata = _metadata_with_axes(
+        [
+            Axis(name="z", type="space", orientation=orientations[0]),
+            Axis(name="y", type="space", orientation=orientations[1]),
+            Axis(name="x", type="space", orientation=orientations[2]),
+        ]
+    )
+    validate_axis_orientation(metadata)
+
+
+def test_axis_orientation_inconsistent_type():
+    # The "y" axis declares a different orientation type than its siblings.
+    metadata = _metadata_with_axes(
+        [
+            Axis(name="z", type="space", orientation=_orientation_dict(_LPS_VALUES[0])),
+            Axis(
+                name="y",
+                type="space",
+                orientation={"type": "other", "value": _LPS_VALUES[1]},
+            ),
+            Axis(name="x", type="space", orientation=_orientation_dict(_LPS_VALUES[2])),
+        ]
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        validate_axis_orientation(metadata)
+    assert exc_info.value.rule == SpecRule.AXIS_ORIENTATION_CONSISTENT_TYPE
+    assert exc_info.value.location == "multiscales[0].axes"
+
+
+def test_axis_orientation_incomplete():
+    # Orientation is defined for "z" and "y" but missing on "x".
+    metadata = _metadata_with_axes(
+        [
+            Axis(name="z", type="space", orientation=_orientation_dict(_LPS_VALUES[0])),
+            Axis(name="y", type="space", orientation=_orientation_dict(_LPS_VALUES[1])),
+            Axis(name="x", type="space"),
+        ]
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        validate_axis_orientation(metadata)
+    assert exc_info.value.rule == SpecRule.AXIS_ORIENTATION_COMPLETENESS
+    assert exc_info.value.location == "multiscales[0].axes"
+    # Axis-name lists render Python-style (`['z', 'y']`); the TypeScript port
+    # matches this byte-for-byte via its formatNameList() helper (locks parity).
+    assert exc_info.value.message == (
+        "RFC 4 requires that if orientation is defined for one spatial axis, "
+        "it must be defined for all spatial axes. "
+        "Axes with orientation: ['z', 'y'], axes without orientation: ['x']"
+    )
+
+
+def test_rfc4_orientation_messages_carry_mapping_markers():
+    """Pin the substrings :func:`validate_axis_orientation` maps onto rules.
+
+    The wrapper distinguishes the two RFC 4 orientation failures by searching
+    :func:`~ngff_zarr.rfc4_validation.validate_rfc4_orientation`'s message text
+    for ``"same type"`` and ``"all spatial axes"``. Those markers are a
+    load-bearing contract: if the wording is edited away, the wrapper silently
+    falls through to a bare ``ValueError`` instead of raising the mapped
+    :class:`ValidationError`. Asserting the markers here makes such an edit fail
+    CI loudly at the source rather than silently break the mapping.
+    """
+    from ngff_zarr.rfc4_validation import validate_rfc4_orientation
+
+    # Mixed orientation type -> the marker the consistent-type rule maps.
+    with pytest.raises(ValueError, match="same type"):
+        validate_rfc4_orientation(
+            [
+                {
+                    "name": "y",
+                    "type": "space",
+                    "orientation": {
+                        "type": "anatomical",
+                        "value": "anterior-to-posterior",
+                    },
+                },
+                {
+                    "name": "x",
+                    "type": "space",
+                    "orientation": {"type": "other", "value": "right-to-left"},
+                },
+            ]
+        )
+
+    # Orientation on some but not all spatial axes -> the completeness marker.
+    with pytest.raises(ValueError, match="all spatial axes"):
+        validate_rfc4_orientation(
+            [
+                {
+                    "name": "y",
+                    "type": "space",
+                    "orientation": {
+                        "type": "anatomical",
+                        "value": "anterior-to-posterior",
+                    },
+                },
+                {"name": "x", "type": "space"},
+            ]
+        )

--- a/py/test/test_structural_validation_parity.py
+++ b/py/test/test_structural_validation_parity.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Parity/manifest test locking the observable structural-validation surface.
+
+This test pins the *cross-language contract* shared by the Python and
+TypeScript ports: the exact set and ordering of :class:`SpecRule` identifiers,
+their lower-kebab-case format, the fail-fast evaluation order of the
+image/multiscales orchestrator (:func:`validate_structural`), and the
+:class:`ValidationLevel` values and default. The mirror Deno test asserts the
+same facts against the identical literal identifier list, so the two suites are
+line-for-line comparable and any future drift between the ports fails CI.
+
+Adding, removing, renaming, or reordering a rule -- in either language -- must
+therefore be a deliberate edit to :data:`CANONICAL_SPEC_RULE_IDS` (and its
+TypeScript twin), not an accident.
+"""
+
+import re
+
+import pytest
+from ngff_zarr import (
+    SpecRule,
+    ValidateOptions,
+    ValidationError,
+    ValidationLevel,
+    validate_structural,
+)
+from ngff_zarr.v04.zarr_metadata import (
+    Axis,
+    Dataset,
+    Metadata,
+    Omero,
+    OmeroChannel,
+    OmeroWindow,
+    Scale,
+    Translation,
+)
+
+# The locked rule manifest: every active OME-Zarr v0.4 structural rule, in
+# canonical declaration order. This identical literal list appears in the Deno
+# mirror test so the two are directly comparable. The first nine entries are
+# the image/multiscales rules dispatched by validate_structural; the final two
+# are the HCS plate/well rules dispatched by validate_plate / validate_well.
+CANONICAL_SPEC_RULE_IDS = [
+    "axis-count",
+    "axis-type",
+    "axis-order",
+    "scale-length-mismatch",
+    "global-coord-transform-after-per-level",
+    "dataset-order-highest-to-lowest",
+    "omero-channel-color-format",
+    "axis-orientation-consistent-type",
+    "axis-orientation-completeness",
+    "plate-row-index-consistency",
+    "well-acquisition-missing",
+]
+
+# The canonical fail-fast evaluation order of the image/multiscales
+# orchestrator (validate_structural). Each entry is the SpecRule the
+# orchestrator must raise when that rule -- and every rule after it -- is
+# violated at once. Two SpecRule values appear twice because two rule functions
+# share each: validate_axis_order and validate_spatial_axis_order both surface
+# AXIS_ORDER (positions 3-4), and validate_per_dataset_scale_count and
+# validate_transform_order both surface GLOBAL_COORD_TRANSFORM_AFTER_PER_LEVEL
+# (positions 5 and 7). The two HCS rules are absent: they are not part of the
+# image/multiscales orchestrator.
+EXPECTED_EVALUATION_ORDER = [
+    SpecRule.AXIS_COUNT,
+    SpecRule.AXIS_TYPE,
+    SpecRule.AXIS_ORDER,  # validate_axis_order (class ordering)
+    SpecRule.AXIS_ORDER,  # validate_spatial_axis_order (spatial suffix)
+    SpecRule.GLOBAL_COORD_TRANSFORM_AFTER_PER_LEVEL,  # per-dataset scale count
+    SpecRule.SCALE_LENGTH_MISMATCH,
+    SpecRule.GLOBAL_COORD_TRANSFORM_AFTER_PER_LEVEL,  # transform order
+    SpecRule.DATASET_ORDER_HIGHEST_TO_LOWEST,
+    SpecRule.OMERO_CHANNEL_COLOR_FORMAT,
+    SpecRule.AXIS_ORIENTATION_CONSISTENT_TYPE,
+]
+
+
+def _omero(color: str) -> Omero:
+    """Build a single-channel OMERO block with the given channel ``color``."""
+    return Omero(
+        channels=[
+            OmeroChannel(
+                color=color,
+                window=OmeroWindow(min=0.0, max=255.0, start=0.0, end=255.0),
+            )
+        ]
+    )
+
+
+def _orientation(orientation_type: str, value: str) -> dict:
+    """Render an anatomical orientation as the raw dict an image read produces."""
+    return {"type": orientation_type, "value": value}
+
+
+def _valid_axes_with_inconsistent_orientation() -> list[Axis]:
+    """Return valid ``[c, z, y, x]`` axes whose orientations mix RFC 4 types.
+
+    Every axis rule passes (channel-then-space class order, ``(z, y, x)``
+    spatial suffix, count 4), but the ``y`` axis declares orientation type
+    ``"other"`` while ``z`` and ``x`` declare ``"anatomical"`` -- tripping
+    :attr:`SpecRule.AXIS_ORIENTATION_CONSISTENT_TYPE`, the last orchestrator
+    rule, when every earlier rule is satisfied.
+    """
+    return [
+        Axis(name="c", type="channel"),
+        Axis(
+            name="z",
+            type="space",
+            orientation=_orientation("anatomical", "inferior-to-superior"),
+        ),
+        Axis(
+            name="y",
+            type="space",
+            orientation=_orientation("other", "anterior-to-posterior"),
+        ),
+        Axis(
+            name="x",
+            type="space",
+            orientation=_orientation("anatomical", "right-to-left"),
+        ),
+    ]
+
+
+def _first_violated_rule(metadata: Metadata) -> SpecRule:
+    """Run the orchestrator and return the single :class:`SpecRule` it raises."""
+    with pytest.raises(ValidationError) as exc_info:
+        validate_structural(metadata)
+    return exc_info.value.rule
+
+
+# ---------------------------------------------------------------------------
+# Manifest: the locked SpecRule set, ordering, and format
+# ---------------------------------------------------------------------------
+
+
+def test_spec_rule_manifest_is_locked():
+    # The exact set must equal the canonical manifest: adding, removing, or
+    # renaming a rule must be a deliberate edit to CANONICAL_SPEC_RULE_IDS.
+    assert {rule.value for rule in SpecRule} == set(CANONICAL_SPEC_RULE_IDS)
+    # Declaration order is part of the cross-language contract, so lock it too;
+    # this is the order the Deno SpecRule object must also declare.
+    assert [rule.value for rule in SpecRule] == CANONICAL_SPEC_RULE_IDS
+    # No two members may share a value (which would create a silent alias).
+    assert len({rule.value for rule in SpecRule}) == len(CANONICAL_SPEC_RULE_IDS)
+
+
+def test_spec_rule_ids_are_lower_kebab_case():
+    # Each identifier is one or more lowercase ASCII words joined by hyphens.
+    for rule in SpecRule:
+        assert re.fullmatch(r"[a-z]+(-[a-z]+)*", rule.value), rule.value
+
+
+def test_validation_level_manifest_and_default():
+    # Exactly two levels, with the documented string values...
+    assert {level.value for level in ValidationLevel} == {"schema_only", "strict"}
+    assert ValidationLevel.SCHEMA_ONLY.value == "schema_only"
+    assert ValidationLevel.STRICT.value == "strict"
+    # ...and STRICT is the default applied when no options are passed.
+    assert ValidateOptions().level == ValidationLevel.STRICT
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator evaluation order (fail-fast, canonical spec-MUST order)
+# ---------------------------------------------------------------------------
+
+
+def test_orchestrator_evaluation_order():
+    """Lock the fail-fast evaluation order of ``validate_structural``.
+
+    Starts from metadata that violates the earliest rule *and* every later
+    rule, then repairs exactly one rule at a time. Because each repair leaves
+    all later violations intact, the rule raised at each step proves that rule
+    is evaluated strictly before every rule after it. The observed sequence
+    must equal :data:`EXPECTED_EVALUATION_ORDER`.
+    """
+    observed: list[SpecRule] = []
+    bad_omero = _omero("xyz")  # OMERO violation (rule 9), present until repaired
+
+    # Stage 1 -> AXIS_COUNT. Six axes simultaneously trip axis-type (two
+    # channels), axis-order (a space precedes a channel), and spatial-order
+    # (names are not the (z, y, x) suffix); axis-count is evaluated first.
+    metadata = Metadata(
+        axes=[
+            Axis(name="x", type="space"),
+            Axis(name="c", type="channel"),
+            Axis(name="c2", type="channel"),
+            Axis(name="t", type="time"),
+            Axis(name="z", type="space"),
+            Axis(name="w", type="space"),
+        ],
+        datasets=[
+            Dataset(
+                path="0",
+                coordinateTransformations=[
+                    Scale([1.0, 1.0, 1.0]),
+                    Scale([1.0, 1.0, 1.0]),
+                ],
+            ),
+            Dataset(
+                path="1",
+                coordinateTransformations=[Scale([1.0, 2.0, 2.0, 2.0])],
+            ),
+        ],
+        coordinateTransformations=None,
+    )
+    metadata.omero = bad_omero
+    observed.append(_first_violated_rule(metadata))
+
+    # Stage 2 -> AXIS_TYPE. Count fixed (5 axes); two channels remain, and a
+    # space still precedes a channel and the spatial names are still wrong.
+    metadata.axes = [
+        Axis(name="x", type="space"),
+        Axis(name="c", type="channel"),
+        Axis(name="c2", type="channel"),
+        Axis(name="z", type="space"),
+        Axis(name="w", type="space"),
+    ]
+    observed.append(_first_violated_rule(metadata))
+
+    # Stage 3 -> AXIS_ORDER (class ordering). One channel now, but a space axis
+    # still precedes it; the spatial names are still not the (z, y, x) suffix.
+    metadata.axes = [
+        Axis(name="x", type="space"),
+        Axis(name="c", type="channel"),
+        Axis(name="z", type="space"),
+        Axis(name="w", type="space"),
+    ]
+    observed.append(_first_violated_rule(metadata))
+
+    # Stage 4 -> AXIS_ORDER (spatial suffix). Class order fixed (channel first),
+    # but spatial names (x, z, w) are not the length-3 suffix of (z, y, x).
+    metadata.axes = [
+        Axis(name="c", type="channel"),
+        Axis(name="x", type="space"),
+        Axis(name="z", type="space"),
+        Axis(name="w", type="space"),
+    ]
+    observed.append(_first_violated_rule(metadata))
+
+    # Stage 5 -> per-dataset scale count. Axes are now fully valid [c, z, y, x]
+    # (with an inconsistent-orientation violation lurking as rule 10). Dataset
+    # 0 still has two scales, so the per-dataset-scale-count rule fires.
+    metadata.axes = _valid_axes_with_inconsistent_orientation()
+    observed.append(_first_violated_rule(metadata))
+
+    # Stage 6 -> SCALE_LENGTH_MISMATCH. Dataset 0 now has exactly one scale, but
+    # its length is 3 against 4 axes; a scale-after-translation (rule 7) lurks.
+    metadata.datasets[0].coordinateTransformations = [
+        Translation([0.0, 0.0, 0.0]),
+        Scale([1.0, 1.0, 1.0]),
+    ]
+    observed.append(_first_violated_rule(metadata))
+
+    # Stage 7 -> transform order. Lengths fixed to 4; dataset 0's scale still
+    # follows a translation. Dataset 1 is made coarser-but-smaller so the
+    # dataset-order rule (8) lurks behind the transform-order violation.
+    metadata.datasets[0].coordinateTransformations = [
+        Translation([0.0, 0.0, 0.0, 0.0]),
+        Scale([1.0, 1.0, 1.0, 1.0]),
+    ]
+    metadata.datasets[1].coordinateTransformations = [Scale([1.0, 0.5, 0.5, 0.5])]
+    observed.append(_first_violated_rule(metadata))
+
+    # Stage 8 -> dataset order. Transform order fixed (scale before
+    # translation); dataset 1 is still coarser-but-smaller than dataset 0.
+    metadata.datasets[0].coordinateTransformations = [
+        Scale([1.0, 1.0, 1.0, 1.0]),
+        Translation([0.0, 0.0, 0.0, 0.0]),
+    ]
+    observed.append(_first_violated_rule(metadata))
+
+    # Stage 9 -> OMERO color. Dataset order fixed (level 1 coarser-larger);
+    # only the bad OMERO color and the orientation violation remain.
+    metadata.datasets[1].coordinateTransformations = [Scale([1.0, 2.0, 2.0, 2.0])]
+    observed.append(_first_violated_rule(metadata))
+
+    # Stage 10 -> orientation. OMERO color fixed; the y axis still declares a
+    # different orientation type than its spatial siblings.
+    metadata.omero = _omero("00FF88")
+    observed.append(_first_violated_rule(metadata))
+
+    assert observed == EXPECTED_EVALUATION_ORDER
+
+    # Fully repaired: give the y axis a consistent orientation type and the
+    # orchestrator accepts the metadata with no violation.
+    metadata.axes[2] = Axis(
+        name="y",
+        type="space",
+        orientation=_orientation("anatomical", "anterior-to-posterior"),
+    )
+    validate_structural(metadata)

--- a/py/test/test_structural_validation_reader.py
+++ b/py/test/test_structural_validation_reader.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Reader-integration tests for strict structural validation.
+
+These exercise the image read path
+(:meth:`~ngff_zarr.v04.zarr_metadata.Metadata._from_zarr_attrs` via
+:func:`~ngff_zarr.from_ngff_zarr`) rather than the rule functions in isolation:
+
+* a valid array round-tripped through :func:`~ngff_zarr.to_ngff_zarr` and read
+  back with ``validate=True`` passes both the schema and structural layers;
+* an in-memory store whose ``.zattrs`` violates one structural rule (a ``scale``
+  vector whose length disagrees with the axis count -- a v0.4 MUST that the JSON
+  Schema cannot express) raises
+  :class:`~ngff_zarr.structural_validation.ValidationError` under
+  ``validate=True`` but reads silently under the default ``validate=False``.
+
+``validate=True`` runs the JSON-Schema pass first, so these tests require the
+optional ``jsonschema`` dependency.
+"""
+
+import numpy as np
+import pytest
+import zarr
+from ngff_zarr import from_ngff_zarr, to_multiscales, to_ngff_zarr
+from ngff_zarr.structural_validation import SpecRule, ValidationError
+
+pytest.importorskip("jsonschema", reason="jsonschema required for validate=True")
+
+
+def _write_valid_2d_store() -> zarr.storage.MemoryStore:
+    """Write a valid 2D ``(y, x)`` two-level multiscales to an in-memory store."""
+    store = zarr.storage.MemoryStore()
+    array = np.random.random((32, 16)).astype("float32")
+    multiscales = to_multiscales(array, [2])
+    to_ngff_zarr(store, multiscales, version="0.4")
+    return store
+
+
+def test_valid_roundtrip_passes_strict_validation():
+    store = _write_valid_2d_store()
+    multiscales = from_ngff_zarr(store, validate=True)
+    assert multiscales is not None
+
+
+def test_scale_length_violation_raises_only_when_validating():
+    store = _write_valid_2d_store()
+    # Corrupt one dataset's scale to length 3 against the 2-axis (y, x) image.
+    # This stays schema-valid (scale has >= 2 entries) but violates the
+    # structural scale-length MUST.
+    root = zarr.open_group(store, mode="r+")
+    attrs = root.attrs.asdict()
+    dataset0 = attrs["multiscales"][0]["datasets"][0]
+    for transform in dataset0["coordinateTransformations"]:
+        if transform.get("type") == "scale":
+            transform["scale"] = [1.0, 1.0, 1.0]
+    root.attrs["multiscales"] = attrs["multiscales"]
+
+    # validate=True surfaces the structural violation as a ValidationError.
+    with pytest.raises(ValidationError) as exc_info:
+        from_ngff_zarr(store, validate=True)
+    assert exc_info.value.rule == SpecRule.SCALE_LENGTH_MISMATCH
+
+    # The same corrupted store reads cleanly when validation is disabled.
+    multiscales = from_ngff_zarr(store, validate=False)
+    assert multiscales is not None

--- a/ts/examples/validate_structural_demo.ts
+++ b/ts/examples/validate_structural_demo.ts
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+/**
+ * End-to-end demo of OME-Zarr v0.4 structural validation.
+ *
+ * Proves {@link validateStructural} works on hand-built {@link Metadata}
+ * objects with no network access and no test fixtures.
+ *
+ * It first builds a fully valid `[c, y, x]` two-level multiscales metadata and
+ * confirms it passes. It then builds a deliberately broken copy for each
+ * image-metadata rule `validateStructural` enforces over plain multiscales
+ * metadata -- axis count, axis type, axis order, scale-vector length,
+ * per-level coordinate-transform ordering, dataset ordering, and OMERO channel
+ * color -- each mutating a single field, and confirms `validateStructural`
+ * raises the expected {@link SpecRule}, printing the caught rule identifier,
+ * location, and message for each.
+ *
+ * Out of this demo's scope: the two RFC 4 anatomical-orientation rules and the
+ * two HCS plate/well rules (enforced through the separate `validatePlate` /
+ * `validateWell` orchestrators).
+ *
+ * Run from the `ts/` directory:
+ *
+ *     deno run examples/validate_structural_demo.ts
+ *
+ * The process exits non-zero if the valid metadata is rejected, if any broken
+ * copy fails to raise, or if a raised rule does not match the expected one, so
+ * the script doubles as a self-checking smoke test.
+ */
+
+import {
+  SpecRule,
+  validateStructural,
+  ValidationError,
+} from "../src/utils/structural_validation.ts";
+import {
+  createScale,
+  createTranslation,
+  type Metadata,
+} from "../src/types/zarr_metadata.ts";
+
+/**
+ * Return a fully valid v0.4 `[c, y, x]` two-level multiscales metadata.
+ *
+ * Three axes (one channel, two space); two datasets, each with a single
+ * length-3 `scale`; the second level is coarser (larger spatial scale) than
+ * the first, as the spec requires. A fresh object is returned on each call so
+ * callers may mutate one field to construct an invalid case in isolation.
+ */
+function buildValidMetadata(): Metadata {
+  return {
+    axes: [
+      { name: "c", type: "channel", unit: undefined },
+      { name: "y", type: "space", unit: undefined },
+      { name: "x", type: "space", unit: undefined },
+    ],
+    datasets: [
+      {
+        path: "0",
+        coordinateTransformations: [createScale([1.0, 1.0, 1.0])],
+      },
+      {
+        path: "1",
+        coordinateTransformations: [createScale([1.0, 2.0, 2.0])],
+      },
+    ],
+    coordinateTransformations: undefined,
+    omero: undefined,
+    name: "image",
+    version: "0.4",
+  };
+}
+
+/** One deliberately broken metadata copy and the rule it should violate. */
+interface InvalidCase {
+  /** Human-readable description of the mutation. */
+  label: string;
+  /** The {@link SpecRule} the orchestrator is expected to raise first. */
+  expectedRule: SpecRule;
+  /** The broken metadata to validate. */
+  metadata: Metadata;
+}
+
+/**
+ * Build one broken copy for each image-metadata rule the demo covers.
+ *
+ * Each case mutates exactly one field of the valid baseline so that the named
+ * rule is the first (and only) one violated, given the orchestrator's
+ * fail-fast spec-MUST ordering. The RFC 4 orientation rules and the HCS
+ * plate/well rules are out of scope; see the module-level comment.
+ */
+function buildInvalidCases(): InvalidCase[] {
+  const cases: InvalidCase[] = [];
+
+  // Six axes: the count is outside the permitted 2..=5 range.
+  let metadata = buildValidMetadata();
+  metadata.axes = [
+    { name: "t", type: "time", unit: undefined },
+    { name: "c", type: "channel", unit: undefined },
+    { name: "z", type: "space", unit: undefined },
+    { name: "y", type: "space", unit: undefined },
+    { name: "x", type: "space", unit: undefined },
+    { name: "x", type: "space", unit: undefined },
+  ];
+  cases.push({
+    label: "six axes (count out of 2..=5)",
+    expectedRule: SpecRule.AxisCount,
+    metadata,
+  });
+
+  // Two channel axes: at most one is permitted.
+  metadata = buildValidMetadata();
+  metadata.axes = [
+    { name: "c", type: "channel", unit: undefined },
+    { name: "c", type: "channel", unit: undefined },
+    { name: "y", type: "space", unit: undefined },
+    { name: "x", type: "space", unit: undefined },
+  ];
+  cases.push({
+    label: "two channel axes",
+    expectedRule: SpecRule.AxisType,
+    metadata,
+  });
+
+  // Spatial axes in (x, y) order: names must be a suffix of (z, y, x).
+  metadata = buildValidMetadata();
+  metadata.axes = [
+    { name: "c", type: "channel", unit: undefined },
+    { name: "x", type: "space", unit: undefined },
+    { name: "y", type: "space", unit: undefined },
+  ];
+  cases.push({
+    label: "spatial axes in x, y order",
+    expectedRule: SpecRule.AxisOrder,
+    metadata,
+  });
+
+  // A dataset scale vector of length 2 against 3 axes.
+  metadata = buildValidMetadata();
+  metadata.datasets[0].coordinateTransformations = [createScale([1.0, 1.0])];
+  cases.push({
+    label: "length-2 scale vector",
+    expectedRule: SpecRule.ScaleLengthMismatch,
+    metadata,
+  });
+
+  // A translation that precedes its scale within a dataset.
+  metadata = buildValidMetadata();
+  metadata.datasets[1].coordinateTransformations = [
+    createTranslation([0.0, 0.0, 0.0]),
+    createScale([1.0, 2.0, 2.0]),
+  ];
+  cases.push({
+    label: "translation before scale",
+    expectedRule: SpecRule.GlobalCoordTransformAfterPerLevel,
+    metadata,
+  });
+
+  // A coarser level whose spatial scale is finer than the level above it.
+  metadata = buildValidMetadata();
+  metadata.datasets[0].coordinateTransformations = [
+    createScale([1.0, 2.0, 2.0]),
+  ];
+  metadata.datasets[1].coordinateTransformations = [
+    createScale([1.0, 1.0, 1.0]),
+  ];
+  cases.push({
+    label: "coarser level with finer scale",
+    expectedRule: SpecRule.DatasetOrderHighestToLowest,
+    metadata,
+  });
+
+  // An OMERO channel color that is not exactly six hex digits.
+  metadata = buildValidMetadata();
+  metadata.omero = {
+    channels: [
+      {
+        color: "xyz",
+        window: { min: 0.0, max: 255.0, start: 0.0, end: 255.0 },
+      },
+    ],
+  };
+  cases.push({
+    label: "omero channel color 'xyz'",
+    expectedRule: SpecRule.OmeroChannelColorFormat,
+    metadata,
+  });
+
+  return cases;
+}
+
+/** Run the demo; return a process exit code (0 on full success). */
+function main(): number {
+  console.log("OME-Zarr v0.4 structural validation demo");
+  console.log("=".repeat(64));
+
+  const valid = buildValidMetadata();
+  try {
+    validateStructural(valid);
+  } catch (error) {
+    if (!(error instanceof ValidationError)) {
+      throw error;
+    }
+    console.log(`UNEXPECTED: valid metadata was rejected: ${error.message}`);
+    return 1;
+  }
+  console.log("valid [c, y, x] two-level metadata: passed validateStructural");
+  console.log("-".repeat(64));
+
+  const cases = buildInvalidCases();
+  let caught = 0;
+  for (const { label, expectedRule, metadata } of cases) {
+    let threw = false;
+    try {
+      validateStructural(metadata);
+    } catch (error) {
+      threw = true;
+      if (!(error instanceof ValidationError)) {
+        throw error;
+      }
+      if (error.rule !== expectedRule) {
+        console.log(
+          `UNEXPECTED rule for ${JSON.stringify(label)}: ` +
+            `got [${error.rule}], expected [${expectedRule}]`,
+        );
+        return 1;
+      }
+      caught += 1;
+      console.log(`caught [${error.rule}] at ${error.location}`);
+      console.log(`    ${label}: ${error.message}`);
+    }
+    if (!threw) {
+      console.log(
+        `UNEXPECTED: ${JSON.stringify(label)} did not raise ValidationError`,
+      );
+      return 1;
+    }
+  }
+
+  console.log("-".repeat(64));
+  const total = cases.length;
+  console.log(`caught ${caught}/${total} expected violations`);
+  return caught === total ? 0 : 1;
+}
+
+if (import.meta.main) {
+  Deno.exit(main());
+}

--- a/ts/src/browser-mod.ts
+++ b/ts/src/browser-mod.ts
@@ -102,6 +102,15 @@ export {
 } from "./utils/factory.ts";
 export { getMethodMetadata } from "./utils/method_metadata.ts";
 export {
+  SpecRule,
+  type ValidateOptions,
+  validatePlate,
+  validateStructural,
+  validateWell,
+  ValidationError,
+  ValidationLevel,
+} from "./utils/structural_validation.ts";
+export {
   isValidDimension,
   isValidUnit,
   validateMetadata,

--- a/ts/src/io/hcs.ts
+++ b/ts/src/io/hcs.ts
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: MIT
 import type { HCSPlate, PlateMetadata } from "../types/hcs.ts";
 import { HCSPlate as HCSPlateClass } from "../types/hcs.ts";
+import {
+  validatePlate,
+  ValidationLevel,
+} from "../utils/structural_validation.ts";
 
 export interface FromHcsZarrOptions {
   validate?: boolean;
@@ -22,10 +26,6 @@ export function fromHcsZarr(
   options: FromHcsZarrOptions = {},
 ): HCSPlate {
   const { validate = false, wellCacheSize, imageCacheSize } = options;
-
-  if (validate) {
-    console.warn("HCS validation not yet implemented");
-  }
 
   if (typeof store !== "string") {
     throw new Error("Non-string store types not yet supported");
@@ -48,11 +48,22 @@ export function fromHcsZarr(
     name: "Test Plate",
   };
 
+  if (validate) {
+    // Strict structural validation of the parsed plate, layered after the
+    // schema pass (schema first, then structural -- mirrors the image reader).
+    // Per-well image rules run lazily in HCSPlate.getWell, where each well's
+    // own metadata is loaded. These plate/well rules are version-agnostic and
+    // the HCS reader handles only v0.4/v0.5 plates, so -- unlike the image
+    // reader's structural pass -- no >=0.4 version gate is required.
+    validatePlate(plateMetadata, { level: ValidationLevel.Strict });
+  }
+
   return new HCSPlateClass({
     store,
     metadata: plateMetadata,
     wellCacheSize,
     imageCacheSize,
+    validate,
   });
 }
 

--- a/ts/src/mod.ts
+++ b/ts/src/mod.ts
@@ -67,6 +67,15 @@ export {
   parseOmero,
 } from "./utils/parse_metadata.ts";
 export {
+  SpecRule,
+  type ValidateOptions,
+  validatePlate,
+  validateStructural,
+  validateWell,
+  ValidationError,
+  ValidationLevel,
+} from "./utils/structural_validation.ts";
+export {
   isValidDimension,
   isValidUnit,
   validateMetadata,

--- a/ts/src/types/hcs.ts
+++ b/ts/src/types/hcs.ts
@@ -8,6 +8,10 @@ import type {
   PlateWell,
   WellImage,
 } from "../schemas/index.ts";
+import {
+  validateWell,
+  ValidationLevel,
+} from "../utils/structural_validation.ts";
 
 export interface LRUCacheOptions {
   maxSize: number;
@@ -75,6 +79,12 @@ export interface HCSPlateOptions {
   metadata: PlateMetadata;
   wellCacheSize?: number | undefined;
   imageCacheSize?: number | undefined;
+  /**
+   * When `true`, each well's structural rules run as it is first loaded via
+   * {@link HCSPlate.getWell}. Defaults to `false`, leaving the read path
+   * unvalidated. Set by `fromHcsZarr` when its own `validate` flag is enabled.
+   */
+  validate?: boolean | undefined;
 }
 
 export interface HCSWellOptions {
@@ -206,6 +216,7 @@ export class HCSPlate {
   public readonly metadata: PlateMetadata;
   private readonly _wells: LRUCache<string, HCSWell>;
   private readonly imageCacheSize: number | undefined;
+  private readonly _validate: boolean;
 
   constructor(options: HCSPlateOptions) {
     this.store = options.store;
@@ -221,6 +232,7 @@ export class HCSPlate {
       name: options.metadata.name,
     };
     this.imageCacheSize = options.imageCacheSize;
+    this._validate = options.validate ?? false;
 
     const wellCacheSize = options.wellCacheSize ?? 500;
     this._wells = new LRUCache<string, HCSWell>({ maxSize: wellCacheSize });
@@ -268,19 +280,31 @@ export class HCSPlate {
     }
 
     // Load the well
+    let well: HCSWell;
     try {
-      const well = HCSWell.fromStore(
+      well = HCSWell.fromStore(
         this.store,
         wellPath,
         wellMeta,
         this.imageCacheSize,
       );
-      this._wells.set(wellPath, well);
-      return well;
     } catch (error) {
       console.error(`Failed to load well at ${wellPath}:`, error);
       return null;
     }
+
+    if (this._validate) {
+      // Strict structural validation of the well's own metadata in the context
+      // of this plate, performed where each well is first loaded (mirrors the
+      // schema/structural split in fromHcsZarr). A ValidationError propagates
+      // to the caller rather than being swallowed as a load failure.
+      validateWell(this.metadata, well.metadata, {
+        level: ValidationLevel.Strict,
+      });
+    }
+
+    this._wells.set(wellPath, well);
+    return well;
   }
 
   getWellByIndices(rowIndex: number, columnIndex: number): HCSWell | null {

--- a/ts/src/utils/from_zarr_attrs.ts
+++ b/ts/src/utils/from_zarr_attrs.ts
@@ -25,6 +25,10 @@ import {
   hasRfc4OrientationMetadata,
   validateRfc4Orientation,
 } from "./rfc4_validation.ts";
+import {
+  validateStructural,
+  ValidationLevel,
+} from "./structural_validation.ts";
 import type { AnatomicalOrientation } from "../types/rfc4.ts";
 import { AnatomicalOrientationValues } from "../types/rfc4.ts";
 
@@ -88,6 +92,29 @@ function extractOrientationsFromAxes(
   }
 
   return hasOrientation ? orientations : undefined;
+}
+
+/**
+ * Return whether an OME-Zarr spec version string is `0.4` or newer.
+ *
+ * The dotted version is compared component-wise as integers, so multi-digit
+ * minor versions order correctly: `"0.10"` is newer than `"0.4"`, not older.
+ * A plain `Number.parseFloat("0.10")` would yield `0.1` and wrongly drop v0.10+
+ * metadata from structural validation. This mirrors the Python port's
+ * `packaging.version.parse(version) >= packaging.version.parse("0.4")` gate.
+ *
+ * Returns `false` for an unparsable version (leading component not a number),
+ * matching the prior `Number.isNaN` guard that skipped validation in that case.
+ */
+function isSpecVersionAtLeastV04(version: string): boolean {
+  const [major, minor = 0] = version
+    .split(".")
+    .map((part) => Number.parseInt(part, 10));
+  if (Number.isNaN(major)) {
+    return false;
+  }
+  // A NaN minor (e.g. "0.x") fails `minor >= 4`, so it needs no separate guard.
+  return major > 0 || (major === 0 && minor >= 4);
 }
 
 /**
@@ -203,6 +230,13 @@ export async function fromZarrAttrsV04(
           name: String(axisObj.name) as SupportedDims,
           type: String(axisObj.type) as AxesType,
           unit: axisObj.unit as Units | undefined,
+          // Preserve RFC 4 orientation on the parsed axis so the strict
+          // structural pass below can run validateAxisOrientation; dropping it
+          // here makes that rule a no-op. This mirrors the Python port, whose
+          // _filter_axis_dict keeps the raw orientation field on each Axis.
+          ...(axisObj.orientation !== undefined && axisObj.orientation !== null
+            ? { orientation: axisObj.orientation as Axis["orientation"] }
+            : {}),
         };
       });
     } else {
@@ -382,6 +416,17 @@ export async function fromZarrAttrsV04(
       }
       : {}),
   };
+
+  // Strict structural validation of the parsed metadata, layered after the
+  // schema pass and RFC 4 dict check above. The structural rules encode the
+  // v0.4+ metadata model (typed axes and per-dataset coordinate
+  // transformations); the legacy v0.1-0.3 layouts predate it, so the rules are
+  // scoped to v0.4 and newer.
+  if (validate) {
+    if (isSpecVersionAtLeastV04(metadata.version)) {
+      validateStructural(metadata, { level: ValidationLevel.Strict });
+    }
+  }
 
   return { metadata, images };
 }

--- a/ts/src/utils/py_format.ts
+++ b/ts/src/utils/py_format.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+/**
+ * Python-style value formatting helpers shared across the validation modules.
+ *
+ * These keep `ValidationError` message bytes identical to the Python port,
+ * which the cross-language parity tests assert.
+ */
+
+/**
+ * Render a list of names as a Python-style list literal, e.g. `['z', 'y']`.
+ *
+ * Mirrors Python's `str(list_of_str)` / f-string rendering: bracketed,
+ * single-quoted elements, comma-space separated. Both the structural
+ * spatial-axis-order message and the RFC 4 axis-orientation-completeness
+ * message interpolate this verbatim, so the two ports stay byte-for-byte
+ * identical. Axis names reaching these rules are single-quote-free, so the
+ * plain single-quoted element form is exact.
+ */
+export function formatNameList(names: readonly string[]): string {
+  return `[${names.map((name) => `'${name}'`).join(", ")}]`;
+}

--- a/ts/src/utils/rfc4_validation.ts
+++ b/ts/src/utils/rfc4_validation.ts
@@ -7,6 +7,7 @@
  */
 
 import { AnatomicalOrientationValuesSchema } from "../schemas/rfc4.ts";
+import { formatNameList } from "./py_format.ts";
 
 /** Valid anatomical orientation values */
 const VALID_ORIENTATION_VALUES = new Set([
@@ -54,6 +55,14 @@ export function hasRfc4OrientationMetadata(
 
 /**
  * Validate RFC 4 anatomical orientation metadata.
+ *
+ * The two inconsistency errors carry stable marker substrings -- `same type`
+ * for a mixed-`type` failure and `all spatial axes` for the all-or-none
+ * completeness failure -- that `validateAxisOrientation` reads to map each
+ * failure onto its `SpecRule`. These markers are a load-bearing contract
+ * pinned by a message-stability test (see
+ * `structural_validation_orientation_test.ts`) so the mapping cannot silently
+ * break if the wording is later edited.
  *
  * @param axes - List of axis metadata dictionaries to validate
  * @throws Error if the orientation metadata is invalid or inconsistent
@@ -114,8 +123,10 @@ export function validateRfc4Orientation(
     throw new Error(
       `RFC 4 requires that if orientation is defined for one spatial axis, ` +
         `it must be defined for all spatial axes. ` +
-        `Axes with orientation: ${spatialAxesWithOrientation.join(", ")}, ` +
-        `axes without orientation: ${spatialAxesWithoutOrientation.join(", ")}`,
+        `Axes with orientation: ` +
+        `${formatNameList(spatialAxesWithOrientation)}, ` +
+        `axes without orientation: ` +
+        `${formatNameList(spatialAxesWithoutOrientation)}`,
     );
   }
 }

--- a/ts/src/utils/structural_validation.ts
+++ b/ts/src/utils/structural_validation.ts
@@ -1,0 +1,899 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+/**
+ * Structural validation for OME-Zarr v0.4 image/multiscales metadata.
+ *
+ * Where the Zod schema validation in {@link validateMetadata} answers "is this
+ * shaped like OME-Zarr?", the rules in this module answer "does this obey the
+ * specification's structural invariants?" -- axis counts, axis ordering,
+ * coordinate-transformation arity, finest-to-coarsest dataset ordering, and
+ * OMERO channel color format. These are spec MUSTs that a JSON Schema cannot
+ * express.
+ *
+ * Each rule is identified by a stable, kebab-case {@link SpecRule} value that is
+ * part of the observable surface: the identifiers, their evaluation order, and
+ * the dotted-segment location strings are kept byte-for-byte identical to the
+ * package's Python implementation so the two stay in lockstep (a property the
+ * cross-language parity tests assert). Rules fail fast -- the orchestrator
+ * throws a {@link ValidationError} on the first violation, in canonical
+ * specification order.
+ *
+ * This module provides the image/multiscales rule surface -- including the
+ * RFC 4 anatomical-orientation checks -- plus the HCS plate/well rules, which
+ * operate on separate metadata objects and are dispatched by the companion
+ * {@link validatePlate} and {@link validateWell} entry points.
+ */
+
+import {
+  type Axis,
+  type Dataset,
+  type Metadata,
+  type Transform,
+  validateColor,
+} from "../types/zarr_metadata.ts";
+import type { PlateMetadata, WellMetadata } from "../types/hcs.ts";
+import {
+  hasRfc4OrientationMetadata,
+  validateRfc4Orientation,
+} from "./rfc4_validation.ts";
+import { formatNameList } from "./py_format.ts";
+
+/**
+ * Stable, kebab-case identifiers for the structural specification rules.
+ *
+ * The string values are the observable surface -- they appear in
+ * {@link ValidationError.rule}, logs, and tests -- and must match the package's
+ * Python implementation exactly. Members are listed in canonical
+ * specification-MUST evaluation order.
+ */
+export const SpecRule = {
+  /** Axis count within the v0.4 range of 2..5 inclusive. */
+  AxisCount: "axis-count",
+  /** At most one `time` axis and at most one `channel` axis. */
+  AxisType: "axis-type",
+  /** time before channel before space; spatial names suffix (z, y, x). */
+  AxisOrder: "axis-order",
+  /** Every scale/translation vector length equals the axis count. */
+  ScaleLengthMismatch: "scale-length-mismatch",
+  /** Exactly one scale per dataset; a translation must follow it. */
+  GlobalCoordTransformAfterPerLevel: "global-coord-transform-after-per-level",
+  /** Datasets ordered finest to coarsest; spatial scale must not shrink. */
+  DatasetOrderHighestToLowest: "dataset-order-highest-to-lowest",
+  /** Each OMERO channel color is exactly six hexadecimal digits. */
+  OmeroChannelColorFormat: "omero-channel-color-format",
+  /** All spatial-axis RFC 4 orientations share one `type`. */
+  AxisOrientationConsistentType: "axis-orientation-consistent-type",
+  /** If any spatial axis declares an orientation, all spatial axes do. */
+  AxisOrientationCompleteness: "axis-orientation-completeness",
+  /** Each well's rowIndex/columnIndex agrees with the row/column in its path. */
+  PlateRowIndexConsistency: "plate-row-index-consistency",
+  /** Each well image references an acquisition when the plate declares many. */
+  WellAcquisitionMissing: "well-acquisition-missing",
+} as const;
+
+/** Union of the {@link SpecRule} string values. */
+export type SpecRule = (typeof SpecRule)[keyof typeof SpecRule];
+
+/**
+ * How much validation {@link validateStructural} performs.
+ *
+ * `"strict"` is the default and runs every structural image/multiscales rule.
+ * `"schema_only"` skips them -- schema validation is the separate concern of
+ * {@link validateMetadata}, which checks the raw attributes via Zod.
+ */
+export const ValidationLevel = {
+  /** Skip structural rules; rely on Zod schema validation only. */
+  SchemaOnly: "schema_only",
+  /** Run every structural image/multiscales rule (the default). */
+  Strict: "strict",
+} as const;
+
+/** Union of the {@link ValidationLevel} string values. */
+export type ValidationLevel =
+  (typeof ValidationLevel)[keyof typeof ValidationLevel];
+
+/**
+ * Options controlling structural validation.
+ */
+export interface ValidateOptions {
+  /**
+   * Validation level to run. Defaults to {@link ValidationLevel.Strict}
+   * (`"strict"`).
+   */
+  level?: ValidationLevel;
+  /**
+   * Whether unknown metadata fields are tolerated. Defaults to `true`,
+   * mirroring the parser, which warns on rather than rejects unknown fields.
+   */
+  allowUnknownFields?: boolean;
+}
+
+/**
+ * Raised when a structural specification rule is violated.
+ *
+ * Carries the offending {@link SpecRule} and an optional `location` identifying
+ * the offending metadata node in dotted-segment (JSON-Pointer-style) form, e.g.
+ * `multiscales[0].datasets[2].coordinateTransformations[0]`. The `message` is
+ * formatted as `Spec rule [<rule>] violated: <message>`.
+ */
+export class ValidationError extends Error {
+  /** The structural rule that was violated. */
+  readonly rule: SpecRule;
+  /** Dotted-segment location of the offending metadata node, if known. */
+  readonly location?: string;
+
+  constructor(rule: SpecRule, message: string, location?: string) {
+    super(`Spec rule [${rule}] violated: ${message}`);
+    this.name = "ValidationError";
+    this.rule = rule;
+    if (location !== undefined) {
+      this.location = location;
+    }
+  }
+}
+
+/**
+ * Check one coordinate transform's vector length against the axis count.
+ *
+ * Centralizes the length invariant shared by the global and per-dataset
+ * coordinate-transformation checks (see {@link SpecRule.ScaleLengthMismatch}),
+ * so the rule lives in one place. Transforms that carry no length-bearing
+ * vector are ignored.
+ *
+ * @param transform - The coordinate transform to inspect.
+ * @param axesLen - The expected vector length (the axis count).
+ * @returns `["scale", actual]` or `["translation", actual]` when the
+ * transform's vector length disagrees with `axesLen`; otherwise `null`.
+ */
+function transformLenMismatch(
+  transform: Transform,
+  axesLen: number,
+): [kind: string, actual: number] | null {
+  if (transform.type === "scale") {
+    const actual = transform.scale.length;
+    if (actual !== axesLen) {
+      return ["scale", actual];
+    }
+  } else if (transform.type === "translation") {
+    const actual = transform.translation.length;
+    if (actual !== axesLen) {
+      return ["translation", actual];
+    }
+  }
+  return null;
+}
+
+/**
+ * Return the first `scale` vector in a dataset, or `null` if none is present.
+ *
+ * Lets {@link validateDatasetOrder} compare adjacent multiscale levels without
+ * re-deriving the per-dataset `scale` lookup.
+ *
+ * @param dataset - The dataset whose coordinate transforms are scanned.
+ * @returns The first `scale` transform's vector, or `null` when the dataset
+ * declares no `scale` transform.
+ */
+function firstScaleVector(dataset: Dataset): number[] | null {
+  for (const transform of dataset.coordinateTransformations) {
+    if (transform.type === "scale") {
+      return transform.scale;
+    }
+  }
+  return null;
+}
+
+/**
+ * Class-ordering rank for axis types: a `time` axis must precede a `channel`
+ * axis, which must precede any `space` axis. Lower rank must never follow
+ * higher rank (see {@link validateAxisOrder}). Axis types absent from this map
+ * (e.g. `array`) carry no rank, so a pair involving one is skipped -- mirroring
+ * the Python implementation's `dict.get(...) is None` handling.
+ */
+const AXIS_TYPE_RANK: Record<string, number | undefined> = {
+  time: 0,
+  channel: 1,
+  space: 2,
+};
+
+/**
+ * Spatial axis names in canonical order. A valid set of `space` axis names is
+ * the matching-length suffix of this tuple: 1 -> `["x"]`, 2 -> `["y", "x"]`,
+ * 3 -> `["z", "y", "x"]` (see {@link validateSpatialAxisOrder}).
+ */
+const SPATIAL_AXIS_NAMES = ["z", "y", "x"] as const;
+
+/**
+ * Render a number the way Python's `str()`/f-string renders a `float`: a
+ * whole-number value keeps a trailing `.0` (e.g. `2` -> `"2.0"`), matching the
+ * `list[float]` scale vectors the Python port interpolates into the
+ * dataset-order message. Non-integer scale ratios (e.g. `1.5`) already render
+ * identically across both languages, so they pass through unchanged. This keeps
+ * the message byte-for-byte identical to Python for the whole-number
+ * downsampling ratios OME-Zarr writers (including this package) emit to disk.
+ */
+function pyFloat(value: number): string {
+  return Number.isInteger(value) ? `${value}.0` : `${value}`;
+}
+
+/**
+ * Validate that the axis count is within the v0.4-permitted range.
+ *
+ * OME-Zarr v0.4 requires between 2 and 5 axes, inclusive.
+ *
+ * @param metadata - The parsed multiscales metadata to validate.
+ * @throws {ValidationError} With {@link SpecRule.AxisCount} when
+ * `metadata.axes.length` lies outside `2..5`; location `multiscales[0].axes`.
+ */
+export function validateAxisCount(metadata: Metadata): void {
+  const count = metadata.axes.length;
+  if (count < 2 || count > 5) {
+    throw new ValidationError(
+      SpecRule.AxisCount,
+      `OME-Zarr v0.4 requires between 2 and 5 axes, inclusive; found ${count}.`,
+      "multiscales[0].axes",
+    );
+  }
+}
+
+/**
+ * Validate axis-type multiplicity.
+ *
+ * At most one `time` axis and at most one `channel` axis may be present.
+ *
+ * @param metadata - The parsed multiscales metadata to validate.
+ * @throws {ValidationError} With {@link SpecRule.AxisType} when more than one
+ * `time` axis or more than one `channel` axis is present; location
+ * `multiscales[0].axes`.
+ */
+export function validateAxisType(metadata: Metadata): void {
+  const timeCount = metadata.axes.filter((ax) => ax.type === "time").length;
+  if (timeCount > 1) {
+    throw new ValidationError(
+      SpecRule.AxisType,
+      `At most one 'time' axis is permitted; found ${timeCount}.`,
+      "multiscales[0].axes",
+    );
+  }
+  const channelCount =
+    metadata.axes.filter((ax) => ax.type === "channel").length;
+  if (channelCount > 1) {
+    throw new ValidationError(
+      SpecRule.AxisType,
+      `At most one 'channel' axis is permitted; found ${channelCount}.`,
+      "multiscales[0].axes",
+    );
+  }
+}
+
+/**
+ * Validate the class ordering of axes.
+ *
+ * Axes are ranked by type (`time` < `channel` < `space`) and must be listed in
+ * non-decreasing rank order: every `time` axis precedes every `channel` axis,
+ * which precedes every `space` axis. The first adjacent pair that inverts this
+ * ranking is reported. Pairs involving an axis type with no rank (e.g. `array`)
+ * are skipped.
+ *
+ * @param metadata - The parsed multiscales metadata to validate.
+ * @throws {ValidationError} With {@link SpecRule.AxisOrder} for the first
+ * adjacent pair where a lower-ranked axis type follows a higher-ranked one;
+ * location `multiscales[0].axes[i+1]`.
+ */
+export function validateAxisOrder(metadata: Metadata): void {
+  const axes = metadata.axes;
+  for (let i = 0; i < axes.length - 1; i++) {
+    const current = axes[i];
+    const following = axes[i + 1];
+    const currentRank = AXIS_TYPE_RANK[current.type];
+    const followingRank = AXIS_TYPE_RANK[following.type];
+    if (currentRank === undefined || followingRank === undefined) {
+      continue;
+    }
+    if (followingRank < currentRank) {
+      throw new ValidationError(
+        SpecRule.AxisOrder,
+        `Axis '${following.name}' of type '${following.type}' must not ` +
+          `follow axis '${current.name}' of type '${current.type}'; axes ` +
+          `must be ordered time, then channel, then space.`,
+        `multiscales[0].axes[${i + 1}]`,
+      );
+    }
+  }
+}
+
+/**
+ * Validate the count and names of spatial axes.
+ *
+ * The `space` axes, taken in order, must be the matching-length suffix of
+ * `(z, y, x)`: one spatial axis must be `(x)`, two must be `(y, x)`, and three
+ * must be `(z, y, x)`. At most three `space` axes are permitted.
+ *
+ * @param metadata - The parsed multiscales metadata to validate.
+ * @throws {ValidationError} With {@link SpecRule.AxisOrder} when there are more
+ * than three `space` axes, or when their names are not the expected suffix of
+ * `(z, y, x)`; location `multiscales[0].axes` or the first offending axis.
+ */
+export function validateSpatialAxisOrder(metadata: Metadata): void {
+  const spaceIndices: number[] = [];
+  metadata.axes.forEach((ax, i) => {
+    if (ax.type === "space") {
+      spaceIndices.push(i);
+    }
+  });
+  const count = spaceIndices.length;
+  if (count > 3) {
+    throw new ValidationError(
+      SpecRule.AxisOrder,
+      `OME-Zarr v0.4 permits at most 3 'space' axes; found ${count}.`,
+      "multiscales[0].axes",
+    );
+  }
+  const expected = SPATIAL_AXIS_NAMES.slice(SPATIAL_AXIS_NAMES.length - count);
+  const actual = spaceIndices.map((i) => metadata.axes[i].name);
+  const mismatch = actual.findIndex((name, j) => name !== expected[j]);
+  if (mismatch !== -1) {
+    throw new ValidationError(
+      SpecRule.AxisOrder,
+      `Spatial axis names ${formatNameList(actual)} must be the ` +
+        `length-${count} suffix of (z, y, x): ${formatNameList(expected)}.`,
+      `multiscales[0].axes[${spaceIndices[mismatch]}]`,
+    );
+  }
+}
+
+/**
+ * Validate that each dataset defines exactly one `scale` transform.
+ *
+ * Every dataset's `coordinateTransformations` must contain exactly one `scale`
+ * (the per-level voxel size). This shares the per-dataset
+ * coordinate-transform-shape rule identifier
+ * ({@link SpecRule.GlobalCoordTransformAfterPerLevel}); there is no dedicated
+ * identifier for the scale count.
+ *
+ * @param metadata - The parsed multiscales metadata to validate.
+ * @throws {ValidationError} With
+ * {@link SpecRule.GlobalCoordTransformAfterPerLevel} when a dataset has zero or
+ * more than one `scale` transform; location
+ * `multiscales[0].datasets[i].coordinateTransformations`.
+ */
+export function validatePerDatasetScaleCount(metadata: Metadata): void {
+  for (let i = 0; i < metadata.datasets.length; i++) {
+    const dataset = metadata.datasets[i];
+    const scaleCount = dataset.coordinateTransformations.filter(
+      (t) => t.type === "scale",
+    ).length;
+    if (scaleCount !== 1) {
+      throw new ValidationError(
+        SpecRule.GlobalCoordTransformAfterPerLevel,
+        `Each dataset must define exactly one 'scale' coordinate ` +
+          `transformation; dataset ${i} has ${scaleCount}.`,
+        `multiscales[0].datasets[${i}].coordinateTransformations`,
+      );
+    }
+  }
+}
+
+/**
+ * Validate coordinate-transform vector lengths against the axis count.
+ *
+ * Every `scale` and `translation` vector -- in the global
+ * `coordinateTransformations` (if present) and in each dataset -- must have
+ * exactly one entry per axis. The first mismatch, scanned
+ * global-then-per-dataset, is reported. The length invariant itself lives in
+ * {@link transformLenMismatch}.
+ *
+ * @param metadata - The parsed multiscales metadata to validate.
+ * @throws {ValidationError} With {@link SpecRule.ScaleLengthMismatch} for the
+ * first transform whose vector length disagrees with `metadata.axes.length`;
+ * location identifies the offending transform.
+ */
+export function validateScaleLength(metadata: Metadata): void {
+  const axesLen = metadata.axes.length;
+  const globalTransforms = metadata.coordinateTransformations;
+  if (globalTransforms) {
+    for (let j = 0; j < globalTransforms.length; j++) {
+      const mismatch = transformLenMismatch(globalTransforms[j], axesLen);
+      if (mismatch !== null) {
+        const [kind, actualLen] = mismatch;
+        throw new ValidationError(
+          SpecRule.ScaleLengthMismatch,
+          `Global '${kind}' transform has length ${actualLen}, but ` +
+            `there are ${axesLen} axes; lengths must match.`,
+          `multiscales[0].coordinateTransformations[${j}]`,
+        );
+      }
+    }
+  }
+  for (let i = 0; i < metadata.datasets.length; i++) {
+    const dataset = metadata.datasets[i];
+    for (let j = 0; j < dataset.coordinateTransformations.length; j++) {
+      const mismatch = transformLenMismatch(
+        dataset.coordinateTransformations[j],
+        axesLen,
+      );
+      if (mismatch !== null) {
+        const [kind, actualLen] = mismatch;
+        throw new ValidationError(
+          SpecRule.ScaleLengthMismatch,
+          `Dataset ${i} '${kind}' transform has length ${actualLen}, ` +
+            `but there are ${axesLen} axes; lengths must match.`,
+          `multiscales[0].datasets[${i}].coordinateTransformations[${j}]`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Validate coordinate-transform ordering within each dataset.
+ *
+ * Within a dataset's `coordinateTransformations`, a `translation` (if present)
+ * must follow its `scale` -- a `scale` must never appear after a `translation`.
+ *
+ * @param metadata - The parsed multiscales metadata to validate.
+ * @throws {ValidationError} With
+ * {@link SpecRule.GlobalCoordTransformAfterPerLevel} for the first dataset
+ * where a `scale` follows a `translation`; location identifies the offending
+ * `scale`.
+ */
+export function validateTransformOrder(metadata: Metadata): void {
+  for (let i = 0; i < metadata.datasets.length; i++) {
+    const dataset = metadata.datasets[i];
+    let seenTranslation = false;
+    for (let j = 0; j < dataset.coordinateTransformations.length; j++) {
+      const transform = dataset.coordinateTransformations[j];
+      if (transform.type === "translation") {
+        seenTranslation = true;
+      } else if (transform.type === "scale" && seenTranslation) {
+        throw new ValidationError(
+          SpecRule.GlobalCoordTransformAfterPerLevel,
+          `In dataset ${i}, a 'scale' transform must not follow a ` +
+            `'translation'; a translation must follow its scale.`,
+          `multiscales[0].datasets[${i}].coordinateTransformations[${j}]`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Validate that datasets are ordered finest to coarsest.
+ *
+ * Multiscale datasets must be listed from highest resolution (finest, i.e.
+ * smallest spatial `scale`) to lowest (coarsest). For each adjacent pair, the
+ * later level's `scale` must not be smaller than the earlier level's on any
+ * `space` axis. Pairs whose `scale` vectors are missing or too short to index a
+ * spatial axis are skipped -- those shapes are the concern of
+ * {@link validatePerDatasetScaleCount} and {@link validateScaleLength} -- so
+ * this rule never indexes out of bounds.
+ *
+ * @param metadata - The parsed multiscales metadata to validate.
+ * @throws {ValidationError} With {@link SpecRule.DatasetOrderHighestToLowest}
+ * for the first adjacent pair whose later (coarser) level has a smaller spatial
+ * scale; location `multiscales[0].datasets[i+1]`.
+ */
+export function validateDatasetOrder(metadata: Metadata): void {
+  const spaceIndices: number[] = [];
+  metadata.axes.forEach((ax, i) => {
+    if (ax.type === "space") {
+      spaceIndices.push(i);
+    }
+  });
+  const datasets = metadata.datasets;
+  for (let i = 0; i < datasets.length - 1; i++) {
+    const finer = firstScaleVector(datasets[i]);
+    const coarser = firstScaleVector(datasets[i + 1]);
+    if (finer === null || coarser === null) {
+      continue;
+    }
+    for (const axisIndex of spaceIndices) {
+      if (axisIndex >= finer.length || axisIndex >= coarser.length) {
+        // Scale too short to compare this axis: another rule's concern.
+        // Skip so we never index out of bounds here.
+        continue;
+      }
+      if (coarser[axisIndex] < finer[axisIndex]) {
+        const axisName = metadata.axes[axisIndex].name;
+        throw new ValidationError(
+          SpecRule.DatasetOrderHighestToLowest,
+          `Datasets must be ordered finest to coarsest; dataset ` +
+            `${i + 1} has spatial scale ${pyFloat(coarser[axisIndex])} ` +
+            `on axis '${axisName}', smaller than dataset ${i}'s ` +
+            `${pyFloat(finer[axisIndex])}.`,
+          `multiscales[0].datasets[${i + 1}]`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Validate the color format of each OMERO channel.
+ *
+ * When OMERO rendering metadata is present, every channel `color` must be
+ * exactly six hexadecimal digits (RGB). This reuses the package's existing
+ * {@link validateColor} predicate rather than re-implementing the format check,
+ * surfacing its failure message through the unified {@link ValidationError}
+ * channel.
+ *
+ * @param metadata - The parsed multiscales metadata to validate.
+ * @throws {ValidationError} With {@link SpecRule.OmeroChannelColorFormat} for
+ * the first channel whose `color` is not six hex digits; location
+ * `multiscales[0].omero.channels[i].color`.
+ */
+export function validateOmeroColorHex(metadata: Metadata): void {
+  const omero = metadata.omero;
+  if (omero === undefined) {
+    return;
+  }
+  for (let i = 0; i < omero.channels.length; i++) {
+    try {
+      validateColor(omero.channels[i].color);
+    } catch (error) {
+      throw new ValidationError(
+        SpecRule.OmeroChannelColorFormat,
+        error instanceof Error ? error.message : String(error),
+        `multiscales[0].omero.channels[${i}].color`,
+      );
+    }
+  }
+}
+
+/**
+ * Render a parsed {@link Axis} back to the record form the RFC 4 helpers
+ * consume.
+ *
+ * Emits only the fields the RFC 4 helpers inspect -- `name`, `type`, and (for a
+ * spatial axis that declares it) `orientation` as a `{ type, value }` record. A
+ * stored `orientation` may be the serialized {@link AxisOrientation} form or
+ * an {@link AnatomicalOrientation}; both already expose a string `type` and
+ * `value`, so the record is built directly without further coercion.
+ *
+ * @param axis - The parsed axis to render.
+ * @returns A plain record carrying `name`, `type`, and, when present,
+ * `orientation`.
+ */
+function axisToValidationRecord(axis: Axis): Record<string, unknown> {
+  const record: Record<string, unknown> = {
+    name: axis.name,
+    type: axis.type,
+  };
+  const orientation = axis.orientation;
+  if (orientation !== undefined && orientation !== null) {
+    record.orientation = {
+      type: orientation.type,
+      value: orientation.value,
+    };
+  }
+  return record;
+}
+
+/**
+ * Validate RFC 4 anatomical-orientation metadata on the spatial axes.
+ *
+ * This rule does not reimplement RFC 4; it wraps the package's existing
+ * logic -- {@link hasRfc4OrientationMetadata} and
+ * {@link validateRfc4Orientation} -- and surfaces its failures through the
+ * unified {@link ValidationError} channel. The parsed {@link Axis} objects are
+ * first rendered back to the record form those helpers expect (see
+ * {@link axisToValidationRecord}).
+ *
+ * Orientation is optional in RFC 4, so when no spatial axis carries it the rule
+ * is a no-op.
+ *
+ * @param metadata - The parsed multiscales metadata to validate.
+ * @throws {ValidationError} With {@link SpecRule.AxisOrientationConsistentType}
+ * when the spatial axes' orientations do not all share one `type`, or
+ * {@link SpecRule.AxisOrientationCompleteness} when orientation is defined for
+ * some but not all spatial axes; location `multiscales[0].axes`. The original
+ * RFC 4 message text is preserved. Any other failure from
+ * {@link validateRfc4Orientation} -- e.g. an orientation value outside the
+ * RFC 4 vocabulary, a schema-level concern with no dedicated structural rule
+ * -- propagates unchanged.
+ */
+export function validateAxisOrientation(metadata: Metadata): void {
+  const axesRecords = metadata.axes.map(axisToValidationRecord);
+  if (!hasRfc4OrientationMetadata(axesRecords)) {
+    return;
+  }
+  try {
+    validateRfc4Orientation(axesRecords);
+  } catch (error) {
+    // validateRfc4Orientation throws exactly two messages this rule maps: a
+    // spatial-orientation "same type" mismatch and the all-or-none completeness
+    // failure. An out-of-vocabulary orientation value -- a schema-level concern
+    // with no dedicated structural rule -- carries neither marker and so
+    // propagates unchanged, matching the package's Python implementation.
+    //
+    // The "same type" / "all spatial axes" substrings below are a load-bearing
+    // contract with validateRfc4Orientation's message text: an unrecognized
+    // error falls through to the final `throw` and surfaces as a plain Error
+    // rather than a ValidationError. The message-stability test in
+    // structural_validation_orientation_test.ts pins both markers so editing
+    // that wording fails CI loudly instead of silently breaking this mapping.
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("same type")) {
+      throw new ValidationError(
+        SpecRule.AxisOrientationConsistentType,
+        message,
+        "multiscales[0].axes",
+      );
+    }
+    if (message.includes("all spatial axes")) {
+      throw new ValidationError(
+        SpecRule.AxisOrientationCompleteness,
+        message,
+        "multiscales[0].axes",
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Render a string as Python's `repr()` renders it, for byte-identical messages.
+ *
+ * The plate/well rule messages interpolate row, column, and well-path strings
+ * the way the Python implementation does with `{value!r}`: a single-quoted
+ * literal, switching to double quotes only when the value contains a single
+ * quote but no double quote. Keeping this byte-for-byte identical to Python is a
+ * property the cross-language parity tests assert. Inputs reaching these rules
+ * are alphanumeric path segments, so this resolves to a plain single-quoted
+ * form in practice.
+ */
+function pyRepr(value: string): string {
+  const quote = value.includes("'") && !value.includes('"') ? '"' : "'";
+  const escaped = value.replaceAll("\\", "\\\\").replaceAll(
+    quote,
+    `\\${quote}`,
+  );
+  return `${quote}${escaped}${quote}`;
+}
+
+/**
+ * Validate each plate well's recorded indices against its `path`.
+ *
+ * Every `PlateWell` records a `path` of the form `"<row>/<column>"` (e.g.
+ * `"B/03"`) alongside numeric `rowIndex` and `columnIndex` fields. OME-Zarr v0.4
+ * requires these to agree: the row segment must name an entry in `plate.rows`
+ * whose position equals `rowIndex`, and the column segment must name an entry in
+ * `plate.columns` whose position equals `columnIndex`. The first offending well,
+ * scanned in order, is reported.
+ *
+ * @param plate - The plate metadata whose wells are validated.
+ * @throws {ValidationError} With {@link SpecRule.PlateRowIndexConsistency} for
+ * the first well whose `path` is not `"<row>/<column>"`, whose row/column
+ * segment is absent from `plate.rows`/`plate.columns`, or whose recorded
+ * `rowIndex`/`columnIndex` disagrees with that segment's position; location
+ * `plate.wells[i]`.
+ */
+export function validatePlateWellIndexConsistency(plate: PlateMetadata): void {
+  const rowIndexByName = new Map<string, number>();
+  plate.rows.forEach((row, i) => rowIndexByName.set(row.name, i));
+  const columnIndexByName = new Map<string, number>();
+  plate.columns.forEach((column, i) => columnIndexByName.set(column.name, i));
+  for (let i = 0; i < plate.wells.length; i++) {
+    const well = plate.wells[i];
+    const location = `plate.wells[${i}]`;
+    const parts = well.path.split("/");
+    if (parts.length !== 2) {
+      throw new ValidationError(
+        SpecRule.PlateRowIndexConsistency,
+        `Well path ${pyRepr(well.path)} must have the form '<row>/<column>'.`,
+        location,
+      );
+    }
+    const [rowName, columnName] = parts;
+    const expectedRow = rowIndexByName.get(rowName);
+    if (expectedRow === undefined) {
+      throw new ValidationError(
+        SpecRule.PlateRowIndexConsistency,
+        `Well path ${pyRepr(well.path)} names row ${pyRepr(rowName)}, which ` +
+          `is not declared in plate.rows.`,
+        location,
+      );
+    }
+    const expectedColumn = columnIndexByName.get(columnName);
+    if (expectedColumn === undefined) {
+      throw new ValidationError(
+        SpecRule.PlateRowIndexConsistency,
+        `Well path ${pyRepr(well.path)} names column ${pyRepr(columnName)}, ` +
+          `which is not declared in plate.columns.`,
+        location,
+      );
+    }
+    if (well.rowIndex !== expectedRow) {
+      throw new ValidationError(
+        SpecRule.PlateRowIndexConsistency,
+        `Well ${pyRepr(well.path)} has rowIndex ${well.rowIndex}, but row ` +
+          `${pyRepr(rowName)} is at index ${expectedRow} in plate.rows.`,
+        location,
+      );
+    }
+    if (well.columnIndex !== expectedColumn) {
+      throw new ValidationError(
+        SpecRule.PlateRowIndexConsistency,
+        `Well ${pyRepr(well.path)} has columnIndex ${well.columnIndex}, but ` +
+          `column ${pyRepr(columnName)} is at index ${expectedColumn} in ` +
+          `plate.columns.`,
+        location,
+      );
+    }
+  }
+}
+
+/**
+ * Validate that well images reference an acquisition when required.
+ *
+ * When a plate declares more than one acquisition, every image in each of its
+ * wells must carry an `acquisition` reference so the field can be attributed to
+ * a specific acquisition. Plates with zero or one acquisition impose no such
+ * requirement, so this rule is a no-op for them. The first image missing its
+ * reference, scanned in order, is reported.
+ *
+ * @param plate - The plate metadata declaring the acquisitions.
+ * @param well - The well metadata whose images are validated.
+ * @throws {ValidationError} With {@link SpecRule.WellAcquisitionMissing} for the
+ * first `WellImage` whose `acquisition` is absent while the plate declares
+ * multiple acquisitions; location `well.images[i].acquisition`.
+ */
+export function validateWellAcquisition(
+  plate: PlateMetadata,
+  well: WellMetadata,
+): void {
+  const acquisitions = plate.acquisitions;
+  if (acquisitions === undefined || acquisitions.length <= 1) {
+    return;
+  }
+  for (let i = 0; i < well.images.length; i++) {
+    const image = well.images[i];
+    if (image.acquisition === undefined || image.acquisition === null) {
+      throw new ValidationError(
+        SpecRule.WellAcquisitionMissing,
+        `Plate declares ${acquisitions.length} acquisitions, so well ` +
+          `image ${i} must reference one via 'acquisition'.`,
+        `well.images[${i}].acquisition`,
+      );
+    }
+  }
+}
+
+/**
+ * Run the structural image/multiscales rules in canonical specification order.
+ *
+ * Orchestrates the per-rule `validate*` functions in this module. It is
+ * fail-fast: the rules run in canonical specification-MUST order and the first
+ * {@link ValidationError} thrown propagates to the caller -- later rules do not
+ * run. The rules run in this order:
+ *
+ * 1. {@link validateAxisCount}
+ * 2. {@link validateAxisType}
+ * 3. {@link validateAxisOrder}
+ * 4. {@link validateSpatialAxisOrder}
+ * 5. {@link validatePerDatasetScaleCount}
+ * 6. {@link validateScaleLength}
+ * 7. {@link validateTransformOrder}
+ * 8. {@link validateDatasetOrder}
+ * 9. {@link validateOmeroColorHex}
+ * 10. {@link validateAxisOrientation}
+ *
+ * Under {@link ValidationLevel.SchemaOnly} this function returns immediately
+ * without running any structural rule -- shape/schema validation is the
+ * separate concern of {@link validateMetadata}, which checks the raw
+ * attributes via Zod. The default level is {@link ValidationLevel.Strict}.
+ *
+ * This orchestrator covers the image/multiscales rules, including the RFC 4
+ * anatomical-orientation checks ({@link validateAxisOrientation}, a no-op when
+ * no axis declares orientation). The HCS plate/well structural rules operate on
+ * separate metadata objects and are dispatched by the companion
+ * {@link validatePlate} and {@link validateWell} entry points.
+ *
+ * @param metadata - The parsed OME-Zarr v0.4 multiscales metadata to validate.
+ * @param options - Validation options; defaults to
+ * `{ level: "strict", allowUnknownFields: true }`.
+ * @throws {ValidationError} For the first structural rule violated, carrying
+ * the offending {@link SpecRule} and `location`. Never thrown under
+ * {@link ValidationLevel.SchemaOnly}, which runs no structural rule.
+ */
+export function validateStructural(
+  metadata: Metadata,
+  options?: ValidateOptions,
+): void {
+  const resolved: Required<ValidateOptions> = {
+    level: options?.level ?? ValidationLevel.Strict,
+    allowUnknownFields: options?.allowUnknownFields ?? true,
+  };
+  if (resolved.level === ValidationLevel.SchemaOnly) {
+    return;
+  }
+  validateAxisCount(metadata);
+  validateAxisType(metadata);
+  validateAxisOrder(metadata);
+  validateSpatialAxisOrder(metadata);
+  validatePerDatasetScaleCount(metadata);
+  validateScaleLength(metadata);
+  validateTransformOrder(metadata);
+  validateDatasetOrder(metadata);
+  validateOmeroColorHex(metadata);
+  validateAxisOrientation(metadata);
+}
+
+/**
+ * Run the structural HCS plate rules in canonical specification order.
+ *
+ * The plate-level counterpart to {@link validateStructural}: it orchestrates
+ * the structural rules that operate on a parsed {@link PlateMetadata}. Like its
+ * image/multiscales sibling it is fail-fast -- the first {@link ValidationError}
+ * thrown propagates to the caller and later rules do not run. The rules run in
+ * this order:
+ *
+ * 1. {@link validatePlateWellIndexConsistency}
+ *
+ * Per-well image rules (e.g. acquisition references) are the separate concern
+ * of {@link validateWell}, called where each well's own metadata is loaded.
+ *
+ * Under {@link ValidationLevel.SchemaOnly} this function returns immediately
+ * without running any structural rule -- shape/schema validation is the
+ * separate concern of {@link validateMetadata}, which checks the raw attributes
+ * via Zod. The default level is {@link ValidationLevel.Strict}.
+ *
+ * @param plate - The parsed OME-Zarr v0.4 plate metadata to validate.
+ * @param options - Validation options; defaults to
+ * `{ level: "strict", allowUnknownFields: true }`.
+ * @throws {ValidationError} For the first structural plate rule violated,
+ * carrying the offending {@link SpecRule} and `location`. Never thrown under
+ * {@link ValidationLevel.SchemaOnly}, which runs no structural rule.
+ */
+export function validatePlate(
+  plate: PlateMetadata,
+  options?: ValidateOptions,
+): void {
+  const resolved: Required<ValidateOptions> = {
+    level: options?.level ?? ValidationLevel.Strict,
+    allowUnknownFields: options?.allowUnknownFields ?? true,
+  };
+  if (resolved.level === ValidationLevel.SchemaOnly) {
+    return;
+  }
+  validatePlateWellIndexConsistency(plate);
+}
+
+/**
+ * Run the structural HCS well rules in canonical specification order.
+ *
+ * Validates a single {@link WellMetadata} in the context of its parent
+ * {@link PlateMetadata} -- the plate's acquisition declarations govern whether
+ * each well image must reference an acquisition. Fail-fast, like
+ * {@link validateStructural} and {@link validatePlate}. The rules run in this
+ * order:
+ *
+ * 1. {@link validateWellAcquisition}
+ *
+ * Under {@link ValidationLevel.SchemaOnly} this function returns immediately
+ * without running any structural rule -- shape/schema validation is the
+ * separate concern of {@link validateMetadata}, which checks the raw attributes
+ * via Zod. The default level is {@link ValidationLevel.Strict}.
+ *
+ * @param plate - The parsed plate metadata that owns `well`; supplies the
+ * acquisition context the well rules consult.
+ * @param well - The parsed well metadata to validate.
+ * @param options - Validation options; defaults to
+ * `{ level: "strict", allowUnknownFields: true }`.
+ * @throws {ValidationError} For the first structural well rule violated,
+ * carrying the offending {@link SpecRule} and `location`. Never thrown under
+ * {@link ValidationLevel.SchemaOnly}, which runs no structural rule.
+ */
+export function validateWell(
+  plate: PlateMetadata,
+  well: WellMetadata,
+  options?: ValidateOptions,
+): void {
+  const resolved: Required<ValidateOptions> = {
+    level: options?.level ?? ValidationLevel.Strict,
+    allowUnknownFields: options?.allowUnknownFields ?? true,
+  };
+  if (resolved.level === ValidationLevel.SchemaOnly) {
+    return;
+  }
+  validateWellAcquisition(plate, well);
+}

--- a/ts/test/hcs_test.ts
+++ b/ts/test/hcs_test.ts
@@ -324,7 +324,20 @@ Deno.test("test_hcs_image_axes_and_dims", async () => {
 });
 
 Deno.test("test_validate_hcs_metadata", () => {
-  // This should not throw an exception
+  // With validate: true, fromHcsZarr now runs the strict plate structural
+  // rules (validatePlate). The mock plate is internally consistent, so this
+  // must not throw.
   const plate = fromHcsZarr(HCS_DATA_PATH, { validate: true });
   assertNotEquals(plate, null);
+});
+
+Deno.test("test_validate_hcs_well_metadata", () => {
+  // Loading a well from a plate read with validate: true runs the strict
+  // per-well structural rules (validateWell) where the well's own metadata is
+  // first available. The mock plate declares a single acquisition, so the
+  // acquisition rule is a no-op and the well loads without throwing.
+  const plate = fromHcsZarr(HCS_DATA_PATH, { validate: true });
+  const well = plate.getWell("A", "1");
+  assertNotEquals(well, null, "Well A/1 should load under validation");
+  assertEquals(well!.images.length, 2, "Well should expose its two fields");
 });

--- a/ts/test/rfc4_integration_test.ts
+++ b/ts/test/rfc4_integration_test.ts
@@ -354,6 +354,30 @@ Deno.test("Round-trip with RAS orientation - write and read back", async () => {
   assertEquals(multiscalesBack.images.length, 1);
 });
 
+Deno.test("fromNgffZarr preserves RFC 4 orientation on parsed metadata.axes", async () => {
+  // Regression for the read path dropping axisObj.orientation when building
+  // metadata.axes: that silently turned the strict structural pass's
+  // validateAxisOrientation rule into a no-op and lost orientation that the
+  // Python port retains via _filter_axis_dict. Reading back must surface
+  // orientation on the spatial axes as the raw { type, value } record.
+  const { multiscales } = await createMultiscalesWithOrientation(LPS);
+
+  const outputStore: MemoryStore = new Map();
+  await toNgffZarr(outputStore, multiscales, { enabledRfcs: [4] });
+
+  const multiscalesBack = await fromNgffZarr(outputStore, { validate: true });
+  const axisByName = new Map(
+    multiscalesBack.metadata.axes.map((ax) => [ax.name, ax]),
+  );
+
+  for (const [name, expected] of Object.entries(LPS)) {
+    const orientation = axisByName.get(name as "x" | "y" | "z")
+      ?.orientation as { type: string; value: string } | undefined;
+    assertEquals(orientation?.type, "anatomical");
+    assertEquals(orientation?.value, expected.value);
+  }
+});
+
 Deno.test("Round-trip with 5D mixed axes (t,c,z,y,x) and LPS orientation", async () => {
   // Create with 5D dimensions
   const { multiscales } = await createMultiscalesWithOrientation(

--- a/ts/test/rfc4_validation_test.ts
+++ b/ts/test/rfc4_validation_test.ts
@@ -214,15 +214,17 @@ async function createTestStore(
 }
 
 Deno.test("fromNgffZarr with valid RFC-4 orientation - validation passes", async () => {
+  // Spatial axes must be ordered (z, y, x) per the OME-Zarr v0.4 axis-order
+  // rule; each axis keeps its own anatomical orientation.
   const multiscalesMetadata = {
     version: "0.4",
     name: "test",
     axes: [
       {
-        name: "x",
+        name: "z",
         type: "space",
         unit: "micrometer",
-        orientation: { type: "anatomical", value: "right-to-left" },
+        orientation: { type: "anatomical", value: "inferior-to-superior" },
       },
       {
         name: "y",
@@ -231,10 +233,10 @@ Deno.test("fromNgffZarr with valid RFC-4 orientation - validation passes", async
         orientation: { type: "anatomical", value: "anterior-to-posterior" },
       },
       {
-        name: "z",
+        name: "x",
         type: "space",
         unit: "micrometer",
-        orientation: { type: "anatomical", value: "inferior-to-superior" },
+        orientation: { type: "anatomical", value: "right-to-left" },
       },
     ],
     datasets: [

--- a/ts/test/structural_validation_hcs_test.ts
+++ b/ts/test/structural_validation_hcs_test.ts
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+/**
+ * Unit tests for the OME-Zarr v0.4 HCS plate/well structural rules in
+ * `../src/utils/structural_validation.ts`.
+ *
+ * Paired pass/fail tests for the two plate/well rules added this phase:
+ *
+ * - {@link validatePlateWellIndexConsistency} -- a small 2x2 plate
+ *   ({@link buildValidPlate}) is mutated in exactly one field so a well's
+ *   recorded `rowIndex`/`columnIndex` (or its `path`) disagrees with the
+ *   row/column named in its `path`.
+ * - {@link validateWellAcquisition} -- a multi-acquisition plate whose well
+ *   image omits its `acquisition` reference.
+ *
+ * Each rule function is exercised directly so the violation is isolated to that
+ * rule, asserting the raised {@link ValidationError} carries the expected
+ * {@link SpecRule} and a populated `location`. The companion
+ * {@link validatePlate}/{@link validateWell} orchestrators are also checked for
+ * their strict/`schema_only` behavior.
+ *
+ * The rule identifiers and location strings are kept byte-for-byte identical to
+ * the package's Python implementation; this suite mirrors
+ * `py/test/test_structural_validation_hcs.py` so the two stay in lockstep.
+ */
+
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  SpecRule,
+  validatePlate,
+  validatePlateWellIndexConsistency,
+  validateWell,
+  validateWellAcquisition,
+  ValidationError,
+  ValidationLevel,
+} from "../src/utils/structural_validation.ts";
+import type { PlateMetadata, WellMetadata } from "../src/types/hcs.ts";
+
+/**
+ * Return a small, fully consistent 2x2 plate.
+ *
+ * Rows `A` (index 0) and `B` (index 1); columns `1` (index 0) and `2` (index 1);
+ * two wells whose `path` and recorded indices agree. This baseline passes the
+ * index-consistency rule, so each test mutates exactly one field of a fresh copy
+ * to trip it.
+ */
+function buildValidPlate(): PlateMetadata {
+  return {
+    columns: [{ name: "1" }, { name: "2" }],
+    rows: [{ name: "A" }, { name: "B" }],
+    wells: [
+      { path: "A/1", rowIndex: 0, columnIndex: 0 },
+      { path: "B/2", rowIndex: 1, columnIndex: 1 },
+    ],
+    version: "0.4",
+  };
+}
+
+/**
+ * Return {@link buildValidPlate} extended with two acquisitions.
+ *
+ * With more than one acquisition declared, every well image must reference one.
+ */
+function buildMultiAcquisitionPlate(): PlateMetadata {
+  const plate = buildValidPlate();
+  plate.acquisitions = [{ id: 0 }, { id: 1 }];
+  return plate;
+}
+
+/** Build well metadata carrying the given images. */
+function buildWell(images: WellMetadata["images"]): WellMetadata {
+  return { images, version: "0.4" };
+}
+
+/**
+ * Assert that `fn` throws a {@link ValidationError} carrying `expectedRule` and
+ * exactly `expectedLocation` (a non-empty, populated location).
+ */
+function assertRuleViolation(
+  fn: () => void,
+  expectedRule: SpecRule,
+  expectedLocation: string,
+): void {
+  const error = assertThrows(fn, ValidationError);
+  assertEquals(error.rule, expectedRule);
+  assertEquals(error.location, expectedLocation);
+}
+
+// ---------------------------------------------------------------------------
+// plate-row-index-consistency
+// ---------------------------------------------------------------------------
+
+Deno.test("validatePlateWellIndexConsistency - accepts a consistent plate", () => {
+  validatePlateWellIndexConsistency(buildValidPlate());
+});
+
+Deno.test(
+  "validatePlateWellIndexConsistency - rejects a mismatched or malformed well",
+  () => {
+    // Each mutation makes the first well's path disagree with its recorded
+    // indices (or be malformed); all trip the same rule at plate.wells[0].
+    const mutations: Array<(plate: PlateMetadata) => void> = [
+      // row-index-mismatch: path "A/1" => row "A" is index 0, but rowIndex
+      // claims 1.
+      (plate) => {
+        plate.wells[0].rowIndex = 1;
+      },
+      // column-index-mismatch: path "A/1" => column "1" is index 0, but
+      // columnIndex claims 1.
+      (plate) => {
+        plate.wells[0].columnIndex = 1;
+      },
+      // unknown-row: row "Z" is not declared in plate.rows.
+      (plate) => {
+        plate.wells[0] = { path: "Z/1", rowIndex: 0, columnIndex: 0 };
+      },
+      // unknown-column: column "9" is not declared in plate.columns.
+      (plate) => {
+        plate.wells[0] = { path: "A/9", rowIndex: 0, columnIndex: 0 };
+      },
+      // malformed-path: a path that is not "<row>/<column>".
+      (plate) => {
+        plate.wells[0] = { path: "A-1", rowIndex: 0, columnIndex: 0 };
+      },
+    ];
+    for (const mutate of mutations) {
+      const plate = buildValidPlate();
+      mutate(plate);
+      assertRuleViolation(
+        () => validatePlateWellIndexConsistency(plate),
+        SpecRule.PlateRowIndexConsistency,
+        "plate.wells[0]",
+      );
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// well-acquisition-missing
+// ---------------------------------------------------------------------------
+
+Deno.test("validateWellAcquisition - no-op for zero or one acquisition", () => {
+  // Zero or one acquisition imposes no requirement, so a missing reference is OK.
+  const well = buildWell([{ path: "0" }]);
+  validateWellAcquisition(buildValidPlate(), well); // acquisitions undefined
+  const single = buildValidPlate();
+  single.acquisitions = [{ id: 0 }];
+  validateWellAcquisition(single, well);
+});
+
+Deno.test(
+  "validateWellAcquisition - accepts multi-acquisition with references",
+  () => {
+    const plate = buildMultiAcquisitionPlate();
+    const well = buildWell([
+      { path: "0", acquisition: 0 },
+      { path: "1", acquisition: 1 },
+    ]);
+    validateWellAcquisition(plate, well);
+  },
+);
+
+Deno.test(
+  "validateWellAcquisition - rejects a missing acquisition reference",
+  () => {
+    const plate = buildMultiAcquisitionPlate();
+    // The second image omits its acquisition reference; the first is fine.
+    const well = buildWell([
+      { path: "0", acquisition: 0 },
+      { path: "1" },
+    ]);
+    assertRuleViolation(
+      () => validateWellAcquisition(plate, well),
+      SpecRule.WellAcquisitionMissing,
+      "well.images[1].acquisition",
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Orchestrators: validatePlate / validateWell
+// ---------------------------------------------------------------------------
+
+Deno.test("validatePlate - strict rejects; schema_only skips", () => {
+  const plate = buildValidPlate();
+  plate.wells[0].rowIndex = 1; // trip plate-row-index-consistency
+  assertRuleViolation(
+    () => validatePlate(plate), // strict by default
+    SpecRule.PlateRowIndexConsistency,
+    "plate.wells[0]",
+  );
+  // schema_only runs no structural rule, so the same plate passes.
+  validatePlate(plate, { level: ValidationLevel.SchemaOnly });
+});
+
+Deno.test("validateWell - strict rejects; schema_only skips", () => {
+  const plate = buildMultiAcquisitionPlate();
+  const well = buildWell([{ path: "0" }]); // missing acquisition reference
+  assertRuleViolation(
+    () => validateWell(plate, well), // strict by default
+    SpecRule.WellAcquisitionMissing,
+    "well.images[0].acquisition",
+  );
+  // schema_only runs no structural rule, so the same well passes.
+  validateWell(plate, well, { level: ValidationLevel.SchemaOnly });
+});

--- a/ts/test/structural_validation_orientation_test.ts
+++ b/ts/test/structural_validation_orientation_test.ts
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+/**
+ * Unit tests for the RFC 4 anatomical-orientation rule in
+ * `../src/utils/structural_validation.ts`.
+ *
+ * Pass/fail tests for {@link validateAxisOrientation}, the wrapper that surfaces
+ * the package's RFC 4 orientation checks through the unified
+ * {@link ValidationError} channel:
+ *
+ * - no spatial axis carries orientation -> no-op;
+ * - a fully specified, consistent orientation passes for both the serialized
+ *   `{ type, value }` form (the image read path) and the
+ *   {@link AnatomicalOrientationValues} enum form (the write path);
+ * - mixed orientation `type` -> {@link SpecRule.AxisOrientationConsistentType};
+ * - orientation on some but not all spatial axes ->
+ *   {@link SpecRule.AxisOrientationCompleteness}.
+ *
+ * Each failing case asserts the expected {@link SpecRule} and the
+ * `multiscales[0].axes` location. The identifiers and location strings are kept
+ * byte-for-byte identical to the package's Python implementation; this suite
+ * mirrors `py/test/test_structural_validation_orientation.py`.
+ */
+
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  SpecRule,
+  validateAxisOrientation,
+  ValidationError,
+} from "../src/utils/structural_validation.ts";
+import { validateRfc4Orientation } from "../src/utils/rfc4_validation.ts";
+import {
+  type Axis,
+  createScale,
+  type Metadata,
+} from "../src/types/zarr_metadata.ts";
+import { AnatomicalOrientationValues } from "../src/types/rfc4.ts";
+
+/** Canonical (z, y, x) LPS orientation values, in axis order. */
+const LPS_VALUES = [
+  "inferior-to-superior",
+  "anterior-to-posterior",
+  "right-to-left",
+] as const;
+
+/**
+ * Wrap three spatial axes carrying the given orientations in an otherwise-valid
+ * single-level metadata.
+ *
+ * {@link validateAxisOrientation} inspects only the axes, so the dataset's
+ * `scale` is a placeholder sized to the axis count. An `undefined` entry leaves
+ * that axis without an orientation.
+ */
+function metadataWithOrientations(
+  orientations: ReadonlyArray<Axis["orientation"]>,
+): Metadata {
+  const names = ["z", "y", "x"] as const;
+  return {
+    axes: names.map((name, i): Axis => {
+      const orientation = orientations[i];
+      return orientation === undefined
+        ? { name, type: "space", unit: undefined }
+        : { name, type: "space", unit: undefined, orientation };
+    }),
+    datasets: [
+      { path: "0", coordinateTransformations: [createScale([1.0, 1.0, 1.0])] },
+    ],
+    coordinateTransformations: undefined,
+    omero: undefined,
+    name: "image",
+    version: "0.4",
+  };
+}
+
+/**
+ * Assert that `fn` throws a {@link ValidationError} carrying `expectedRule` and
+ * exactly `expectedLocation` (a non-empty, populated location).
+ */
+function assertRuleViolation(
+  fn: () => void,
+  expectedRule: SpecRule,
+  expectedLocation: string,
+): void {
+  const error = assertThrows(fn, ValidationError);
+  assertEquals(error.rule, expectedRule);
+  assertEquals(error.location, expectedLocation);
+}
+
+Deno.test("validateAxisOrientation - no orientation is a no-op", () => {
+  // No spatial axis declares orientation: the rule returns without raising.
+  validateAxisOrientation(
+    metadataWithOrientations([undefined, undefined, undefined]),
+  );
+});
+
+Deno.test("validateAxisOrientation - accepts a consistent orientation", () => {
+  // The serialized `{ type, value }` form, as produced by the image read path.
+  validateAxisOrientation(
+    metadataWithOrientations(
+      LPS_VALUES.map((value) => ({ type: "anatomical", value })),
+    ),
+  );
+  // The AnatomicalOrientation enum form, as produced by the write path.
+  const enumValues = [
+    AnatomicalOrientationValues.InferiorToSuperior,
+    AnatomicalOrientationValues.AnteriorToPosterior,
+    AnatomicalOrientationValues.RightToLeft,
+  ];
+  validateAxisOrientation(
+    metadataWithOrientations(
+      enumValues.map((value) => ({ type: "anatomical", value })),
+    ),
+  );
+});
+
+Deno.test("validateAxisOrientation - rejects inconsistent orientation types", () => {
+  // The "y" axis declares a different orientation type than its siblings.
+  const metadata = metadataWithOrientations([
+    { type: "anatomical", value: LPS_VALUES[0] },
+    { type: "other", value: LPS_VALUES[1] },
+    { type: "anatomical", value: LPS_VALUES[2] },
+  ]);
+  assertRuleViolation(
+    () => validateAxisOrientation(metadata),
+    SpecRule.AxisOrientationConsistentType,
+    "multiscales[0].axes",
+  );
+});
+
+Deno.test("validateAxisOrientation - rejects incomplete orientation", () => {
+  // Orientation is defined for "z" and "y" but missing on "x".
+  const metadata = metadataWithOrientations([
+    { type: "anatomical", value: LPS_VALUES[0] },
+    { type: "anatomical", value: LPS_VALUES[1] },
+    undefined,
+  ]);
+  const error = assertThrows(
+    () => validateAxisOrientation(metadata),
+    ValidationError,
+  );
+  assertEquals(error.rule, SpecRule.AxisOrientationCompleteness);
+  assertEquals(error.location, "multiscales[0].axes");
+  // The axis-name lists render Python-style (`['z', 'y']`) so the surfaced
+  // RFC 4 message is byte-for-byte identical to the Python port (locks parity).
+  assertEquals(
+    error.message,
+    "Spec rule [axis-orientation-completeness] violated: RFC 4 requires " +
+      "that if orientation is defined for one spatial axis, it must be " +
+      "defined for all spatial axes. Axes with orientation: ['z', 'y'], " +
+      "axes without orientation: ['x']",
+  );
+});
+
+Deno.test(
+  "validateRfc4Orientation - messages carry the SpecRule mapping markers",
+  () => {
+    // validateAxisOrientation distinguishes the two RFC 4 orientation failures
+    // by searching this function's message text for "same type" and "all
+    // spatial axes". Those markers are a load-bearing contract: editing the
+    // wording away makes the wrapper silently rethrow a plain Error instead of
+    // the mapped ValidationError. Asserting them here fails loudly at the
+    // source. Mirrors the Python
+    // test_rfc4_orientation_messages_carry_mapping_markers.
+
+    // Mixed orientation type -> the marker the consistent-type rule maps.
+    assertThrows(
+      () =>
+        validateRfc4Orientation([
+          {
+            name: "y",
+            type: "space",
+            orientation: { type: "anatomical", value: "anterior-to-posterior" },
+          },
+          {
+            name: "x",
+            type: "space",
+            orientation: { type: "other", value: "right-to-left" },
+          },
+        ]),
+      Error,
+      "same type",
+    );
+
+    // Orientation on some but not all spatial axes -> the completeness marker.
+    assertThrows(
+      () =>
+        validateRfc4Orientation([
+          {
+            name: "y",
+            type: "space",
+            orientation: { type: "anatomical", value: "anterior-to-posterior" },
+          },
+          { name: "x", type: "space" },
+        ]),
+      Error,
+      "all spatial axes",
+    );
+  },
+);

--- a/ts/test/structural_validation_parity_test.ts
+++ b/ts/test/structural_validation_parity_test.ts
@@ -1,0 +1,341 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+/**
+ * Parity/manifest test locking the observable structural-validation surface.
+ *
+ * This is the Deno mirror of `py/test/test_structural_validation_parity.py`. It
+ * pins the *cross-language contract* shared by the TypeScript and Python ports:
+ * the exact set and ordering of {@link SpecRule} identifiers, their
+ * lower-kebab-case format, the fail-fast evaluation order of the
+ * image/multiscales orchestrator ({@link validateStructural}), and the
+ * {@link ValidationLevel} values and default. The two suites assert the same
+ * facts against the identical literal identifier list
+ * ({@link CANONICAL_SPEC_RULE_IDS}), so they are line-for-line comparable and
+ * any future drift between the ports fails CI.
+ *
+ * Adding, removing, renaming, or reordering a rule -- in either language -- must
+ * therefore be a deliberate edit to {@link CANONICAL_SPEC_RULE_IDS} (and its
+ * Python twin), not an accident.
+ *
+ * Two adaptations to TypeScript are unavoidable and are the only intentional
+ * departures from the Python twin:
+ *
+ * 1. Axis names. TypeScript constrains `Axis.name` to the closed `SupportedDims`
+ *    union (`"c" | "x" | "y" | "z" | "t"`), so the Python ordering test's
+ *    free-form helper names (`"c2"`, `"w"`) are replaced with valid members
+ *    (a repeated `"c"`, a `"y"`). The per-stage violations -- and therefore the
+ *    observed evaluation order -- are identical; only the labels differ.
+ * 2. The default level. Python pins it on a constructable options object
+ *    (`ValidateOptions().level == STRICT`); TypeScript's `ValidateOptions` is a
+ *    bare interface whose default is resolved inside {@link validateStructural}.
+ *    The same default is asserted observably instead (see the level test).
+ *
+ * The validation surface is imported from the package root (`../src/mod.ts`),
+ * mirroring the Python test's import from `ngff_zarr`; the metadata constructors
+ * come from the types module, mirroring its import from
+ * `ngff_zarr.v04.zarr_metadata`.
+ */
+
+import { assertEquals, assertMatch, assertThrows } from "@std/assert";
+import {
+  SpecRule,
+  validateStructural,
+  ValidationError,
+  ValidationLevel,
+} from "../src/mod.ts";
+import {
+  type Axis,
+  type AxisOrientation,
+  createScale,
+  createTranslation,
+  type Metadata,
+  type Omero,
+} from "../src/types/zarr_metadata.ts";
+
+// The locked rule manifest: every active OME-Zarr v0.4 structural rule, in
+// canonical declaration order. This identical literal list appears in the
+// Python twin so the two are directly comparable. The first nine entries are
+// the image/multiscales rules dispatched by validateStructural; the final two
+// are the HCS plate/well rules dispatched by validatePlate / validateWell.
+const CANONICAL_SPEC_RULE_IDS: string[] = [
+  "axis-count",
+  "axis-type",
+  "axis-order",
+  "scale-length-mismatch",
+  "global-coord-transform-after-per-level",
+  "dataset-order-highest-to-lowest",
+  "omero-channel-color-format",
+  "axis-orientation-consistent-type",
+  "axis-orientation-completeness",
+  "plate-row-index-consistency",
+  "well-acquisition-missing",
+];
+
+// The canonical fail-fast evaluation order of the image/multiscales
+// orchestrator (validateStructural). Each entry is the SpecRule the
+// orchestrator must raise when that rule -- and every rule after it -- is
+// violated at once. Two SpecRule values appear twice because two rule functions
+// share each: validateAxisOrder and validateSpatialAxisOrder both surface
+// AxisOrder (positions 3-4), and validatePerDatasetScaleCount and
+// validateTransformOrder both surface GlobalCoordTransformAfterPerLevel
+// (positions 5 and 7). The two HCS rules are absent: they are not part of the
+// image/multiscales orchestrator.
+const EXPECTED_EVALUATION_ORDER: SpecRule[] = [
+  SpecRule.AxisCount,
+  SpecRule.AxisType,
+  SpecRule.AxisOrder, // validateAxisOrder (class ordering)
+  SpecRule.AxisOrder, // validateSpatialAxisOrder (spatial suffix)
+  SpecRule.GlobalCoordTransformAfterPerLevel, // per-dataset scale count
+  SpecRule.ScaleLengthMismatch,
+  SpecRule.GlobalCoordTransformAfterPerLevel, // transform order
+  SpecRule.DatasetOrderHighestToLowest,
+  SpecRule.OmeroChannelColorFormat,
+  SpecRule.AxisOrientationConsistentType,
+];
+
+/** Build a single-channel OMERO block with the given channel `color`. */
+function makeOmero(color: string): Omero {
+  return {
+    channels: [
+      {
+        color,
+        window: { min: 0.0, max: 255.0, start: 0.0, end: 255.0 },
+      },
+    ],
+  };
+}
+
+/** Render an anatomical orientation as the record an image read produces. */
+function orientation(type: string, value: string): AxisOrientation {
+  return { type, value };
+}
+
+/**
+ * Return valid `[c, z, y, x]` axes whose orientations mix RFC 4 types.
+ *
+ * Every axis rule passes (channel-then-space class order, `(z, y, x)` spatial
+ * suffix, count 4), but the `y` axis declares orientation type `"other"` while
+ * `z` and `x` declare `"anatomical"` -- tripping
+ * {@link SpecRule.AxisOrientationConsistentType}, the last orchestrator rule,
+ * once every earlier rule is satisfied.
+ */
+function validAxesWithInconsistentOrientation(): Axis[] {
+  return [
+    { name: "c", type: "channel", unit: undefined },
+    {
+      name: "z",
+      type: "space",
+      unit: undefined,
+      orientation: orientation("anatomical", "inferior-to-superior"),
+    },
+    {
+      name: "y",
+      type: "space",
+      unit: undefined,
+      orientation: orientation("other", "anterior-to-posterior"),
+    },
+    {
+      name: "x",
+      type: "space",
+      unit: undefined,
+      orientation: orientation("anatomical", "right-to-left"),
+    },
+  ];
+}
+
+/** Run the orchestrator and return the single {@link SpecRule} it raises. */
+function firstViolatedRule(metadata: Metadata): SpecRule {
+  const error = assertThrows(
+    () => validateStructural(metadata),
+    ValidationError,
+  );
+  return error.rule;
+}
+
+// ---------------------------------------------------------------------------
+// Manifest: the locked SpecRule set, ordering, and format
+// ---------------------------------------------------------------------------
+
+Deno.test("SpecRule manifest is locked to the canonical identifier set", () => {
+  const ruleValues: string[] = Object.values(SpecRule);
+  // The exact set must equal the canonical manifest: adding, removing, or
+  // renaming a rule must be a deliberate edit to CANONICAL_SPEC_RULE_IDS.
+  assertEquals(new Set(ruleValues), new Set(CANONICAL_SPEC_RULE_IDS));
+  // Declaration order is part of the cross-language contract, so lock it too;
+  // this is the order the Python SpecRule enum must also declare.
+  assertEquals(ruleValues, CANONICAL_SPEC_RULE_IDS);
+  // No two members may share a value (which would create a silent alias).
+  assertEquals(new Set(ruleValues).size, CANONICAL_SPEC_RULE_IDS.length);
+});
+
+Deno.test("SpecRule identifiers are lower-kebab-case", () => {
+  // Each identifier is one or more lowercase ASCII words joined by hyphens.
+  // The anchored RegExp.test is the equivalent of Python's re.fullmatch with
+  // the identical pattern body `[a-z]+(-[a-z]+)*`.
+  const kebab = /^[a-z]+(-[a-z]+)*$/;
+  for (const value of Object.values(SpecRule)) {
+    assertMatch(value, kebab);
+  }
+});
+
+Deno.test("ValidationLevel manifest and default", () => {
+  const levelValues: string[] = Object.values(ValidationLevel);
+  // Exactly two levels, with the documented string values...
+  assertEquals(new Set(levelValues), new Set(["schema_only", "strict"]));
+  assertEquals(ValidationLevel.SchemaOnly, "schema_only");
+  assertEquals(ValidationLevel.Strict, "strict");
+  // ...and strict is the default applied when no options are passed. Python
+  // pins this on a constructable options object (ValidateOptions().level ==
+  // STRICT); TypeScript's ValidateOptions is a bare interface whose default is
+  // resolved inside validateStructural. Assert the identical default
+  // observably: omitting options (and an empty options object) runs the strict
+  // rules and rejects an invalid metadata, while schema_only skips them.
+  const invalid: Metadata = {
+    axes: [{ name: "x", type: "space", unit: undefined }],
+    datasets: [
+      { path: "0", coordinateTransformations: [createScale([1.0])] },
+    ],
+    coordinateTransformations: undefined,
+    omero: undefined,
+    name: "image",
+    version: "0.4",
+  };
+  assertThrows(() => validateStructural(invalid), ValidationError);
+  assertThrows(() => validateStructural(invalid, {}), ValidationError);
+  validateStructural(invalid, { level: ValidationLevel.SchemaOnly });
+});
+
+// ---------------------------------------------------------------------------
+// Orchestrator evaluation order (fail-fast, canonical spec-MUST order)
+// ---------------------------------------------------------------------------
+
+Deno.test("validateStructural evaluates rules in canonical order", () => {
+  // Starts from metadata that violates the earliest rule *and* every later
+  // rule, then repairs exactly one rule at a time. Because each repair leaves
+  // all later violations intact, the rule raised at each step proves that rule
+  // is evaluated strictly before every rule after it. The observed sequence
+  // must equal EXPECTED_EVALUATION_ORDER.
+  const observed: SpecRule[] = [];
+  const badOmero = makeOmero("xyz"); // OMERO violation (rule 9), until repaired
+
+  // Stage 1 -> AxisCount. Six axes simultaneously trip axis-type (two
+  // channels), axis-order (a space precedes a channel), and spatial-order
+  // (names are not the (z, y, x) suffix); axis-count is evaluated first.
+  const metadata: Metadata = {
+    axes: [
+      { name: "x", type: "space", unit: undefined },
+      { name: "c", type: "channel", unit: undefined },
+      { name: "c", type: "channel", unit: undefined },
+      { name: "t", type: "time", unit: undefined },
+      { name: "z", type: "space", unit: undefined },
+      { name: "y", type: "space", unit: undefined },
+    ],
+    datasets: [
+      {
+        path: "0",
+        coordinateTransformations: [
+          createScale([1.0, 1.0, 1.0]),
+          createScale([1.0, 1.0, 1.0]),
+        ],
+      },
+      {
+        path: "1",
+        coordinateTransformations: [createScale([1.0, 2.0, 2.0, 2.0])],
+      },
+    ],
+    coordinateTransformations: undefined,
+    omero: badOmero,
+    name: "image",
+    version: "0.4",
+  };
+  observed.push(firstViolatedRule(metadata));
+
+  // Stage 2 -> AxisType. Count fixed (5 axes); two channels remain, and a
+  // space still precedes a channel and the spatial names are still wrong.
+  metadata.axes = [
+    { name: "x", type: "space", unit: undefined },
+    { name: "c", type: "channel", unit: undefined },
+    { name: "c", type: "channel", unit: undefined },
+    { name: "z", type: "space", unit: undefined },
+    { name: "y", type: "space", unit: undefined },
+  ];
+  observed.push(firstViolatedRule(metadata));
+
+  // Stage 3 -> AxisOrder (class ordering). One channel now, but a space axis
+  // still precedes it; the spatial names are still not the (z, y, x) suffix.
+  metadata.axes = [
+    { name: "x", type: "space", unit: undefined },
+    { name: "c", type: "channel", unit: undefined },
+    { name: "z", type: "space", unit: undefined },
+    { name: "y", type: "space", unit: undefined },
+  ];
+  observed.push(firstViolatedRule(metadata));
+
+  // Stage 4 -> AxisOrder (spatial suffix). Class order fixed (channel first),
+  // but spatial names (x, z, y) are not the length-3 suffix of (z, y, x).
+  metadata.axes = [
+    { name: "c", type: "channel", unit: undefined },
+    { name: "x", type: "space", unit: undefined },
+    { name: "z", type: "space", unit: undefined },
+    { name: "y", type: "space", unit: undefined },
+  ];
+  observed.push(firstViolatedRule(metadata));
+
+  // Stage 5 -> per-dataset scale count. Axes are now fully valid [c, z, y, x]
+  // (with an inconsistent-orientation violation lurking as rule 10). Dataset 0
+  // still has two scales, so the per-dataset-scale-count rule fires.
+  metadata.axes = validAxesWithInconsistentOrientation();
+  observed.push(firstViolatedRule(metadata));
+
+  // Stage 6 -> ScaleLengthMismatch. Dataset 0 now has exactly one scale, but a
+  // length-3 vector against 4 axes; a scale-after-translation (rule 7) lurks.
+  metadata.datasets[0].coordinateTransformations = [
+    createTranslation([0.0, 0.0, 0.0]),
+    createScale([1.0, 1.0, 1.0]),
+  ];
+  observed.push(firstViolatedRule(metadata));
+
+  // Stage 7 -> transform order. Lengths fixed to 4; dataset 0's scale still
+  // follows a translation. Dataset 1 is made coarser-but-smaller so the
+  // dataset-order rule (8) lurks behind the transform-order violation.
+  metadata.datasets[0].coordinateTransformations = [
+    createTranslation([0.0, 0.0, 0.0, 0.0]),
+    createScale([1.0, 1.0, 1.0, 1.0]),
+  ];
+  metadata.datasets[1].coordinateTransformations = [
+    createScale([1.0, 0.5, 0.5, 0.5]),
+  ];
+  observed.push(firstViolatedRule(metadata));
+
+  // Stage 8 -> dataset order. Transform order fixed (scale before
+  // translation); dataset 1 is still coarser-but-smaller than dataset 0.
+  metadata.datasets[0].coordinateTransformations = [
+    createScale([1.0, 1.0, 1.0, 1.0]),
+    createTranslation([0.0, 0.0, 0.0, 0.0]),
+  ];
+  observed.push(firstViolatedRule(metadata));
+
+  // Stage 9 -> OMERO color. Dataset order fixed (level 1 coarser-larger); only
+  // the bad OMERO color and the orientation violation remain.
+  metadata.datasets[1].coordinateTransformations = [
+    createScale([1.0, 2.0, 2.0, 2.0]),
+  ];
+  observed.push(firstViolatedRule(metadata));
+
+  // Stage 10 -> orientation. OMERO color fixed; the y axis still declares a
+  // different orientation type than its spatial siblings.
+  metadata.omero = makeOmero("00FF88");
+  observed.push(firstViolatedRule(metadata));
+
+  assertEquals(observed, EXPECTED_EVALUATION_ORDER);
+
+  // Fully repaired: give the y axis a consistent orientation type and the
+  // orchestrator accepts the metadata with no violation.
+  metadata.axes[2] = {
+    name: "y",
+    type: "space",
+    unit: undefined,
+    orientation: orientation("anatomical", "anterior-to-posterior"),
+  };
+  validateStructural(metadata);
+});

--- a/ts/test/structural_validation_reader_test.ts
+++ b/ts/test/structural_validation_reader_test.ts
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+/**
+ * Reader-integration tests for strict structural validation on the image read
+ * path (`fromOmeZarr({ validate: true })` in `../src/io/from_ngff_zarr.ts`),
+ * exercising the wiring added this phase rather than the rule functions in
+ * isolation:
+ *
+ * - a valid in-memory v0.4 `(y, x)` two-level image passes both the schema and
+ *   structural layers under `{ validate: true }`;
+ * - an image whose `scale` vector length disagrees with the axis count -- a v0.4
+ *   MUST the JSON Schema cannot express -- is rejected under `{ validate: true }`
+ *   but reads silently under the default `{ validate: false }`.
+ *
+ * `fromOmeZarr` wraps any read failure in a generic `Error` whose message it
+ * preserves, so the structural {@link ValidationError} surfaces here as an
+ * `Error` carrying the `Spec rule [<rule>] violated: ...` text rather than as a
+ * `ValidationError` instance (the rule's type/`location` surface is covered by
+ * the direct unit tests in `structural_validation_test.ts`). This suite mirrors
+ * `py/test/test_structural_validation_reader.py`.
+ */
+
+import { assertExists, assertRejects, assertStringIncludes } from "@std/assert";
+import * as zarr from "zarrita";
+import { fromOmeZarr, type MemoryStore } from "../src/io/from_ngff_zarr.ts";
+import { fromZarrAttrsV04 } from "../src/utils/from_zarr_attrs.ts";
+import { SpecRule } from "../src/utils/structural_validation.ts";
+
+/**
+ * Build an in-memory v0.4 store from the given multiscales metadata, creating a
+ * small 2D zarr array for each declared dataset path so the reader can open
+ * every level.
+ */
+async function createImageStore(
+  multiscalesMetadata: Record<string, unknown>,
+): Promise<MemoryStore> {
+  const store: MemoryStore = new Map();
+  const root = zarr.root(store);
+  await zarr.create(root, {
+    attributes: { multiscales: [multiscalesMetadata] },
+  });
+  const datasets = multiscalesMetadata.datasets as Array<{ path: string }>;
+  for (const dataset of datasets) {
+    await zarr.create(root.resolve(dataset.path), {
+      shape: [16, 16],
+      data_type: "uint8",
+      chunk_shape: [16, 16],
+      fill_value: 0,
+    });
+  }
+  return store;
+}
+
+/**
+ * A valid v0.4 `(y, x)` two-level multiscales: finest level first, each level's
+ * `scale` length matching the two axes. Passes every structural rule.
+ */
+function buildValidImageMetadata(): Record<string, unknown> {
+  return {
+    version: "0.4",
+    name: "image",
+    axes: [
+      { name: "y", type: "space", unit: "micrometer" },
+      { name: "x", type: "space", unit: "micrometer" },
+    ],
+    datasets: [
+      {
+        path: "0",
+        coordinateTransformations: [{ type: "scale", scale: [1.0, 1.0] }],
+      },
+      {
+        path: "1",
+        coordinateTransformations: [{ type: "scale", scale: [2.0, 2.0] }],
+      },
+    ],
+  };
+}
+
+Deno.test("fromOmeZarr - valid v0.4 image passes strict validation", async () => {
+  const store = await createImageStore(buildValidImageMetadata());
+  const multiscales = await fromOmeZarr(store, { validate: true });
+  assertExists(multiscales);
+});
+
+Deno.test(
+  "fromOmeZarr - scale-length violation throws only when validating",
+  async () => {
+    // Corrupt the first level's scale to length 3 against the 2-axis (y, x)
+    // image. This stays schema-valid (the scale still has >= 2 entries) but
+    // violates the structural scale-length MUST.
+    const metadata = buildValidImageMetadata();
+    (metadata.datasets as Array<Record<string, unknown>>)[0]
+      .coordinateTransformations = [{ type: "scale", scale: [1.0, 1.0, 1.0] }];
+    const store = await createImageStore(metadata);
+
+    // validate: true surfaces the structural violation. fromOmeZarr re-wraps the
+    // ValidationError in a generic Error, preserving its message text.
+    const error = await assertRejects(
+      () => fromOmeZarr(store, { validate: true }),
+      Error,
+      SpecRule.ScaleLengthMismatch,
+    );
+    assertStringIncludes(error.message, "Spec rule [");
+
+    // The same corrupted store reads cleanly when validation is disabled.
+    const multiscales = await fromOmeZarr(store, { validate: false });
+    assertExists(multiscales);
+  },
+);
+
+Deno.test(
+  "fromZarrAttrsV04 - structural validation gates a multi-digit minor version",
+  async () => {
+    // A future "0.10" minor is newer than "0.4" and must still be validated.
+    // The gate compares version components as integers; a naive parseFloat
+    // would read "0.10" as 0.1 (< 0.4) and silently skip the structural pass.
+    // Exercised directly on fromZarrAttrsV04 because fromOmeZarr's version
+    // detection does not (yet) admit a "0.10" store.
+    const metadata = buildValidImageMetadata();
+    metadata.version = "0.10";
+    (metadata.datasets as Array<Record<string, unknown>>)[0]
+      .coordinateTransformations = [{ type: "scale", scale: [1.0, 1.0, 1.0] }];
+    const store = await createImageStore(metadata);
+
+    const error = await assertRejects(
+      () => fromZarrAttrsV04({ multiscales: [metadata] }, store, true),
+      Error,
+      SpecRule.ScaleLengthMismatch,
+    );
+    assertStringIncludes(error.message, "Spec rule [");
+
+    // A pre-0.4 minor is still skipped: structural rules predate that model.
+    metadata.version = "0.3";
+    const v03Store = await createImageStore(metadata);
+    const result = await fromZarrAttrsV04(
+      { multiscales: [metadata] },
+      v03Store,
+      true,
+    );
+    assertExists(result.metadata);
+  },
+);

--- a/ts/test/structural_validation_test.ts
+++ b/ts/test/structural_validation_test.ts
@@ -1,0 +1,438 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+/**
+ * Unit tests for the OME-Zarr v0.4 structural validation engine in
+ * `../src/utils/structural_validation.ts`.
+ *
+ * One paired pass/fail test per structural rule: a shared, fully valid
+ * `[c, y, x]` two-level baseline ({@link buildValidMetadata}) is mutated in
+ * exactly one field to trip exactly one rule, asserting the raised
+ * {@link ValidationError} carries the expected {@link SpecRule} and a populated
+ * `location`. Each rule function is exercised directly so the violation is
+ * isolated to that rule. Further tests cover the public surface (rule-identifier
+ * strings, level values, error formatting) and the orchestrator's fail-fast
+ * ordering and `schema_only` short-circuit.
+ *
+ * The rule identifiers and location strings are kept byte-for-byte identical to
+ * the package's Python implementation; this suite mirrors
+ * `py/test/test_structural_validation.py` so the two stay in lockstep.
+ */
+
+import { assertEquals, assertInstanceOf, assertThrows } from "@std/assert";
+import {
+  SpecRule,
+  validateAxisCount,
+  validateAxisOrder,
+  validateAxisType,
+  validateDatasetOrder,
+  validateOmeroColorHex,
+  validatePerDatasetScaleCount,
+  validateScaleLength,
+  validateSpatialAxisOrder,
+  validateStructural,
+  validateTransformOrder,
+  ValidationError,
+  ValidationLevel,
+} from "../src/utils/structural_validation.ts";
+import {
+  type Axis,
+  createScale,
+  createTranslation,
+  type Metadata,
+  type Omero,
+} from "../src/types/zarr_metadata.ts";
+
+/**
+ * Return a fully valid v0.4 `[c, y, x]` two-level multiscales metadata.
+ *
+ * Three axes (one channel, two space); two datasets, each with a single
+ * length-3 `scale`; the second level is coarser than the first. This baseline
+ * passes every structural rule, so each test mutates exactly one field of a
+ * fresh copy to trip exactly one rule.
+ */
+function buildValidMetadata(): Metadata {
+  return {
+    axes: [
+      { name: "c", type: "channel", unit: undefined },
+      { name: "y", type: "space", unit: undefined },
+      { name: "x", type: "space", unit: undefined },
+    ],
+    datasets: [
+      {
+        path: "0",
+        coordinateTransformations: [createScale([1.0, 1.0, 1.0])],
+      },
+      {
+        path: "1",
+        coordinateTransformations: [createScale([1.0, 2.0, 2.0])],
+      },
+    ],
+    coordinateTransformations: undefined,
+    omero: undefined,
+    name: "image",
+    version: "0.4",
+  };
+}
+
+/** Build a single-channel OMERO block with the given channel `color`. */
+function makeOmero(color: string): Omero {
+  return {
+    channels: [
+      {
+        color,
+        window: { min: 0.0, max: 255.0, start: 0.0, end: 255.0 },
+      },
+    ],
+  };
+}
+
+/**
+ * Assert that `fn` throws a {@link ValidationError} carrying `expectedRule` and
+ * exactly `expectedLocation` (a non-empty, populated location).
+ */
+function assertRuleViolation(
+  fn: () => void,
+  expectedRule: SpecRule,
+  expectedLocation: string,
+): void {
+  const error = assertThrows(fn, ValidationError);
+  assertEquals(error.rule, expectedRule);
+  assertEquals(error.location, expectedLocation);
+}
+
+// ---------------------------------------------------------------------------
+// Per-rule paired pass/fail tests
+// ---------------------------------------------------------------------------
+
+Deno.test("validateAxisCount - accepts the 3-axis baseline", () => {
+  validateAxisCount(buildValidMetadata());
+});
+
+Deno.test("validateAxisCount - rejects counts outside 2..5", () => {
+  for (const count of [1, 6]) {
+    const metadata = buildValidMetadata();
+    metadata.axes = Array.from(
+      { length: count },
+      (): Axis => ({ name: "x", type: "space", unit: undefined }),
+    );
+    assertRuleViolation(
+      () => validateAxisCount(metadata),
+      SpecRule.AxisCount,
+      "multiscales[0].axes",
+    );
+  }
+});
+
+Deno.test("validateAxisType - accepts a single channel axis", () => {
+  validateAxisType(buildValidMetadata());
+});
+
+Deno.test("validateAxisType - rejects two time or two channel axes", () => {
+  for (const [axisType, name] of [["time", "t"], ["channel", "c"]] as const) {
+    const metadata = buildValidMetadata();
+    metadata.axes = [
+      { name, type: axisType, unit: undefined },
+      { name, type: axisType, unit: undefined },
+      { name: "y", type: "space", unit: undefined },
+      { name: "x", type: "space", unit: undefined },
+    ];
+    assertRuleViolation(
+      () => validateAxisType(metadata),
+      SpecRule.AxisType,
+      "multiscales[0].axes",
+    );
+  }
+});
+
+Deno.test("validateAxisOrder - accepts channel-before-space order", () => {
+  validateAxisOrder(buildValidMetadata());
+});
+
+Deno.test("validateAxisOrder - rejects time after channel", () => {
+  // A 'time' axis after a 'channel' axis inverts the time < channel ranking.
+  const metadata = buildValidMetadata();
+  metadata.axes = [
+    { name: "c", type: "channel", unit: undefined },
+    { name: "t", type: "time", unit: undefined },
+    { name: "y", type: "space", unit: undefined },
+    { name: "x", type: "space", unit: undefined },
+  ];
+  assertRuleViolation(
+    () => validateAxisOrder(metadata),
+    SpecRule.AxisOrder,
+    "multiscales[0].axes[1]",
+  );
+});
+
+Deno.test("validateSpatialAxisOrder - accepts the (y, x) suffix", () => {
+  validateSpatialAxisOrder(buildValidMetadata());
+});
+
+Deno.test("validateSpatialAxisOrder - rejects bad suffix and too many", () => {
+  // (x, y) is not the (y, x) suffix of (z, y, x).
+  const suffixMismatch = buildValidMetadata();
+  suffixMismatch.axes = [
+    { name: "c", type: "channel", unit: undefined },
+    { name: "x", type: "space", unit: undefined },
+    { name: "y", type: "space", unit: undefined },
+  ];
+  assertRuleViolation(
+    () => validateSpatialAxisOrder(suffixMismatch),
+    SpecRule.AxisOrder,
+    "multiscales[0].axes[1]",
+  );
+
+  // Four space axes exceed the v0.4 maximum of three.
+  const tooMany = buildValidMetadata();
+  tooMany.axes = [
+    { name: "z", type: "space", unit: undefined },
+    { name: "z", type: "space", unit: undefined },
+    { name: "y", type: "space", unit: undefined },
+    { name: "x", type: "space", unit: undefined },
+  ];
+  assertRuleViolation(
+    () => validateSpatialAxisOrder(tooMany),
+    SpecRule.AxisOrder,
+    "multiscales[0].axes",
+  );
+});
+
+Deno.test("validatePerDatasetScaleCount - accepts one scale per level", () => {
+  validatePerDatasetScaleCount(buildValidMetadata());
+});
+
+Deno.test("validatePerDatasetScaleCount - rejects zero or two scales", () => {
+  const zeroScales = buildValidMetadata();
+  zeroScales.datasets[0].coordinateTransformations = [
+    createTranslation([0.0, 0.0, 0.0]),
+  ];
+  assertRuleViolation(
+    () => validatePerDatasetScaleCount(zeroScales),
+    SpecRule.GlobalCoordTransformAfterPerLevel,
+    "multiscales[0].datasets[0].coordinateTransformations",
+  );
+
+  const twoScales = buildValidMetadata();
+  twoScales.datasets[0].coordinateTransformations = [
+    createScale([1.0, 1.0, 1.0]),
+    createScale([1.0, 1.0, 1.0]),
+  ];
+  assertRuleViolation(
+    () => validatePerDatasetScaleCount(twoScales),
+    SpecRule.GlobalCoordTransformAfterPerLevel,
+    "multiscales[0].datasets[0].coordinateTransformations",
+  );
+});
+
+Deno.test("validateScaleLength - accepts matching global and per-level", () => {
+  const metadata = buildValidMetadata();
+  validateScaleLength(metadata);
+  // A correctly sized global scale (length == axis count) is also accepted.
+  metadata.coordinateTransformations = [createScale([1.0, 1.0, 1.0])];
+  validateScaleLength(metadata);
+});
+
+Deno.test("validateScaleLength - rejects a short per-dataset scale", () => {
+  // A length-2 dataset scale against 3 axes.
+  const metadata = buildValidMetadata();
+  metadata.datasets[0].coordinateTransformations = [createScale([1.0, 1.0])];
+  assertRuleViolation(
+    () => validateScaleLength(metadata),
+    SpecRule.ScaleLengthMismatch,
+    "multiscales[0].datasets[0].coordinateTransformations[0]",
+  );
+});
+
+Deno.test("validateScaleLength - rejects a short global scale", () => {
+  // A length-2 global scale against 3 axes.
+  const metadata = buildValidMetadata();
+  metadata.coordinateTransformations = [createScale([1.0, 1.0])];
+  assertRuleViolation(
+    () => validateScaleLength(metadata),
+    SpecRule.ScaleLengthMismatch,
+    "multiscales[0].coordinateTransformations[0]",
+  );
+});
+
+Deno.test("validateTransformOrder - accepts a scale then translation", () => {
+  const metadata = buildValidMetadata();
+  validateTransformOrder(metadata);
+  // A translation following its scale is valid.
+  metadata.datasets[0].coordinateTransformations = [
+    createScale([1.0, 1.0, 1.0]),
+    createTranslation([0.0, 0.0, 0.0]),
+  ];
+  validateTransformOrder(metadata);
+});
+
+Deno.test("validateTransformOrder - rejects a scale after a translation", () => {
+  // A scale after a translation: a translation must follow its scale.
+  const metadata = buildValidMetadata();
+  metadata.datasets[0].coordinateTransformations = [
+    createTranslation([0.0, 0.0, 0.0]),
+    createScale([1.0, 1.0, 1.0]),
+  ];
+  assertRuleViolation(
+    () => validateTransformOrder(metadata),
+    SpecRule.GlobalCoordTransformAfterPerLevel,
+    "multiscales[0].datasets[0].coordinateTransformations[1]",
+  );
+});
+
+Deno.test("validateDatasetOrder - accepts finest-to-coarsest order", () => {
+  validateDatasetOrder(buildValidMetadata());
+});
+
+Deno.test("validateDatasetOrder - rejects a finer scale at a coarser level", () => {
+  // The second (coarser) level has a finer spatial scale than the first.
+  const metadata = buildValidMetadata();
+  metadata.datasets[0].coordinateTransformations = [
+    createScale([1.0, 2.0, 2.0]),
+  ];
+  metadata.datasets[1].coordinateTransformations = [
+    createScale([1.0, 1.0, 1.0]),
+  ];
+  const error = assertThrows(
+    () => validateDatasetOrder(metadata),
+    ValidationError,
+  );
+  assertEquals(error.rule, SpecRule.DatasetOrderHighestToLowest);
+  assertEquals(error.location, "multiscales[0].datasets[1]");
+  // Whole-number float scales render Python-style (`1.0`, not `1`) so the
+  // message is byte-for-byte identical to the Python port (locks parity).
+  assertEquals(
+    error.message,
+    "Spec rule [dataset-order-highest-to-lowest] violated: Datasets must " +
+      "be ordered finest to coarsest; dataset 1 has spatial scale 1.0 on " +
+      "axis 'y', smaller than dataset 0's 2.0.",
+  );
+});
+
+Deno.test("validateOmeroColorHex - accepts absent omero and valid hex", () => {
+  validateOmeroColorHex(buildValidMetadata()); // omero is undefined
+  const metadata = buildValidMetadata();
+  metadata.omero = makeOmero("00FF88");
+  validateOmeroColorHex(metadata);
+});
+
+Deno.test("validateOmeroColorHex - rejects a non-hex channel color", () => {
+  const metadata = buildValidMetadata();
+  metadata.omero = makeOmero("xyz");
+  assertRuleViolation(
+    () => validateOmeroColorHex(metadata),
+    SpecRule.OmeroChannelColorFormat,
+    "multiscales[0].omero.channels[0].color",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Public-surface tests
+// ---------------------------------------------------------------------------
+
+Deno.test("SpecRule values are the exact kebab-case identifiers", () => {
+  assertEquals(SpecRule.AxisCount, "axis-count");
+  assertEquals(SpecRule.AxisType, "axis-type");
+  assertEquals(SpecRule.AxisOrder, "axis-order");
+  assertEquals(SpecRule.ScaleLengthMismatch, "scale-length-mismatch");
+  assertEquals(
+    SpecRule.GlobalCoordTransformAfterPerLevel,
+    "global-coord-transform-after-per-level",
+  );
+  assertEquals(
+    SpecRule.DatasetOrderHighestToLowest,
+    "dataset-order-highest-to-lowest",
+  );
+  assertEquals(SpecRule.OmeroChannelColorFormat, "omero-channel-color-format");
+});
+
+Deno.test("ValidationLevel values match the spec strings", () => {
+  assertEquals(ValidationLevel.Strict, "strict");
+  assertEquals(ValidationLevel.SchemaOnly, "schema_only");
+});
+
+Deno.test("ValidationError formats its message and carries rule/location", () => {
+  const error = new ValidationError(
+    SpecRule.AxisCount,
+    "found 6 axes",
+    "multiscales[0].axes",
+  );
+  assertInstanceOf(error, ValidationError);
+  assertInstanceOf(error, Error);
+  assertEquals(error.name, "ValidationError");
+  assertEquals(error.message, "Spec rule [axis-count] violated: found 6 axes");
+  assertEquals(error.rule, SpecRule.AxisCount);
+  assertEquals(error.location, "multiscales[0].axes");
+});
+
+// ---------------------------------------------------------------------------
+// Orchestrator tests
+// ---------------------------------------------------------------------------
+
+Deno.test("validateStructural - accepts the valid baseline", () => {
+  // Default options (strict) and an explicit strict both accept the baseline.
+  validateStructural(buildValidMetadata());
+  validateStructural(buildValidMetadata(), { level: ValidationLevel.Strict });
+});
+
+Deno.test("validateStructural - is fail-fast in canonical rule order", () => {
+  // Two independent violations: dataset-order (rule 8) and omero-color (9).
+  const metadata = buildValidMetadata();
+  metadata.datasets[0].coordinateTransformations = [
+    createScale([1.0, 2.0, 2.0]),
+  ];
+  metadata.datasets[1].coordinateTransformations = [
+    createScale([1.0, 1.0, 1.0]),
+  ];
+  metadata.omero = makeOmero("xyz");
+  const error = assertThrows(
+    () => validateStructural(metadata),
+    ValidationError,
+  );
+  // Fail-fast reports the earlier-ordered rule, not the OMERO color.
+  assertEquals(error.rule, SpecRule.DatasetOrderHighestToLowest);
+});
+
+Deno.test("validateStructural - default is strict; schema_only skips", () => {
+  // A single axis is a clear axis-count violation under strict...
+  const metadata = buildValidMetadata();
+  metadata.axes = [{ name: "x", type: "space", unit: undefined }];
+  // ...with no options the default strict level runs the rules and rejects it,
+  // confirming the documented default; an explicit strict rejects it too.
+  assertThrows(() => validateStructural(metadata), ValidationError);
+  assertThrows(
+    () => validateStructural(metadata, { level: ValidationLevel.Strict }),
+    ValidationError,
+  );
+  // ...but schema_only runs no structural rule, so the same metadata passes.
+  validateStructural(metadata, { level: ValidationLevel.SchemaOnly });
+});
+
+Deno.test("validateStructural - option defaults: strict, allowUnknownFields true", () => {
+  // ValidateOptions is a bare interface, so its documented defaults --
+  // { level: "strict", allowUnknownFields: true } -- are resolved inside
+  // validateStructural rather than on a constructable options object (unlike
+  // Python's ValidateOptions dataclass). Pin the defaults' observable contract:
+  // omitting options, an empty object, and either allowUnknownFields value all
+  // accept the valid baseline (the default level is strict and the baseline
+  // passes the strict rules).
+  validateStructural(buildValidMetadata());
+  validateStructural(buildValidMetadata(), {});
+  validateStructural(buildValidMetadata(), { allowUnknownFields: true });
+  validateStructural(buildValidMetadata(), { allowUnknownFields: false });
+
+  // allowUnknownFields is inert with respect to the structural rules (matching
+  // Python): a structural violation is still reported under its default-true
+  // value and when explicitly disabled.
+  const invalid = buildValidMetadata();
+  invalid.datasets[0].coordinateTransformations = [createScale([1.0, 1.0])];
+  assertRuleViolation(
+    () => validateStructural(invalid, { allowUnknownFields: true }),
+    SpecRule.ScaleLengthMismatch,
+    "multiscales[0].datasets[0].coordinateTransformations[0]",
+  );
+  assertRuleViolation(
+    () => validateStructural(invalid, { allowUnknownFields: false }),
+    SpecRule.ScaleLengthMismatch,
+    "multiscales[0].datasets[0].coordinateTransformations[0]",
+  );
+});


### PR DESCRIPTION
## Summary

Adds **structural validation** for the OME-Zarr **v0.4** specification to both the
Python (`ngff-zarr`) and TypeScript (`@fideus-labs/ngff-zarr`) ports. Structural
validation enforces the spec MUSTs that a JSON Schema *cannot* express, layered
conceptually on top of the existing schema (shape) validation. The two ports
expose an **identical, byte-stable** validation surface, locked in place by
cross-language parity tests.

Where schema validation answers *"is this shaped like OME-Zarr?"*, structural
validation answers *"does this obey the spec's structural invariants?"* — axis
counts/ordering, coordinate-transformation arity, finest→coarsest dataset
ordering, OMERO channel color format, RFC 4 anatomical orientation, and HCS
plate/well consistency.

## Motivation

A JSON Schema validates the *shape* of one node at a time. Several OME-Zarr v0.4
MUSTs are instead **cross-field, ordering, positional, conditional, or
cross-object** constraints that span multiple nodes and cannot be expressed as
schema keywords. For example:

- **Cross-field** — every `scale`/`translation` vector must have exactly one
  entry per axis (`len == len(axes)`); the target lives in a sibling array.
- **Ordering** — multiscale levels must run finest→coarsest, a pairwise
  comparison across adjacent `datasets`.
- **Positional** — exactly one `scale` per dataset, and a `translation` may
  never precede its `scale`.
- **Cross-object** — a well's `rowIndex` must match the position of its `path`
  row within `plate.rows`.
- **Conditional** — `well-acquisition-missing` only applies when the plate
  declares more than one acquisition.

These imperative, multi-node dependencies are implemented as ordinary code
layered on top of schema validation. The work spans both language
implementations so that anyone reading or writing OME-Zarr through either port
gets the same guarantees and the same diagnostics.

## What changed

### Validation rules — 11 canonical `SpecRule` identifiers

Stable lower-kebab-case identifiers, part of the observable surface, evaluated
**fail-fast in canonical spec-MUST order**:

| # | `SpecRule` | Enforces |
|---|------------|----------|
| 1 | `axis-count` | axis count within `2..=5` |
| 2 | `axis-type` | ≤1 `time` axis and ≤1 `channel` axis |
| 3 | `axis-order` | `time` → `channel` → `space`; space names a suffix of `(z, y, x)` |
| 4 | `scale-length-mismatch` | every `scale`/`translation` length == axis count |
| 5 | `global-coord-transform-after-per-level` | exactly one `scale` per dataset; `translation` follows its `scale` |
| 6 | `dataset-order-highest-to-lowest` | datasets ordered finest→coarsest on spatial scale |
| 7 | `omero-channel-color-format` | each OMERO channel `color` is exactly 6 hex digits |
| 8 | `axis-orientation-consistent-type` | RFC 4 anatomical orientation only on spatial axes |
| 9 | `axis-orientation-completeness` | RFC 4 orientation present on all/none of the spatial axes |
| 10 | `plate-row-index-consistency` | well `rowIndex`/`columnIndex` match the plate's row/column tables |
| 11 | `well-acquisition-missing` | well images declare an `acquisition` when the plate has >1 |

Rules 1–9 run on images/multiscales; rules 10–11 are dispatched by the separate
plate/well orchestrators.

### Public API (mirrored in both ports)

- **Three fail-fast orchestrators:** `validate_structural` / `validateStructural`
  (image + OMERO + RFC 4), `validate_plate` / `validatePlate`, and
  `validate_well` / `validateWell`.
- **`ValidationLevel`** — exactly `{ strict, schema_only }`, with **`strict` as
  the default**. `schema_only` skips all structural rules.
- **`ValidationError`** carrying `rule`, `message`, and an optional dotted
  `location` (e.g. `multiscales[0].datasets[2].coordinateTransformations[0]`).
  String form: `Spec rule [<rule>] violated: <message>`.
- **`SpecRule`** and **`ValidateOptions`** for callers that need the rule set or
  to choose a level.
- Exported from the Python package root (`py/ngff_zarr/__init__.py`) and from
  the TypeScript `mod.ts` / `browser-mod.ts`.

### Reader integration

Strict structural validation is wired into both readers so reads are validated
by default: the image/multiscales reader and the HCS plate/well reader in each
port (`py/ngff_zarr/hcs.py`, the Python reader, `ts/src/io/hcs.ts`, and the TS
reader).

### Cross-language parity guarantee

`py/test/test_structural_validation_parity.py` and
`ts/test/structural_validation_parity_test.ts` each pin a **byte-identical**
`CANONICAL_SPEC_RULE_IDS` manifest and assert set equality, declaration/iteration
order, no aliasing, lower-kebab-case format, the level set + default, and the
fail-fast evaluation order. Adding, renaming, reordering, or dropping a rule in
only one language breaks CI. TypeScript-only message-fidelity helpers (trailing
`.0` on whole-number scales, Python-style quoted name lists, `repr`-style
strings) keep `ValidationError` message bytes identical across the two ports.

### Tests, demos & docs

- Paired pass/fail unit tests per rule, plus dedicated HCS, RFC 4 orientation,
  and reader-integration suites in **both** languages.
- Runnable, network-free demo scripts: `py/examples/validate_structural_demo.py`
  and `ts/examples/validate_structural_demo.ts`.
- New documentation under `docs/validation/` (`overview`, `rule-reference`,
  `api`, `parity`), wired into `docs/conf.py`.

## Implementation notes

- **Pure stdlib at runtime (Python).** The rules operate on the already-parsed
  `Metadata`/`Plate`/`Well` dataclasses, with `Metadata` imported only under
  `TYPE_CHECKING`. They run even when the optional `[validate]` (jsonschema)
  extra is not installed — structural validation is independent of the schema
  validator.
- **Reuses existing predicates** rather than duplicating them — e.g.
  `OmeroChannel.validate_color()` for the OMERO color rule and the existing RFC 4
  orientation helpers.
- **Fail-fast:** the orchestrator raises on the first violated rule in canonical
  order; later rules do not run. The HCS rules are intentionally absent from the
  image orchestrator's order and handled by the plate/well orchestrators (whose
  acquisition declarations govern the well rules).
- **Out of scope (both levels):** no chunk/store-reading checks — the rules
  validate metadata only.

---

~5,100 lines added across 31 files (engine, readers, tests, demos, and docs) in
`py/` and `ts/`. No changes to existing public behavior beyond readers now
applying strict structural validation by default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in structural validation for OME‑Zarr v0.4 in Python and TypeScript (strict by default), including validate-on-read and optional HCS plate/well checks with lazy per-well validation; validation utilities now part of public APIs.

* **Documentation**
  * Added overview, API guide, rule reference, parity contract, examples; docs build now excludes validation artifacts.

* **Tests**
  * Extensive unit, integration, HCS, orientation, reader, example, and cross-language parity tests added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->