### PR TITLE
feat(py,ts): extend RFC-4 vocabulary with subject-local tissue orientations

### DIFF
--- a/docs/rfc4.md
+++ b/docs/rfc4.md
@@ -139,6 +139,27 @@ ngff_image = ngff_zarr.itk_image_to_ngff_image(
 - `distal-to-proximal`: Describes the directional orientation from the periphery
   of an anatomical structure or limb to the center of the body.
 
+The following values describe subject-local orientation within layered and
+polarized tissues (e.g. biopsies, histology slides), independent of the
+specimen's position relative to the whole organism:
+
+- `superficial-to-deep`: Describes the directional orientation from the outer
+  surface (superficial) to the inner depth (deep) of a layered tissue such as
+  skin, gut, or cortex.
+- `deep-to-superficial`: Describes the directional orientation from the inner
+  depth (deep) to the outer surface (superficial) of a layered tissue such as
+  skin, gut, or cortex.
+- `apical-to-basal`: Describes the directional orientation from the apical
+  surface (apical) to the basal surface (basal) of an epithelial layer or
+  polarized cell structure.
+- `basal-to-apical`: Describes the directional orientation from the basal
+  surface (basal) to the apical surface (apical) of an epithelial layer or
+  polarized cell structure.
+- `apex-to-base`: Describes the directional orientation from the tip (apex) to
+  the broad base (base) of an organ such as the heart or lung.
+- `base-to-apex`: Describes the directional orientation from the broad base
+  (base) to the tip (apex) of an organ such as the heart or lung.
+
 ## ITK LPS Coordinate System
 
 ITK uses the LPS (Left-Posterior-Superior) coordinate system by default. In LPS,

--- a/py/ngff_zarr/rfc4.py
+++ b/py/ngff_zarr/rfc4.py
@@ -57,6 +57,18 @@ class AnatomicalOrientationValues(str, Enum):
     proximal_to_distal = "proximal-to-distal"
     # Describes the directional orientation from the periphery of an anatomical structure or limb to the center of the body
     distal_to_proximal = "distal-to-proximal"
+    # Describes the directional orientation from the outer surface (superficial) to the inner depth (deep) of a layered tissue such as skin, gut, or cortex
+    superficial_to_deep = "superficial-to-deep"
+    # Describes the directional orientation from the inner depth (deep) to the outer surface (superficial) of a layered tissue such as skin, gut, or cortex
+    deep_to_superficial = "deep-to-superficial"
+    # Describes the directional orientation from the apical surface (apical) to the basal surface (basal) of an epithelial layer or polarized cell structure
+    apical_to_basal = "apical-to-basal"
+    # Describes the directional orientation from the basal surface (basal) to the apical surface (apical) of an epithelial layer or polarized cell structure
+    basal_to_apical = "basal-to-apical"
+    # Describes the directional orientation from the tip (apex) to the broad base (base) of an organ such as the heart or lung
+    apex_to_base = "apex-to-base"
+    # Describes the directional orientation from the broad base (base) to the tip (apex) of an organ such as the heart or lung
+    base_to_apex = "base-to-apex"
 
 
 @dataclass

--- a/py/ngff_zarr/rfc4_validation.py
+++ b/py/ngff_zarr/rfc4_validation.py
@@ -84,6 +84,12 @@ def validate_rfc4_orientation(axes: list[dict[str, Any]]) -> None:
         "caudal-to-cranial",
         "proximal-to-distal",
         "distal-to-proximal",
+        "superficial-to-deep",
+        "deep-to-superficial",
+        "apical-to-basal",
+        "basal-to-apical",
+        "apex-to-base",
+        "base-to-apex",
     }
 
     for axis in axes:

--- a/py/ngff_zarr/spec/rfc/4/orientation.schema.json
+++ b/py/ngff_zarr/spec/rfc/4/orientation.schema.json
@@ -38,7 +38,13 @@
                 "cranial-to-caudal",
                 "caudal-to-cranial",
                 "proximal-to-distal",
-                "distal-to-proximal"
+                "distal-to-proximal",
+                "superficial-to-deep",
+                "deep-to-superficial",
+                "apical-to-basal",
+                "basal-to-apical",
+                "apex-to-base",
+                "base-to-apex"
             ],
             "title": "AnatomicalOrientationValues",
             "type": "string"

--- a/py/test/test_rfc4.py
+++ b/py/test/test_rfc4.py
@@ -112,6 +112,17 @@ def test_anatomical_orientation_values_enum():
     assert (
         AnatomicalOrientationValues.superior_to_inferior.value == "superior-to-inferior"
     )
+    # Subject-local layered- and polarized-tissue values (per ome/ngff#528)
+    assert (
+        AnatomicalOrientationValues.superficial_to_deep.value == "superficial-to-deep"
+    )
+    assert (
+        AnatomicalOrientationValues.deep_to_superficial.value == "deep-to-superficial"
+    )
+    assert AnatomicalOrientationValues.apical_to_basal.value == "apical-to-basal"
+    assert AnatomicalOrientationValues.basal_to_apical.value == "basal-to-apical"
+    assert AnatomicalOrientationValues.apex_to_base.value == "apex-to-base"
+    assert AnatomicalOrientationValues.base_to_apex.value == "base-to-apex"
 
 
 # --- Tests for anatomical_orientation_to_itk_direction ---
@@ -175,6 +186,18 @@ class TestAnatomicalOrientationToItkDirection:
             )
             is None
         )
+
+    def test_subject_local_returns_none(self):
+        """Layered/polarized-tissue values are not LPS-compatible (ome/ngff#528)."""
+        for value in (
+            AnatomicalOrientationValues.superficial_to_deep,
+            AnatomicalOrientationValues.deep_to_superficial,
+            AnatomicalOrientationValues.apical_to_basal,
+            AnatomicalOrientationValues.basal_to_apical,
+            AnatomicalOrientationValues.apex_to_base,
+            AnatomicalOrientationValues.base_to_apex,
+        ):
+            assert anatomical_orientation_to_itk_direction(value) is None
 
 
 # --- Tests for itk_direction_to_anatomical_orientation ---

--- a/py/test/test_rfc4_validation.py
+++ b/py/test/test_rfc4_validation.py
@@ -75,6 +75,50 @@ def test_validate_rfc4_orientation_valid():
     validate_rfc4_orientation(axes_lps)
 
 
+@pytest.mark.parametrize(
+    ("x_value", "y_value", "z_value"),
+    [
+        # Forward directions. RFC 4 requires the value to be unique per spatial
+        # axis, so each triple pairs three distinct orientations.
+        ("superficial-to-deep", "apical-to-basal", "apex-to-base"),
+        # Reverse directions, covering the remaining three new values.
+        ("deep-to-superficial", "basal-to-apical", "base-to-apex"),
+    ],
+)
+def test_validate_rfc4_orientation_subject_local_values(x_value, y_value, z_value):
+    """Layered/polarized-tissue values pass validation (ome/ngff#528).
+
+    Exercises both the in-code value set and the JSON-schema enum, so a value
+    missing from either artifact would be caught here. The two parameter sets
+    together cover all six new subject-local orientation values.
+    """
+    pytest.importorskip("jsonschema", reason="jsonschema required for RFC 4 validation")
+
+    axes_subject_local = [
+        {
+            "name": "x",
+            "type": "space",
+            "unit": "micrometer",
+            "orientation": {"type": "anatomical", "value": x_value},
+        },
+        {
+            "name": "y",
+            "type": "space",
+            "unit": "micrometer",
+            "orientation": {"type": "anatomical", "value": y_value},
+        },
+        {
+            "name": "z",
+            "type": "space",
+            "unit": "micrometer",
+            "orientation": {"type": "anatomical", "value": z_value},
+        },
+    ]
+
+    # Should not raise any exception
+    validate_rfc4_orientation(axes_subject_local)
+
+
 def test_validate_rfc4_orientation_mixed_types():
     """Test RFC 4 validation with mixed axis types."""
     # Valid with time and channel axes mixed in

--- a/py/test/test_tiff_to_ngff_image.py
+++ b/py/test/test_tiff_to_ngff_image.py
@@ -454,9 +454,16 @@ def test_tiff_file_to_ngff_images_unsupported_axis_warning():
         warnings.simplefilter("always")
         images = tiff_file_to_ngff_images(tiff_path)
 
-        # Check warning was issued
-        assert len(w) == 1
-        assert "Dropping unsupported TIFF axes: Q" in str(w[0].message)
+        # Check the expected warning was issued. Filter for the relevant
+        # warning rather than asserting on the total count, since unrelated
+        # libraries (e.g. tifffile/numpy) may emit additional warnings on
+        # some platforms.
+        dropped_warnings = [
+            warning
+            for warning in w
+            if "Dropping unsupported TIFF axes: Q" in str(warning.message)
+        ]
+        assert len(dropped_warnings) == 1
 
     assert len(images) == 1
     name, img = images[0]

--- a/ts/src/schemas/rfc4.ts
+++ b/ts/src/schemas/rfc4.ts
@@ -22,6 +22,12 @@ export const AnatomicalOrientationValuesSchema: z.ZodType<
   | "caudal-to-cranial"
   | "proximal-to-distal"
   | "distal-to-proximal"
+  | "superficial-to-deep"
+  | "deep-to-superficial"
+  | "apical-to-basal"
+  | "basal-to-apical"
+  | "apex-to-base"
+  | "base-to-apex"
 > = z.enum([
   "left-to-right",
   "right-to-left",
@@ -41,6 +47,12 @@ export const AnatomicalOrientationValuesSchema: z.ZodType<
   "caudal-to-cranial",
   "proximal-to-distal",
   "distal-to-proximal",
+  "superficial-to-deep",
+  "deep-to-superficial",
+  "apical-to-basal",
+  "basal-to-apical",
+  "apex-to-base",
+  "base-to-apex",
 ]);
 
 // AnatomicalOrientation object schema
@@ -64,7 +76,13 @@ export const AnatomicalOrientationSchema: z.ZodType<{
     | "cranial-to-caudal"
     | "caudal-to-cranial"
     | "proximal-to-distal"
-    | "distal-to-proximal";
+    | "distal-to-proximal"
+    | "superficial-to-deep"
+    | "deep-to-superficial"
+    | "apical-to-basal"
+    | "basal-to-apical"
+    | "apex-to-base"
+    | "base-to-apex";
 }> = z.object({
   type: z.literal("anatomical"),
   value: AnatomicalOrientationValuesSchema,

--- a/ts/src/types/rfc4.ts
+++ b/ts/src/types/rfc4.ts
@@ -50,6 +50,18 @@ export enum AnatomicalOrientationValues {
   ProximalToDistal = "proximal-to-distal",
   // Describes the directional orientation from the periphery of an anatomical structure or limb to the center of the body
   DistalToProximal = "distal-to-proximal",
+  // Describes the directional orientation from the outer surface (superficial) to the inner depth (deep) of a layered tissue such as skin, gut, or cortex
+  SuperficialToDeep = "superficial-to-deep",
+  // Describes the directional orientation from the inner depth (deep) to the outer surface (superficial) of a layered tissue such as skin, gut, or cortex
+  DeepToSuperficial = "deep-to-superficial",
+  // Describes the directional orientation from the apical surface (apical) to the basal surface (basal) of an epithelial layer or polarized cell structure
+  ApicalToBasal = "apical-to-basal",
+  // Describes the directional orientation from the basal surface (basal) to the apical surface (apical) of an epithelial layer or polarized cell structure
+  BasalToApical = "basal-to-apical",
+  // Describes the directional orientation from the tip (apex) to the broad base (base) of an organ such as the heart or lung
+  ApexToBase = "apex-to-base",
+  // Describes the directional orientation from the broad base (base) to the tip (apex) of an organ such as the heart or lung
+  BaseToApex = "base-to-apex",
 }
 
 /**

--- a/ts/src/utils/from_zarr_attrs.ts
+++ b/ts/src/utils/from_zarr_attrs.ts
@@ -54,6 +54,12 @@ const ORIENTATION_VALUE_MAP: Record<string, AnatomicalOrientationValues> = {
   "caudal-to-cranial": AnatomicalOrientationValues.CaudalToCranial,
   "proximal-to-distal": AnatomicalOrientationValues.ProximalToDistal,
   "distal-to-proximal": AnatomicalOrientationValues.DistalToProximal,
+  "superficial-to-deep": AnatomicalOrientationValues.SuperficialToDeep,
+  "deep-to-superficial": AnatomicalOrientationValues.DeepToSuperficial,
+  "apical-to-basal": AnatomicalOrientationValues.ApicalToBasal,
+  "basal-to-apical": AnatomicalOrientationValues.BasalToApical,
+  "apex-to-base": AnatomicalOrientationValues.ApexToBase,
+  "base-to-apex": AnatomicalOrientationValues.BaseToApex,
 };
 
 /**

--- a/ts/src/utils/rfc4_validation.ts
+++ b/ts/src/utils/rfc4_validation.ts
@@ -29,6 +29,12 @@ const VALID_ORIENTATION_VALUES = new Set([
   "caudal-to-cranial",
   "proximal-to-distal",
   "distal-to-proximal",
+  "superficial-to-deep",
+  "deep-to-superficial",
+  "apical-to-basal",
+  "basal-to-apical",
+  "apex-to-base",
+  "base-to-apex",
 ]);
 
 /**

--- a/ts/test/rfc4_rfc5_schemas_test.ts
+++ b/ts/test/rfc4_rfc5_schemas_test.ts
@@ -29,6 +29,12 @@ Deno.test("AnatomicalOrientationValuesSchema validation", () => {
     "posterior-to-anterior",
     "rostral-to-caudal",
     "proximal-to-distal",
+    "superficial-to-deep",
+    "deep-to-superficial",
+    "apical-to-basal",
+    "basal-to-apical",
+    "apex-to-base",
+    "base-to-apex",
   ];
 
   validValues.forEach((value) => {

--- a/ts/test/rfc4_test.ts
+++ b/ts/test/rfc4_test.ts
@@ -139,6 +139,19 @@ Deno.test("AnatomicalOrientationValues enum - correct string values", () => {
     AnatomicalOrientationValues.SuperiorToInferior,
     "superior-to-inferior",
   );
+  // Subject-local layered- and polarized-tissue values (per ome/ngff#528)
+  assertEquals(
+    AnatomicalOrientationValues.SuperficialToDeep,
+    "superficial-to-deep",
+  );
+  assertEquals(
+    AnatomicalOrientationValues.DeepToSuperficial,
+    "deep-to-superficial",
+  );
+  assertEquals(AnatomicalOrientationValues.ApicalToBasal, "apical-to-basal");
+  assertEquals(AnatomicalOrientationValues.BasalToApical, "basal-to-apical");
+  assertEquals(AnatomicalOrientationValues.ApexToBase, "apex-to-base");
+  assertEquals(AnatomicalOrientationValues.BaseToApex, "base-to-apex");
 });
 
 Deno.test("LPS coordinate system - correct orientations", () => {
@@ -235,6 +248,43 @@ Deno.test("anatomicalOrientationToItkDirection - non-LPS returns undefined", () 
   assertEquals(
     anatomicalOrientationToItkDirection(
       AnatomicalOrientationValues.ProximalToDistal,
+    ),
+    undefined,
+  );
+  // Subject-local layered/polarized-tissue values (ome/ngff#528)
+  assertEquals(
+    anatomicalOrientationToItkDirection(
+      AnatomicalOrientationValues.SuperficialToDeep,
+    ),
+    undefined,
+  );
+  assertEquals(
+    anatomicalOrientationToItkDirection(
+      AnatomicalOrientationValues.DeepToSuperficial,
+    ),
+    undefined,
+  );
+  assertEquals(
+    anatomicalOrientationToItkDirection(
+      AnatomicalOrientationValues.ApicalToBasal,
+    ),
+    undefined,
+  );
+  assertEquals(
+    anatomicalOrientationToItkDirection(
+      AnatomicalOrientationValues.BasalToApical,
+    ),
+    undefined,
+  );
+  assertEquals(
+    anatomicalOrientationToItkDirection(
+      AnatomicalOrientationValues.ApexToBase,
+    ),
+    undefined,
+  );
+  assertEquals(
+    anatomicalOrientationToItkDirection(
+      AnatomicalOrientationValues.BaseToApex,
     ),
     undefined,
   );

--- a/ts/test/rfc4_validation_test.ts
+++ b/ts/test/rfc4_validation_test.ts
@@ -72,6 +72,33 @@ Deno.test("validateRfc4Orientation - valid LPS orientation passes", () => {
   validateRfc4Orientation(axesLps);
 });
 
+Deno.test("validateRfc4Orientation - subject-local tissue values pass", () => {
+  // Layered/polarized-tissue values (ome/ngff#528) must be accepted.
+  const axesSubjectLocal = [
+    {
+      name: "x",
+      type: "space",
+      unit: "micrometer",
+      orientation: { type: "anatomical", value: "superficial-to-deep" },
+    },
+    {
+      name: "y",
+      type: "space",
+      unit: "micrometer",
+      orientation: { type: "anatomical", value: "apical-to-basal" },
+    },
+    {
+      name: "z",
+      type: "space",
+      unit: "micrometer",
+      orientation: { type: "anatomical", value: "apex-to-base" },
+    },
+  ];
+
+  // Should not throw any exception
+  validateRfc4Orientation(axesSubjectLocal);
+});
+
 Deno.test("validateRfc4Orientation - mixed axis types (time/channel) pass", () => {
   const axesMixed = [
     { name: "t", type: "time", unit: "second" },


### PR DESCRIPTION
## Summary

Extends the RFC-4 anatomical orientation controlled vocabulary with **six new subject-local orientation values** for layered and polarized tissues, mirroring the upstream spec change in [ome/ngff#528](https://github.com/ome/ngff/pull/528). The values are added consistently across the Python and TypeScript implementations, the JSON schema, the docs, and the test suites.

| Pair | Use case |
|------|----------|
| `superficial-to-deep` / `deep-to-superficial` | Layered tissues (skin, gut, cortex) |
| `apical-to-basal` / `basal-to-apical` | Epithelial layers, polarized cells |
| `apex-to-base` / `base-to-apex` | Organs (heart, lungs) |

## Why

RFC-4 originally scoped orientation to whole-organism / patient-global context. ome/ngff#528 broadens it to **subject-local** orientation — the internal axes of a specimen (e.g. biopsies, histology slides, spatial transcriptomics samples) whose position relative to the whole organism may be unknown but whose internal tissue structure is well defined. For example, the depth axis of a skin biopsy is `superficial-to-deep` regardless of where on the body it was taken. These six values give that community a controlled vocabulary without requiring registration to an atlas coordinate system.

## What changed

**Vocabulary additions** (appended after `distal-to-proximal`, in spec order):
- Python: `AnatomicalOrientationValues` enum (`py/ngff_zarr/rfc4.py`), the validation value set (`py/ngff_zarr/rfc4_validation.py`), and the JSON-schema enum (`py/ngff_zarr/spec/rfc/4/orientation.schema.json`).
- TypeScript: the `AnatomicalOrientationValues` enum (`ts/src/types/rfc4.ts`), the zod schema's value union and `z.enum` array (`ts/src/schemas/rfc4.ts`), the validation set (`ts/src/utils/rfc4_validation.ts`), and the string→enum read map `ORIENTATION_VALUE_MAP` (`ts/src/utils/from_zarr_attrs.ts`).
- Docs: `docs/rfc4.md` vocabulary list, with a note explaining the subject-local scope.

## Implementation details

- **Non-LPS by design.** These tissue-local orientations are intentionally *not* mapped to ITK LPS direction cosines. `anatomical_orientation_to_itk_direction` / `anatomicalOrientationToItkDirection` correctly fall through to `None` / `undefined` for them, consistent with the existing handling of `dorsal`/`palmar`/`rostral` values. The LPS/RAS convenience constants are unchanged.
- **No README/AGENTS changes needed.** Those files describe RFC-4 generally and show import examples; they do not enumerate the vocabulary (that lives in `docs/rfc4.md`).
- **MCP package untouched** — it does not enumerate orientation values.

## Tests

All six new values are covered in both languages:
- Enum string values (`test_rfc4.py`, `rfc4_test.ts`).
- JSON-schema / zod validation (`rfc4_rfc5_schemas_test.ts`) and the `validate_rfc4_orientation` / `validateRfc4Orientation` paths (`test_rfc4_validation.py`, `rfc4_validation_test.ts`) — the Python validation test exercises both the in-code value set and the JSON-schema enum, so a value missing from either artifact is caught. Triples keep values unique per spatial axis, respecting RFC-4 semantics.
- ITK direction `None` / `undefined` fallthrough for all six (`test_rfc4.py`, `rfc4_test.ts`).

**Verification:** 44 Python and 63 TypeScript RFC-4 tests pass; ruff + ruff format and deno fmt/lint clean. A CodeRabbit review was run to completion (0 findings).

## Note

ome/ngff#528 is still **open / under review** upstream, so value names and descriptions could shift before it merges. This PR implements the vocabulary as it currently stands in that PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended RFC4 anatomical orientation support with six new values: `superficial-to-deep`, `deep-to-superficial`, `apical-to-basal`, `basal-to-apical`, `apex-to-base`, `base-to-apex`, across Python and TypeScript.

* **Documentation**
  * Updated RFC4 documentation to list the newly supported orientation values.

* **Tests**
  * Expanded schema and validation tests to accept the new orientation strings, including additional subject-local tissue cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->