### PR TITLE
feat: OME-Zarr v0.5 structural validation (Python + TypeScript)

### DIFF
--- a/docs/validation/overview.md
+++ b/docs/validation/overview.md
@@ -17,13 +17,15 @@ related:
 
 # Structural Validation Overview
 
-**Structural validation** enforces the OME-Zarr v0.4 specification MUSTs that a
+**Structural validation** enforces the OME-Zarr specification MUSTs that a
 JSON Schema cannot express. It is layered conceptually on top of *schema*
 validation: where schema validation answers "is this shaped like OME-Zarr?",
 structural validation answers "does this obey the spec's structural
 invariants?" — axis counts and ordering, coordinate-transformation arity,
 finest-to-coarsest dataset ordering, OMERO channel color format, RFC 4
-anatomical orientation, and HCS plate/well consistency.
+anatomical orientation, and HCS plate/well consistency. Most rules enforce v0.4
+MUSTs; two additional rules (`zarr-format`, `ome-namespace`) enforce the v0.5
+`ome`-namespace and Zarr v3 store conventions and fire only for v0.5 metadata.
 
 The rules operate on the already-parsed metadata object (the `Metadata`,
 `Plate`, and `Well` dataclasses in Python; their equivalents in TypeScript), so
@@ -59,6 +61,10 @@ conditional constraints that span multiple nodes:
   `plate.rows`, a derived lookup across objects.
 - **Conditional** — `well-acquisition-missing` only applies when the plate
   declares more than one acquisition.
+- **Store-format / namespacing** — `zarr-format` and `ome-namespace` enforce
+  v0.5 conventions (a Zarr v3 store, and metadata wrapped under the top-level
+  `ome` namespace rather than duplicated into each multiscale entry) that the
+  per-document schema does not capture.
 
 These imperative, multi-node dependencies are exactly why the rules are
 implemented as ordinary code layered on top of schema validation, rather than

--- a/docs/validation/parity.md
+++ b/docs/validation/parity.md
@@ -20,9 +20,9 @@ related:
 # Cross-Language Parity Guarantee
 
 The Python and TypeScript ports expose an **identical, byte-stable**
-structural-validation surface for OME-Zarr v0.4. This page describes the
-contract and the tests that lock it. For the rules, see [[rule-reference]]; for
-usage, see [[api]].
+structural-validation surface for OME-Zarr v0.4 and v0.5. This page describes
+the contract and the tests that lock it. For the rules, see [[rule-reference]];
+for usage, see [[api]].
 
 ## The contract
 
@@ -59,11 +59,15 @@ The canonical `SpecRule` set, in evaluation order:
 7. `omero-channel-color-format`
 8. `axis-orientation-consistent-type`
 9. `axis-orientation-completeness`
-10. `plate-row-index-consistency`
-11. `well-acquisition-missing`
+10. `zarr-format`
+11. `ome-namespace`
+12. `plate-row-index-consistency`
+13. `well-acquisition-missing`
 
-Each suite pins this list as a `CANONICAL_SPEC_RULE_IDS` literal — byte-identical
-between the two languages so the tests are line-for-line comparable.
+Entries 10–11 are the v0.5 namespacing rules; they fire only for v0.5 metadata
+and are inert for v0.4. Each suite pins this list as a `CANONICAL_SPEC_RULE_IDS`
+literal — byte-identical between the two languages so the tests are
+line-for-line comparable.
 
 ## The parity tests
 
@@ -86,16 +90,19 @@ Each suite independently locks:
   `/^[a-z]+(-[a-z]+)*$/` in TypeScript).
 - **Level set and default** — `ValidationLevel` has exactly `schema_only` and
   `strict`, and `strict` is the default.
-- **Fail-fast evaluation order** — driving the orchestrator with metadata that
-  violates the earliest rule plus every later rule, then repairing exactly one
-  rule per stage across ten stages, the rule raised at each stage builds a
+- **Fail-fast evaluation order** — driving the orchestrator with v0.4 metadata
+  that violates the earliest rule plus every later rule, then repairing exactly
+  one rule per stage across ten stages, the rule raised at each stage builds a
   sequence equal to a shared `EXPECTED_EVALUATION_ORDER`. This proves every rule
   is evaluated strictly before all rules after it; a final, fully-repaired
   metadata is accepted with no violation.
 
-The two HCS rules (`plate-row-index-consistency`, `well-acquisition-missing`)
-are deliberately absent from the image orchestrator's evaluation order; they are
-dispatched by the separate plate/well orchestrators (see [[rule-reference]]).
+The two v0.5 namespacing rules (`zarr-format`, `ome-namespace`) run last in the
+image orchestrator but are inert for the v0.4 metadata the order test exercises,
+so they never appear in `EXPECTED_EVALUATION_ORDER`. The two HCS rules
+(`plate-row-index-consistency`, `well-acquisition-missing`) are deliberately
+absent from the image orchestrator's evaluation order; they are dispatched by
+the separate plate/well orchestrators (see [[rule-reference]]).
 
 ## Sanctioned TypeScript-only adaptations
 

--- a/docs/validation/rule-reference.md
+++ b/docs/validation/rule-reference.md
@@ -18,11 +18,13 @@ related:
 
 # Structural Validation Rule Reference
 
-This is the canonical table of OME-Zarr v0.4 structural rules. Each rule has a
+This is the canonical table of OME-Zarr structural rules. Each rule has a
 stable, lower-kebab-case identifier (the `SpecRule` value) that is identical
-across the Python and TypeScript ports — see [[parity]] for the guarantee. For
-the conceptual background and the two validation levels, see [[overview]]; for
-invocation, see [[api]].
+across the Python and TypeScript ports — see [[parity]] for the guarantee. Most
+rules enforce OME-Zarr v0.4 MUSTs; the two v0.5 namespacing rules
+(`zarr-format`, `ome-namespace`) fire only for v0.5 metadata and are inert (a
+no-op) for v0.4. For the conceptual background and the two validation levels,
+see [[overview]]; for invocation, see [[api]].
 
 Location strings are dotted-segment, JSON-Pointer-style identifiers of the
 offending metadata node, emitted byte-for-byte identically in both languages.
@@ -32,19 +34,21 @@ offending metadata node, emitted byte-for-byte identically in both languages.
 The rules are listed in canonical spec-MUST evaluation order — the same order
 the `SpecRule` enum declares them and the orchestrators evaluate them.
 
-| #  | Identifier | Applies to | What it checks | Spec MUST (v0.4) | Example location |
-| -- | ---------- | ---------- | -------------- | ---------------- | ---------------- |
-| 1  | `axis-count` | images/multiscales | The number of axes is within the closed range 2–5. | Between 2 and 5 axes, inclusive. | `multiscales[0].axes` |
-| 2  | `axis-type` | images/multiscales | At most one `time` axis and at most one `channel` axis. | ≤ 1 time axis and ≤ 1 channel axis. | `multiscales[0].axes` |
-| 3  | `axis-order` | images/multiscales | Axes ordered time → channel → space; at most 3 space axes; the space-axis names are the length-N suffix of `(z, y, x)`. | Axes ordered time, then channel, then space, with spatial names a suffix of `(z, y, x)`. | `multiscales[0].axes[1]` |
-| 4  | `scale-length-mismatch` | images/multiscales | Every `scale`/`translation` vector length equals the axis count, for both the global and per-dataset transforms. | Each scale/translation has exactly one entry per axis. | `multiscales[0].datasets[2].coordinateTransformations[0]` |
-| 5  | `global-coord-transform-after-per-level` | images/multiscales | Exactly one `scale` per dataset, and a `translation` must follow — not precede — its `scale`. | Each dataset defines exactly one scale; a translation follows its scale. | `multiscales[0].datasets[1].coordinateTransformations` |
-| 6  | `dataset-order-highest-to-lowest` | images/multiscales | Datasets ordered finest → coarsest; the spatial scale must not decrease as the level index rises. | Multiscale datasets ordered from highest to lowest resolution. | `multiscales[0].datasets[2]` |
-| 7  | `omero-channel-color-format` | OMERO | Each OMERO channel `color` is exactly six hexadecimal digits (RGB). | OMERO channel color is 6 hex digits. | `multiscales[0].omero.channels[0].color` |
+| #  | Identifier | Applies to | What it checks | Spec MUST | Example location |
+| -- | ---------- | ---------- | -------------- | --------- | ---------------- |
+| 1  | `axis-count` | images/multiscales | The number of axes is within the closed range 2–5. | v0.4: between 2 and 5 axes, inclusive. | `multiscales[0].axes` |
+| 2  | `axis-type` | images/multiscales | At most one `time` axis and at most one `channel` axis. | v0.4: ≤ 1 time axis and ≤ 1 channel axis. | `multiscales[0].axes` |
+| 3  | `axis-order` | images/multiscales | Axes ordered time → channel → space; at most 3 space axes; the space-axis names are the length-N suffix of `(z, y, x)`. | v0.4: axes ordered time, then channel, then space, with spatial names a suffix of `(z, y, x)`. | `multiscales[0].axes[1]` |
+| 4  | `scale-length-mismatch` | images/multiscales | Every `scale`/`translation` vector length equals the axis count, for both the global and per-dataset transforms. | v0.4: each scale/translation has exactly one entry per axis. | `multiscales[0].datasets[2].coordinateTransformations[0]` |
+| 5  | `global-coord-transform-after-per-level` | images/multiscales | Exactly one `scale` per dataset, and a `translation` must follow — not precede — its `scale`. | v0.4: each dataset defines exactly one scale; a translation follows its scale. | `multiscales[0].datasets[1].coordinateTransformations` |
+| 6  | `dataset-order-highest-to-lowest` | images/multiscales | Datasets ordered finest → coarsest; the spatial scale must not decrease as the level index rises. | v0.4: multiscale datasets ordered from highest to lowest resolution. | `multiscales[0].datasets[2]` |
+| 7  | `omero-channel-color-format` | OMERO | Each OMERO channel `color` is exactly six hexadecimal digits (RGB). | v0.4: OMERO channel color is 6 hex digits. | `multiscales[0].omero.channels[0].color` |
 | 8  | `axis-orientation-consistent-type` | RFC 4 orientation | All spatial-axis anatomical orientations share one `type`. | RFC 4: all spatial-axis orientations share one type. | `multiscales[0].axes` |
 | 9  | `axis-orientation-completeness` | RFC 4 orientation | If any spatial axis declares an orientation, all spatial axes must. | RFC 4: orientation is all-or-none across spatial axes. | `multiscales[0].axes` |
-| 10 | `plate-row-index-consistency` | HCS plate | Each well's `path` is `<row>/<column>`, naming declared row/column entries, with `rowIndex`/`columnIndex` equal to those entries' positions. | Well `rowIndex`/`columnIndex` match the named row/column positions in `plate.rows`/`plate.columns`. | `plate.wells[3]` |
-| 11 | `well-acquisition-missing` | HCS well | When the plate declares more than one acquisition, every well image references one via `acquisition`. | With multiple acquisitions, each well image references an acquisition. | `well.images[0].acquisition` |
+| 10 | `zarr-format` | images/multiscales (v0.5) | A v0.5 entry implies a Zarr v3 store; a `zarr_format` value that leaked into the entry must be exactly `3`. Inert for v0.4. | v0.5: metadata is backed by a Zarr v3 store (`zarr_format == 3`). | `multiscales[0]` |
+| 11 | `ome-namespace` | images/multiscales (v0.5) | A v0.5 entry must not retain a group-level `ome` or `multiscales` wrapper key — the `ome` namespace wraps the group attributes, not each entry. Inert for v0.4. | v0.5: multiscales live under the top-level `ome` namespace, with `version` hoisted to `ome.version`. | `multiscales[0]` |
+| 12 | `plate-row-index-consistency` | HCS plate | Each well's `path` is `<row>/<column>`, naming declared row/column entries, with `rowIndex`/`columnIndex` equal to those entries' positions. | v0.4: well `rowIndex`/`columnIndex` match the named row/column positions in `plate.rows`/`plate.columns`. | `plate.wells[3]` |
+| 13 | `well-acquisition-missing` | HCS well | When the plate declares more than one acquisition, every well image references one via `acquisition`. | v0.4: with multiple acquisitions, each well image references an acquisition. | `well.images[0].acquisition` |
 
 ## Evaluation order and orchestrators
 
@@ -52,19 +56,21 @@ The rules are evaluated fail-fast: the first violation raises a
 `ValidationError` and later rules do not run. Three orchestrators dispatch the
 rules:
 
-- **`validate_structural` / `validateStructural`** evaluates rules **1–9** (the
-  image/multiscales rules, including the OMERO color check and the RFC 4
-  orientation checks). Rules 3 and 5 each have two internal enforcement points
-  that share a single identifier — axis class-ordering then spatial-name
-  ordering for `axis-order`; per-dataset scale-count then transform-ordering for
-  `global-coord-transform-after-per-level` — so the observed evaluation order
-  is a 10-step sequence over these nine identifiers.
-- **`validate_plate` / `validatePlate`** evaluates rule **10**
+- **`validate_structural` / `validateStructural`** evaluates rules **1–11** (the
+  image/multiscales rules, including the OMERO color check, the RFC 4
+  orientation checks, and the two v0.5 namespacing rules). Rules 3 and 5 each
+  have two internal enforcement points that share a single identifier — axis
+  class-ordering then spatial-name ordering for `axis-order`; per-dataset
+  scale-count then transform-ordering for
+  `global-coord-transform-after-per-level`. The v0.5 namespacing rules (10 and
+  11) run last and are inert for v0.4 input, so for a v0.4 metadata the observed
+  evaluation order is a 10-step sequence over identifiers 1–9.
+- **`validate_plate` / `validatePlate`** evaluates rule **12**
   (`plate-row-index-consistency`).
-- **`validate_well` / `validateWell`** evaluates rule **11**
+- **`validate_well` / `validateWell`** evaluates rule **13**
   (`well-acquisition-missing`), in the context of its parent plate.
 
-The two HCS rules (10 and 11) are deliberately absent from the image
+The two HCS rules (12 and 13) are deliberately absent from the image
 orchestrator's order; they operate on separate metadata objects. The exact
 fail-fast sequence is locked by the parity tests described in [[parity]].
 
@@ -76,5 +82,6 @@ fail-fast sequence is locked by the parity tests described in [[parity]].
 - **OMERO** — `omero-channel-color-format`.
 - **RFC 4 orientation** — `axis-orientation-consistent-type`,
   `axis-orientation-completeness`.
+- **v0.5 namespacing** — `zarr-format`, `ome-namespace` (inert for v0.4).
 - **HCS plate / well** — `plate-row-index-consistency`,
   `well-acquisition-missing`.

--- a/py/ngff_zarr/structural_validation.py
+++ b/py/ngff_zarr/structural_validation.py
@@ -52,6 +52,12 @@ violation, in canonical spec-MUST order.
 #   axis-orientation-completeness
 #       if any spatial axis has orientation, all spatial axes do
 #       e.g. multiscales[0].axes
+#   zarr-format
+#       a v0.5 entry implies a Zarr v3 store (a leaked zarr_format must be 3)
+#       e.g. multiscales[0]
+#   ome-namespace
+#       a v0.5 entry must not retain a group-level ome/multiscales wrapper key
+#       e.g. multiscales[0]
 #   plate-row-index-consistency
 #       each well's rowIndex/columnIndex matches the row/column named in its path
 #       e.g. plate.wells[3]
@@ -87,6 +93,8 @@ class SpecRule(str, Enum):
     OMERO_CHANNEL_COLOR_FORMAT = "omero-channel-color-format"
     AXIS_ORIENTATION_CONSISTENT_TYPE = "axis-orientation-consistent-type"
     AXIS_ORIENTATION_COMPLETENESS = "axis-orientation-completeness"
+    ZARR_FORMAT = "zarr-format"
+    OME_NAMESPACE = "ome-namespace"
     PLATE_ROW_INDEX_CONSISTENCY = "plate-row-index-consistency"
     WELL_ACQUISITION_MISSING = "well-acquisition-missing"
 
@@ -571,6 +579,73 @@ def validate_axis_orientation(metadata: Metadata) -> None:
         raise
 
 
+def validate_zarr_format_for_version(metadata: Metadata) -> None:
+    """Validate that a v0.5 multiscales entry implies a Zarr v3 store.
+
+    OME-Zarr v0.5 metadata MUST be backed by a Zarr v3 store
+    (``zarr_format == 3``). A v0.4 dataset is always Zarr v2 and carries no
+    ``zarr_format``, so this rule is inert below v0.5. The parsed
+    :class:`~ngff_zarr.v04.zarr_metadata.Metadata` does not surface the group's
+    ``zarr_format`` byte -- its authoritative on-disk verification is a
+    store-backed concern -- but a ``zarr_format`` mis-embedded *inside* the
+    multiscale entry (captured in :attr:`~ngff_zarr.v04.zarr_metadata.Metadata.extra`)
+    is reachable here: it belongs on the enclosing Zarr v3 group, never on the
+    entry, and any value other than ``3`` is incompatible with v0.5.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.ZARR_FORMAT` when v0.5 metadata carries a
+        ``zarr_format`` other than ``3`` in its ``extra`` passthrough; location
+        ``multiscales[0]``.
+    """
+    if metadata.version != "0.5":
+        return
+    zarr_format = metadata.extra.get("zarr_format")
+    if zarr_format is not None and zarr_format != 3:
+        raise ValidationError(
+            SpecRule.ZARR_FORMAT,
+            f"OME-Zarr v0.5 requires a Zarr v3 store (zarr_format == 3), but "
+            f"the entry declares zarr_format = {zarr_format}.",
+            "multiscales[0]",
+        )
+
+
+def validate_ome_namespace(metadata: Metadata) -> None:
+    """Validate that a v0.5 multiscales entry is not double-namespaced.
+
+    At v0.5 the multiscales metadata lives under the top-level ``ome`` namespace
+    key of the group's ``zarr.json`` attributes, with the spec ``version``
+    hoisted to ``ome.version``. The reader unwraps that namespace into this
+    :class:`~ngff_zarr.v04.zarr_metadata.Metadata`, so the group-level wrapper
+    keys -- ``ome`` itself and the ``multiscales`` array -- must never reappear
+    *inside* a multiscale entry. A surviving wrapper key (captured in
+    :attr:`~ngff_zarr.v04.zarr_metadata.Metadata.extra`) means the document is
+    double-namespaced, was not unwrapped, or is otherwise malformed with respect
+    to the v0.5 ``ome`` namespacing. A v0.4 store keeps multiscales at the
+    ``.zattrs`` top level with no ``ome`` wrapper, so this rule is inert below
+    v0.5.
+
+    Raises
+    ------
+    ValidationError
+        With :attr:`SpecRule.OME_NAMESPACE` when v0.5 metadata retains a
+        group-level ``ome`` or ``multiscales`` key in its ``extra`` passthrough;
+        location ``multiscales[0]``.
+    """
+    if metadata.version != "0.5":
+        return
+    for wrapper_key in ("ome", "multiscales"):
+        if wrapper_key in metadata.extra:
+            raise ValidationError(
+                SpecRule.OME_NAMESPACE,
+                f"v0.5 metadata entry retains the group-level '{wrapper_key}' "
+                f"key; the 'ome' namespace wraps the group attributes, not each "
+                f"multiscale entry.",
+                "multiscales[0]",
+            )
+
+
 def validate_plate_well_index_consistency(plate: Plate) -> None:
     """Validate each plate well's recorded indices against its ``path``.
 
@@ -688,11 +763,16 @@ def validate_structural(
     8. :func:`validate_dataset_order`
     9. :func:`validate_omero_color_hex`
     10. :func:`validate_axis_orientation`
+    11. :func:`validate_zarr_format_for_version`
+    12. :func:`validate_ome_namespace`
+
+    Rules 11 and 12 are the OME-Zarr v0.5 namespacing checks; they fire only for
+    v0.5 metadata and are inert (a no-op) for v0.4.
 
     Parameters
     ----------
     metadata:
-        The parsed OME-Zarr v0.4 multiscales metadata to validate.
+        The parsed OME-Zarr v0.4+ multiscales metadata to validate.
     options:
         Validation options. Defaults to :class:`ValidateOptions`, i.e.
         :attr:`ValidationLevel.STRICT`. Under
@@ -730,6 +810,8 @@ def validate_structural(
     validate_dataset_order(metadata)
     validate_omero_color_hex(metadata)
     validate_axis_orientation(metadata)
+    validate_zarr_format_for_version(metadata)
+    validate_ome_namespace(metadata)
 
 
 def validate_plate(plate: Plate, options: ValidateOptions | None = None) -> None:

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -135,6 +135,11 @@ def _pop_metadata_optionals(
     Removes the draft RFC 4 ``orientation`` from every axis unless RFC 4 is
     enabled, then recursively culls all remaining ``None``-valued keys.
     """
+    # ``Metadata.extra`` is a read-side validation aid (leaked-key capture for
+    # the v0.5 namespacing rules), never part of the written multiscale entry.
+    # It is an empty dict on every clean read, which ``_remove_none_values``
+    # would not strip, so drop it explicitly.
+    metadata_dict.pop("extra", None)
     # RFC 4 anatomical orientation is a draft feature gated behind an explicit
     # opt-in. Drop it from every axis (even when populated) unless RFC 4 is
     # enabled; populated orientations on enabled writes survive the None

--- a/py/ngff_zarr/v04/zarr_metadata.py
+++ b/py/ngff_zarr/v04/zarr_metadata.py
@@ -3,7 +3,7 @@
 import functools
 import logging
 import re
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, field, fields
 from typing import TYPE_CHECKING, Literal, Union
 
 from .._supported_versions import NgffVersion
@@ -299,6 +299,29 @@ class Well:
     version: str = "0.4"
 
 
+# Recognized keys of a single ``multiscales[]`` entry. Any other key present in
+# an entry is a leak -- a group-level ``ome`` / ``multiscales`` wrapper, a
+# ``zarr_format`` byte that belongs on the enclosing Zarr v3 group, and so on --
+# and is routed to :attr:`Metadata.extra` for the v0.5 namespacing rules to
+# inspect. ``omero`` is absent on purpose: it is a sibling of ``multiscales``,
+# parsed separately, never a field of the entry. ``@type`` *is* recognized: the
+# writer (:func:`ngff_zarr.to_ngff_zarr`) stamps the JSON-LD ``@type``
+# (``"ngff:Image"``) onto every entry, so it is a legitimate library-written key,
+# not a leak.
+_MULTISCALE_ENTRY_FIELDS = frozenset(
+    {
+        "@type",
+        "version",
+        "name",
+        "axes",
+        "datasets",
+        "coordinateTransformations",
+        "type",
+        "metadata",
+    }
+)
+
+
 @dataclass
 class Metadata:
     axes: list[Axis]
@@ -309,6 +332,12 @@ class Metadata:
     version: str = "0.4"
     type: str | None = None
     metadata: MethodMetadata | None = None
+    #: Unrecognized keys that leaked into the ``multiscales[]`` entry (a
+    #: malformed or double-namespaced v0.5 document). Captured verbatim so the
+    #: v0.5 namespacing rules (``zarr-format``, ``ome-namespace``) can flag them;
+    #: mirrors the Rust port's ``#[serde(flatten)]`` ``extra`` passthrough. It is
+    #: a validation aid only and is never serialized back to the store.
+    extra: dict = field(default_factory=dict)
 
     def to_version(self, version: str | NgffVersion) -> "Metadata":
         if isinstance(version, str):
@@ -381,6 +410,7 @@ class Metadata:
         import sys
 
         import dask.array
+        import packaging.version
 
         from ..ngff_image import NgffImage
         from ..parse_metadata import _parse_omero
@@ -399,9 +429,26 @@ class Metadata:
             )
 
         if validate:
-            validate_ngff(
-                root_attrs, version=root_attrs["multiscales"][0].get("version", "0.4")
+            # OME-Zarr v0.5 hoists the spec ``version`` to the group-level
+            # ``ome`` namespace and validates the ``ome``-wrapped instance
+            # against the v0.5 image schema; v0.4 keeps ``version`` on each
+            # multiscale entry and validates the bare root. Prefer the
+            # group-level version (the v0.5 read path floors it to ``"0.5"``) so
+            # a v0.5 store selects the v0.5 schema, falling back to the per-entry
+            # version for v0.4 and the legacy v0.1-0.3 layouts.
+            schema_version = str(
+                root_attrs.get("version")
+                or root_attrs["multiscales"][0].get("version", "0.4")
             )
+            if packaging.version.parse(schema_version) >= packaging.version.parse(
+                "0.5"
+            ):
+                # ``root_attrs`` is the unwrapped ``ome`` content (multiscales +
+                # hoisted version + omero); re-wrap it so the instance matches
+                # the v0.5 image schema's required ``ome`` namespace.
+                validate_ngff({"ome": root_attrs}, version=schema_version)
+            else:
+                validate_ngff(root_attrs, version=schema_version)
 
             # RFC 4 validation for anatomical orientation
             if "axes" in root_attrs["multiscales"][0] and isinstance(
@@ -416,6 +463,13 @@ class Metadata:
                     validate_rfc4_orientation(axes_dicts)
 
         omero = _parse_omero(root_attrs.get("omero"))
+        # OME-Zarr v0.5 hoists the spec ``version`` to the group-level ``ome``
+        # namespace; v0.4 carries it on each multiscale entry. Capture the
+        # group-level value (if any) before descending into the entry so the
+        # parsed Metadata records the true spec version -- which the v0.5
+        # structural rules (zarr-format, ome-namespace) gate on. v0.4 has no
+        # group-level version, so this falls back to the entry's below.
+        group_version = root_attrs.get("version")
         root_attrs = root_attrs["multiscales"][0]
 
         # This handles backwards compatibility for version<=0.3
@@ -515,13 +569,25 @@ class Metadata:
             )
             images.append(ngff_image)
 
+        # Keys that a malformed or double-namespaced document leaked into the
+        # multiscale entry -- e.g. a group-level ``ome`` / ``multiscales``
+        # wrapper, or a ``zarr_format`` byte that belongs on the enclosing
+        # Zarr v3 group, never on the entry. Captured verbatim so the v0.5
+        # namespacing rules can flag them.
+        extra = {
+            key: value
+            for key, value in root_attrs.items()
+            if key not in _MULTISCALE_ENTRY_FIELDS
+        }
+
         metadata = cls(
             axes=axes,
             datasets=datasets,
             name=root_attrs.get("name", "image"),
-            version=root_attrs.get("version", "0.4"),
+            version=group_version or root_attrs.get("version", "0.4"),
             omero=omero,
             coordinateTransformations=root_attrs.get("coordinateTransformations", None),
+            extra=extra,
         )
 
         if validate:
@@ -531,8 +597,6 @@ class Metadata:
             # coordinate transformations); the legacy v0.1-0.3 layouts predate
             # it, so the rules are scoped to v0.4 and newer. Imported lazily so
             # the default validate=False read path incurs no extra import cost.
-            import packaging.version
-
             from ..structural_validation import (
                 ValidateOptions,
                 ValidationLevel,

--- a/py/ngff_zarr/v05/zarr_metadata.py
+++ b/py/ngff_zarr/v05/zarr_metadata.py
@@ -74,8 +74,18 @@ class Metadata:
     ) -> tuple["Metadata", list["NgffImage"]]:  # noqa: F821
         from ..v04.zarr_metadata import Metadata as Metadata_v04
 
+        # The v0.4 parser hoists the group-level ``version`` (here ``ome.version``)
+        # so its structural pass sees the true spec version, which the v0.5
+        # namespacing rules gate on. This entry point definitionally handles
+        # v0.5, so floor ``ome.version`` to ``"0.5"`` when it is missing *or*
+        # explicitly null (a malformed ``"version": null`` reads back as ``None``);
+        # either way the store would otherwise be validated as v0.4 and skip the
+        # v0.5 rules. Shallow-copy so the caller's attrs are untouched.
+        ome_attrs = dict(root_attrs["ome"])
+        if ome_attrs.get("version") is None:
+            ome_attrs["version"] = "0.5"
         v4_metadata, images = Metadata_v04._from_zarr_attrs(
-            root_attrs["ome"], store, validate=validate, subpath=subpath
+            ome_attrs, store, validate=validate, subpath=subpath
         )
         metadata = cls._from_v04(v4_metadata)
         return metadata, images

--- a/py/test/test_ngff_validation.py
+++ b/py/test/test_ngff_validation.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 import numpy as np
+import pytest
 import zarr
 from ngff_zarr import (
     NgffMultiscales,
@@ -16,6 +17,14 @@ from packaging import version
 
 zarr_version = version.parse(zarr.__version__)
 zarr_version_major = zarr_version.major
+
+# OME-Zarr v0.5 requires a Zarr v3 store, which zarr-python only writes at
+# >= 3.0.0b1. The CI matrix exercises legs pinned to zarr 2.x (v0.4 only), where
+# ``to_ngff_zarr(..., version="0.5")`` raises; skip the v0.5-writing tests there.
+requires_zarr_v3 = pytest.mark.skipif(
+    zarr_version < version.parse("3.0.0b1"),
+    reason="OME-Zarr v0.5 requires zarr-python >= 3.0.0b1",
+)
 
 
 def check_valid_ngff(multiscale: NgffMultiscales):
@@ -75,3 +84,86 @@ def test_validate_0_3():
 def test_validate_0_3_no_version():
     test_store = Path(__file__).parent / "data" / "input" / "v03" / "9528933.zarr"
     from_ngff_zarr(test_store, validate=True)
+
+
+def _write_valid_2d_store_v05() -> zarr.storage.MemoryStore:
+    """Write a valid 2D ``(y, x)`` two-level v0.5 multiscales to a store."""
+    store = zarr.storage.MemoryStore()
+    array = np.random.random((32, 16)).astype("float32")
+    to_ngff_zarr(store, to_multiscales(array, [2]), version="0.5")
+    return store
+
+
+@requires_zarr_v3
+def test_validate_v05_wrapped_instance():
+    # The public ``validate`` entry point checks a v0.5 store against the v0.5
+    # image schema, which requires the ``ome`` namespace wrapper. The full root
+    # attributes (``{"ome": {...}}``) validate; the unwrapped ``ome`` content
+    # does not (it lacks the required top-level ``ome`` wrapper), proving the
+    # vendored v0.5 schema -- not the v0.4 schema -- is what runs.
+    jsonschema = pytest.importorskip("jsonschema")
+
+    store = _write_valid_2d_store_v05()
+    root_attrs = zarr.open_group(store, mode="r").attrs.asdict()
+
+    validate(root_attrs, version="0.5", model="image")
+    with pytest.raises(jsonschema.ValidationError):
+        validate(root_attrs["ome"], version="0.5", model="image")
+
+
+@requires_zarr_v3
+def test_validate_v05_schema_active_on_read_path():
+    # The read path validates the ``ome``-wrapped instance against the v0.5
+    # image schema. A duplicate multiscale entry violates the schema's
+    # ``uniqueItems`` constraint -- a pure schema concern the structural rules
+    # (which inspect only ``multiscales[0]``) do not check -- so it is rejected
+    # under ``validate=True`` and read silently under ``validate=False``.
+    jsonschema = pytest.importorskip("jsonschema")
+
+    store = _write_valid_2d_store_v05()
+    root = zarr.open_group(store, mode="r+")
+    attrs = root.attrs.asdict()
+    ome = attrs["ome"]
+    ome["multiscales"] = [ome["multiscales"][0], ome["multiscales"][0]]
+    root.attrs["ome"] = ome
+
+    with pytest.raises(jsonschema.ValidationError):
+        from_ngff_zarr(store, validate=True)
+
+    multiscales = from_ngff_zarr(store, validate=False)
+    assert multiscales is not None
+
+
+@requires_zarr_v3
+def test_read_path_schema_instance_by_version():
+    # The v0.4 and v0.5 image schemas share identical multiscale definitions and
+    # differ only in the ``ome`` wrapper, so the rewire is behavior-neutral on
+    # realistic inputs; this spy locks the wiring directly. The read path must
+    # hand the schema validator the ``ome``-wrapped instance tagged version
+    # "0.5" for a v0.5 store, and the bare root tagged "0.4" for a v0.4 store.
+    pytest.importorskip("jsonschema")
+    from unittest import mock
+
+    def _schema_call(store):
+        with mock.patch("ngff_zarr.validate.validate") as spy:
+            from_ngff_zarr(store, validate=True)
+        assert spy.call_count >= 1
+        args, kwargs = spy.call_args
+        instance = args[0] if args else kwargs["ngff_dict"]
+        version_arg = args[1] if len(args) > 1 else kwargs["version"]
+        return instance, version_arg
+
+    # v0.5: wrapped under ``ome``, tagged "0.5".
+    v05_instance, v05_version = _schema_call(_write_valid_2d_store_v05())
+    assert "ome" in v05_instance
+    assert "multiscales" in v05_instance["ome"]
+    assert v05_version == "0.5"
+
+    # v0.4: bare root with top-level ``multiscales``, tagged "0.4".
+    store_v04 = zarr.storage.MemoryStore()
+    array = np.random.random((32, 16)).astype("float32")
+    to_ngff_zarr(store_v04, to_multiscales(array, [2]), version="0.4")
+    v04_instance, v04_version = _schema_call(store_v04)
+    assert "multiscales" in v04_instance
+    assert "ome" not in v04_instance
+    assert v04_version == "0.4"

--- a/py/test/test_structural_validation_parity.py
+++ b/py/test/test_structural_validation_parity.py
@@ -36,11 +36,13 @@ from ngff_zarr.v04.zarr_metadata import (
     Translation,
 )
 
-# The locked rule manifest: every active OME-Zarr v0.4 structural rule, in
-# canonical declaration order. This identical literal list appears in the Deno
-# mirror test so the two are directly comparable. The first nine entries are
-# the image/multiscales rules dispatched by validate_structural; the final two
-# are the HCS plate/well rules dispatched by validate_plate / validate_well.
+# The locked rule manifest: every active OME-Zarr structural rule, in canonical
+# declaration order. This identical literal list appears in the Deno mirror test
+# so the two are directly comparable. The first eleven entries are the
+# image/multiscales rules dispatched by validate_structural -- the first nine
+# are the v0.4 rules and the next two (zarr-format, ome-namespace) are the v0.5
+# namespacing rules, inert for v0.4; the final two are the HCS plate/well rules
+# dispatched by validate_plate / validate_well.
 CANONICAL_SPEC_RULE_IDS = [
     "axis-count",
     "axis-type",
@@ -51,6 +53,8 @@ CANONICAL_SPEC_RULE_IDS = [
     "omero-channel-color-format",
     "axis-orientation-consistent-type",
     "axis-orientation-completeness",
+    "zarr-format",
+    "ome-namespace",
     "plate-row-index-consistency",
     "well-acquisition-missing",
 ]
@@ -63,7 +67,9 @@ CANONICAL_SPEC_RULE_IDS = [
 # AXIS_ORDER (positions 3-4), and validate_per_dataset_scale_count and
 # validate_transform_order both surface GLOBAL_COORD_TRANSFORM_AFTER_PER_LEVEL
 # (positions 5 and 7). The two HCS rules are absent: they are not part of the
-# image/multiscales orchestrator.
+# image/multiscales orchestrator. The two v0.5 namespacing rules (zarr-format,
+# ome-namespace) run last in the orchestrator but are inert for the v0.4
+# metadata exercised here, so they never appear in the observed order.
 EXPECTED_EVALUATION_ORDER = [
     SpecRule.AXIS_COUNT,
     SpecRule.AXIS_TYPE,

--- a/py/test/test_structural_validation_reader.py
+++ b/py/test/test_structural_validation_reader.py
@@ -23,8 +23,17 @@ import pytest
 import zarr
 from ngff_zarr import from_ngff_zarr, to_multiscales, to_ngff_zarr
 from ngff_zarr.structural_validation import SpecRule, ValidationError
+from packaging import version
 
 pytest.importorskip("jsonschema", reason="jsonschema required for validate=True")
+
+# OME-Zarr v0.5 requires a Zarr v3 store, which zarr-python only writes at
+# >= 3.0.0b1. The CI matrix exercises legs pinned to zarr 2.x (v0.4 only), where
+# ``to_ngff_zarr(..., version="0.5")`` raises; skip the v0.5-writing tests there.
+requires_zarr_v3 = pytest.mark.skipif(
+    version.parse(zarr.__version__) < version.parse("3.0.0b1"),
+    reason="OME-Zarr v0.5 requires zarr-python >= 3.0.0b1",
+)
 
 
 def _write_valid_2d_store() -> zarr.storage.MemoryStore:
@@ -40,6 +49,142 @@ def test_valid_roundtrip_passes_strict_validation():
     store = _write_valid_2d_store()
     multiscales = from_ngff_zarr(store, validate=True)
     assert multiscales is not None
+
+
+def _write_valid_2d_store_v05() -> zarr.storage.MemoryStore:
+    """Write a valid 2D ``(y, x)`` two-level v0.5 multiscales to a store."""
+    store = zarr.storage.MemoryStore()
+    array = np.random.random((32, 16)).astype("float32")
+    multiscales = to_multiscales(array, [2])
+    to_ngff_zarr(store, multiscales, version="0.5")
+    return store
+
+
+@requires_zarr_v3
+def test_valid_v05_roundtrip_passes_strict_validation():
+    # A clean v0.5 store passes strict validation: the reader hoists
+    # ``ome.version`` so the structural pass sees v0.5, and the new namespacing
+    # rules accept it (no leaked group-level key, no contradictory zarr_format).
+    store = _write_valid_2d_store_v05()
+    multiscales = from_ngff_zarr(store, validate=True)
+    assert multiscales is not None
+
+
+@requires_zarr_v3
+def test_v05_ome_namespace_violation_raises_only_when_validating():
+    store = _write_valid_2d_store_v05()
+    # Leak the group-level ``ome`` wrapper key into the multiscale entry, where
+    # it must never appear -- a double-namespaced / malformed v0.5 document.
+    root = zarr.open_group(store, mode="r+")
+    attrs = root.attrs.asdict()
+    ome = attrs["ome"]
+    ome["multiscales"][0]["ome"] = {"version": "0.5"}
+    root.attrs["ome"] = ome
+
+    # validate=True surfaces the structural violation as a ValidationError.
+    with pytest.raises(ValidationError) as exc_info:
+        from_ngff_zarr(store, validate=True)
+    assert exc_info.value.rule == SpecRule.OME_NAMESPACE
+
+    # The same store reads cleanly when validation is disabled.
+    multiscales = from_ngff_zarr(store, validate=False)
+    assert multiscales is not None
+
+
+@pytest.mark.parametrize(
+    "version", ["0.4", pytest.param("0.5", marks=requires_zarr_v3)]
+)
+def test_extra_passthrough_is_never_serialized(version):
+    # ``Metadata.extra`` is a read-side validation aid (it captures leaked
+    # group-level keys for the v0.5 namespacing rules). It must never reach the
+    # written store: the write path serializes the metadata dataclass via
+    # ``asdict``, which would otherwise emit an ``extra: {}`` key on every entry.
+    # ``_pop_metadata_optionals`` drops it; this guards that drop in both layouts.
+    store = zarr.storage.MemoryStore()
+    array = np.random.random((32, 16)).astype("float32")
+    multiscales = to_multiscales(array, [2])
+    to_ngff_zarr(store, multiscales, version=version)
+
+    attrs = zarr.open_group(store, mode="r").attrs.asdict()
+    entry = (
+        attrs["ome"]["multiscales"][0] if version == "0.5" else attrs["multiscales"][0]
+    )
+    assert "extra" not in entry, (
+        f"v{version}: 'extra' leaked into the written multiscale entry: {sorted(entry)}"
+    )
+
+
+def test_clean_roundtrip_read_has_empty_extra():
+    # ``Metadata.extra`` captures only leaked / mis-namespaced keys. A clean
+    # library-authored store must therefore read back with an empty ``extra`` --
+    # in particular the serializer-written JSON-LD ``@type`` (``"ngff:Image"``)
+    # is a recognized entry field, not a leak, so it must not appear in ``extra``.
+    # (v0.4 is asserted directly: its returned Metadata carries ``extra``; the
+    # v0.5 conversion drops ``extra`` from its returned object, so this read-side
+    # contract is the v0.4 parser's to keep.)
+    store = _write_valid_2d_store()
+    multiscales = from_ngff_zarr(store, validate=True)
+    assert multiscales.metadata.extra == {}
+
+
+@requires_zarr_v3
+def test_v05_namespacing_validated_when_ome_version_null():
+    # A malformed v0.5 store with ``ome.version: null`` (JSON null -> Python
+    # None) must still be validated with the v0.5 namespacing rules. The v0.5
+    # read path floors a missing *or* null version to "0.5" before the structural
+    # pass, so a leaked group-level wrapper key is still caught rather than
+    # silently treated as v0.4 (where the rule is inert).
+    store = _write_valid_2d_store_v05()
+    root = zarr.open_group(store, mode="r+")
+    attrs = root.attrs.asdict()
+    ome = attrs["ome"]
+    ome["version"] = None  # malformed: explicit null version
+    ome["multiscales"][0]["ome"] = {"version": "0.5"}  # leaked wrapper key
+    root.attrs["ome"] = ome
+
+    with pytest.raises(ValidationError) as exc_info:
+        from_ngff_zarr(store, validate=True)
+    assert exc_info.value.rule == SpecRule.OME_NAMESPACE
+
+
+@requires_zarr_v3
+def test_v05_zarr_format_violation_raises_only_when_validating():
+    store = _write_valid_2d_store_v05()
+    # Mis-embed a non-3 ``zarr_format`` byte inside the multiscale entry; it
+    # belongs on the enclosing Zarr v3 group, never on the entry, and a value
+    # other than 3 contradicts the v0.5 => Zarr v3 requirement.
+    root = zarr.open_group(store, mode="r+")
+    attrs = root.attrs.asdict()
+    ome = attrs["ome"]
+    ome["multiscales"][0]["zarr_format"] = 2
+    root.attrs["ome"] = ome
+
+    with pytest.raises(ValidationError) as exc_info:
+        from_ngff_zarr(store, validate=True)
+    assert exc_info.value.rule == SpecRule.ZARR_FORMAT
+
+    multiscales = from_ngff_zarr(store, validate=False)
+    assert multiscales is not None
+
+
+@requires_zarr_v3
+def test_v05_namespacing_validated_when_ome_version_missing():
+    # A malformed v0.5 store missing ``ome.version`` must still be validated with
+    # the v0.5 namespacing rules. The store is routed to the v0.5 read path by
+    # its ``ome`` key, and that path floors the spec version to "0.5" before the
+    # structural pass, so a leaked group-level wrapper key is still caught --
+    # rather than silently treated as v0.4 (where the rule is inert).
+    store = _write_valid_2d_store_v05()
+    root = zarr.open_group(store, mode="r+")
+    attrs = root.attrs.asdict()
+    ome = attrs["ome"]
+    del ome["version"]  # malformed: missing ome.version
+    ome["multiscales"][0]["ome"] = {"version": "0.5"}  # leaked wrapper key
+    root.attrs["ome"] = ome
+
+    with pytest.raises(ValidationError) as exc_info:
+        from_ngff_zarr(store, validate=True)
+    assert exc_info.value.rule == SpecRule.OME_NAMESPACE
 
 
 def test_scale_length_violation_raises_only_when_validating():

--- a/py/test/test_structural_validation_v05.py
+++ b/py/test/test_structural_validation_v05.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Unit tests for the OME-Zarr v0.5 structural-validation rules.
+
+The two v0.5 namespacing rules -- :func:`validate_zarr_format_for_version`
+(``zarr-format``) and :func:`validate_ome_namespace` (``ome-namespace``) -- fire
+only for v0.5 metadata and are inert for v0.4. They inspect the leaked-key
+``extra`` passthrough the reader fills when a malformed or double-namespaced
+document puts a group-level key inside a multiscale entry. Each rule is exercised
+directly (inert-on-v0.4, accepts-clean-v0.5, rejects-malformed-v0.5) and once
+end-to-end through the :func:`validate_structural` orchestrator.
+"""
+
+import pytest
+from ngff_zarr.structural_validation import (
+    SpecRule,
+    ValidationError,
+    validate_ome_namespace,
+    validate_structural,
+    validate_zarr_format_for_version,
+)
+from ngff_zarr.v04.zarr_metadata import Axis, Dataset, Metadata, Scale
+
+
+def _valid_v04_metadata() -> Metadata:
+    """A fully valid v0.4 ``[c, y, x]`` two-level multiscales metadata."""
+    return Metadata(
+        axes=[
+            Axis(name="c", type="channel"),
+            Axis(name="y", type="space"),
+            Axis(name="x", type="space"),
+        ],
+        datasets=[
+            Dataset(path="0", coordinateTransformations=[Scale([1.0, 1.0, 1.0])]),
+            Dataset(path="1", coordinateTransformations=[Scale([1.0, 2.0, 2.0])]),
+        ],
+        coordinateTransformations=None,
+    )
+
+
+def _valid_v05_metadata() -> Metadata:
+    """The valid baseline relabeled to v0.5 with an empty ``extra`` passthrough.
+
+    This is the cleanly-unwrapped form a v0.5 read produces: ``version`` hoisted
+    out of ``ome.version`` and no group-level wrapper key surviving in the entry.
+    """
+    metadata = _valid_v04_metadata()
+    metadata.version = "0.5"
+    return metadata
+
+
+# ── zarr-format ────────────────────────────────────────────────────────────
+
+
+def test_zarr_format_rule_is_inert_on_v04_even_with_stray_key():
+    # Gated strictly on the v0.5 version: a v0.4 dataset is Zarr v2, so the rule
+    # must not fire even if a zarr_format key is (anomalously) present in extra.
+    metadata = _valid_v04_metadata()
+    metadata.extra = {"zarr_format": 2}
+    validate_zarr_format_for_version(metadata)
+
+
+def test_zarr_format_rule_accepts_clean_v05():
+    # A clean v0.5 entry carries no zarr_format in extra; nothing to contradict
+    # Zarr v3, so the rule is inert.
+    validate_zarr_format_for_version(_valid_v05_metadata())
+
+
+def test_zarr_format_rule_accepts_v05_with_explicit_v3():
+    # A zarr_format of exactly 3 (the v0.5 requirement) is accepted.
+    metadata = _valid_v05_metadata()
+    metadata.extra = {"zarr_format": 3}
+    validate_zarr_format_for_version(metadata)
+
+
+def test_zarr_format_rule_rejects_v05_non_v3():
+    # A v0.5 entry that declares a non-3 zarr_format is incompatible with the
+    # v0.5 => Zarr v3 requirement and must be rejected.
+    metadata = _valid_v05_metadata()
+    metadata.extra = {"zarr_format": 2}
+    with pytest.raises(ValidationError) as exc_info:
+        validate_zarr_format_for_version(metadata)
+    assert exc_info.value.rule == SpecRule.ZARR_FORMAT
+    assert exc_info.value.location == "multiscales[0]"
+
+
+# ── ome-namespace ──────────────────────────────────────────────────────────
+
+
+def test_ome_namespace_rule_is_inert_on_v04_even_with_residual_wrapper():
+    # Gated strictly on the v0.5 version: a v0.4 store has no ome wrapper, so the
+    # rule must not fire on v0.4 metadata regardless of extra.
+    metadata = _valid_v04_metadata()
+    metadata.extra = {"ome": {"version": "0.5"}}
+    validate_ome_namespace(metadata)
+
+
+def test_ome_namespace_rule_accepts_clean_v05():
+    # A cleanly-unwrapped v0.5 entry retains no group-level wrapper key.
+    validate_ome_namespace(_valid_v05_metadata())
+
+
+def test_ome_namespace_rule_rejects_residual_ome_wrapper():
+    # A v0.5 entry that still carries the group-level ome key is
+    # double-namespaced / malformed.
+    metadata = _valid_v05_metadata()
+    metadata.extra = {"ome": {"version": "0.5", "multiscales": []}}
+    with pytest.raises(ValidationError) as exc_info:
+        validate_ome_namespace(metadata)
+    assert exc_info.value.rule == SpecRule.OME_NAMESPACE
+    assert exc_info.value.location == "multiscales[0]"
+
+
+def test_ome_namespace_rule_rejects_residual_multiscales_wrapper():
+    # The multiscales array is also a group-level key; it must not appear inside
+    # a multiscale entry.
+    metadata = _valid_v05_metadata()
+    metadata.extra = {"multiscales": []}
+    with pytest.raises(ValidationError) as exc_info:
+        validate_ome_namespace(metadata)
+    assert exc_info.value.rule == SpecRule.OME_NAMESPACE
+    assert exc_info.value.location == "multiscales[0]"
+
+
+# ── end-to-end through validate_structural ─────────────────────────────────
+
+
+def test_validate_structural_accepts_clean_v05():
+    # End-to-end through the orchestrator: a clean v0.5 metadata passes every
+    # rule (the new v0.5 namespacing rules included).
+    validate_structural(_valid_v05_metadata())
+
+
+def test_validate_structural_flags_malformed_v05_namespace():
+    # The active ome-namespace rule fires through the orchestrator.
+    metadata = _valid_v05_metadata()
+    metadata.extra = {"ome": {"version": "0.5"}}
+    with pytest.raises(ValidationError) as exc_info:
+        validate_structural(metadata)
+    assert exc_info.value.rule == SpecRule.OME_NAMESPACE
+
+
+def test_validate_structural_flags_malformed_v05_zarr_format():
+    # The active zarr-format rule fires through the orchestrator.
+    metadata = _valid_v05_metadata()
+    metadata.extra = {"zarr_format": 2}
+    with pytest.raises(ValidationError) as exc_info:
+        validate_structural(metadata)
+    assert exc_info.value.rule == SpecRule.ZARR_FORMAT

--- a/ts/src/types/zarr_metadata.ts
+++ b/ts/src/types/zarr_metadata.ts
@@ -79,6 +79,14 @@ export interface MetadataInterface {
   version: string;
   type?: string;
   metadata?: MethodMetadata;
+  /**
+   * Unrecognized keys that leaked into the `multiscales[]` entry (a malformed
+   * or double-namespaced v0.5 document). Captured verbatim so the v0.5
+   * namespacing rules (`zarr-format`, `ome-namespace`) can flag them; mirrors
+   * the Rust port's `#[serde(flatten)]` `extra` passthrough. It is a read-side
+   * validation aid only and is never serialized back to the store.
+   */
+  extra?: Record<string, unknown>;
 }
 
 /**

--- a/ts/src/utils/from_zarr_attrs.ts
+++ b/ts/src/utils/from_zarr_attrs.ts
@@ -118,6 +118,27 @@ function isSpecVersionAtLeastV04(version: string): boolean {
 }
 
 /**
+ * Recognized keys of a single `multiscales[]` entry. Any other key present in an
+ * entry is a leak -- a group-level `ome` / `multiscales` wrapper, a
+ * `zarr_format` byte that belongs on the enclosing Zarr v3 group, and so on --
+ * and is routed to `Metadata.extra` for the v0.5 namespacing rules to inspect.
+ * `omero` is absent on purpose: it is a sibling of `multiscales`, parsed
+ * separately, never a field of the entry. `@type` *is* recognized: the Python
+ * writer stamps the JSON-LD `@type` (`"ngff:Image"`) onto every entry, so it is
+ * a legitimate library-written key, not a leak.
+ */
+const MULTISCALE_ENTRY_FIELDS = new Set<string>([
+  "@type",
+  "version",
+  "name",
+  "axes",
+  "datasets",
+  "coordinateTransformations",
+  "type",
+  "metadata",
+]);
+
+/**
  * Parse Metadata and NgffImages from OME-Zarr v0.4 root attributes.
  *
  * This mirrors the Python `Metadata._from_zarr_attrs` class method.
@@ -391,13 +412,32 @@ export async function fromZarrAttrsV04(
     images.push(ngffImage);
   }
 
+  // Keys that a malformed or double-namespaced document leaked into the
+  // multiscale entry -- e.g. a group-level `ome` / `multiscales` wrapper, or a
+  // `zarr_format` byte that belongs on the enclosing Zarr v3 group, never on the
+  // entry. Captured verbatim so the v0.5 namespacing rules can flag them.
+  const extra: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(multiscalesMetadata)) {
+    if (!MULTISCALE_ENTRY_FIELDS.has(key)) {
+      extra[key] = value;
+    }
+  }
+
   // Build the metadata object - use spread to only include optional properties if defined
   const metadata: MetadataInterface = {
     axes,
     datasets,
     name: (multiscalesMetadata.name as string) ?? "image",
-    version: (multiscalesMetadata.version as string) ?? "0.4",
+    // OME-Zarr v0.5 hoists the spec `version` to the group-level `ome`
+    // namespace; v0.4 carries it on each multiscale entry. Prefer the
+    // group-level value (which fromZarrAttrsV05 forwards as a top-level
+    // `version`) so the structural pass sees the true spec version -- which the
+    // v0.5 namespacing rules gate on. v0.4 has no top-level version, so this
+    // falls back to the entry's.
+    version: (rootAttrs.version as string | undefined) ??
+      (multiscalesMetadata.version as string) ?? "0.4",
     omero,
+    extra,
     coordinateTransformations:
       (multiscalesMetadata.coordinateTransformations as Transform[]) ??
         undefined,
@@ -448,14 +488,24 @@ export async function fromZarrAttrsV05(
 
   let v04Attrs: Record<string, unknown>;
   if (omeData && "multiscales" in omeData) {
-    // Standard v0.5 format with "ome" wrapper
+    // Standard v0.5 format with "ome" wrapper. Forward the hoisted
+    // `ome.version` as a top-level `version` so fromZarrAttrsV04 records the
+    // true spec version (v0.5), which the v0.5 namespacing rules gate on. This
+    // entry point definitionally handles v0.5, so default to "0.5" when
+    // `ome.version` is absent -- otherwise a malformed v0.5 store missing its
+    // version would fall back to "0.4" and skip the v0.5 namespacing rules
+    // during the structural pass (which runs before the version is corrected
+    // below).
     v04Attrs = {
+      version: omeData.version ?? "0.5",
       multiscales: omeData.multiscales,
       omero: omeData.omero ?? rootAttrs.omero,
     };
   } else if ("multiscales" in rootAttrs) {
-    // Compatibility mode: multiscales at root level (as written by toNgffZarr)
+    // Compatibility mode: multiscales at root level (as written by toNgffZarr).
+    // Same v0.5 floor as the wrapped branch above.
     v04Attrs = {
+      version: rootAttrs.version ?? "0.5",
       multiscales: rootAttrs.multiscales,
       omero: rootAttrs.omero,
     };

--- a/ts/src/utils/structural_validation.ts
+++ b/ts/src/utils/structural_validation.ts
@@ -65,6 +65,10 @@ export const SpecRule = {
   AxisOrientationConsistentType: "axis-orientation-consistent-type",
   /** If any spatial axis declares an orientation, all spatial axes do. */
   AxisOrientationCompleteness: "axis-orientation-completeness",
+  /** A v0.5 entry implies a Zarr v3 store: a leaked `zarr_format` must be 3. */
+  ZarrFormat: "zarr-format",
+  /** A v0.5 entry must not retain a group-level `ome`/`multiscales` wrapper. */
+  OmeNamespace: "ome-namespace",
   /** Each well's rowIndex/columnIndex agrees with the row/column in its path. */
   PlateRowIndexConsistency: "plate-row-index-consistency",
   /** Each well image references an acquisition when the plate declares many. */
@@ -651,6 +655,74 @@ function pyRepr(value: string): string {
 }
 
 /**
+ * Validate that a v0.5 multiscales entry implies a Zarr v3 store.
+ *
+ * OME-Zarr v0.5 metadata MUST be backed by a Zarr v3 store
+ * (`zarr_format === 3`). A v0.4 dataset is always Zarr v2 and carries no
+ * `zarr_format`, so this rule is inert below v0.5. The parsed {@link Metadata}
+ * does not surface the group's `zarr_format` byte -- its authoritative on-disk
+ * verification is a store-backed concern -- but a `zarr_format` mis-embedded
+ * *inside* the multiscale entry (captured in {@link Metadata.extra}) is
+ * reachable here: it belongs on the enclosing Zarr v3 group, never on the entry,
+ * and any value other than `3` is incompatible with v0.5.
+ *
+ * @param metadata - The parsed multiscales metadata to validate.
+ * @throws {ValidationError} With {@link SpecRule.ZarrFormat} when v0.5 metadata
+ * carries a `zarr_format` other than `3` in its `extra` passthrough; location
+ * `multiscales[0]`.
+ */
+export function validateZarrFormatForVersion(metadata: Metadata): void {
+  if (metadata.version !== "0.5") {
+    return;
+  }
+  const zarrFormat = metadata.extra?.zarr_format;
+  if (zarrFormat !== undefined && zarrFormat !== 3) {
+    throw new ValidationError(
+      SpecRule.ZarrFormat,
+      `OME-Zarr v0.5 requires a Zarr v3 store (zarr_format == 3), but ` +
+        `the entry declares zarr_format = ${String(zarrFormat)}.`,
+      "multiscales[0]",
+    );
+  }
+}
+
+/**
+ * Validate that a v0.5 multiscales entry is not double-namespaced.
+ *
+ * At v0.5 the multiscales metadata lives under the top-level `ome` namespace key
+ * of the group's `zarr.json` attributes, with the spec `version` hoisted to
+ * `ome.version`. The reader unwraps that namespace into this {@link Metadata}, so
+ * the group-level wrapper keys -- `ome` itself and the `multiscales` array --
+ * must never reappear *inside* a multiscale entry. A surviving wrapper key
+ * (captured in {@link Metadata.extra}) means the document is double-namespaced,
+ * was not unwrapped, or is otherwise malformed with respect to the v0.5 `ome`
+ * namespacing. A v0.4 store keeps multiscales at the `.zattrs` top level with no
+ * `ome` wrapper, so this rule is inert below v0.5.
+ *
+ * @param metadata - The parsed multiscales metadata to validate.
+ * @throws {ValidationError} With {@link SpecRule.OmeNamespace} when v0.5 metadata
+ * retains a group-level `ome` or `multiscales` key in its `extra` passthrough;
+ * location `multiscales[0]`.
+ */
+export function validateOmeNamespace(metadata: Metadata): void {
+  if (metadata.version !== "0.5") {
+    return;
+  }
+  const extra = metadata.extra ?? {};
+  for (const wrapperKey of ["ome", "multiscales"]) {
+    if (wrapperKey in extra) {
+      throw new ValidationError(
+        SpecRule.OmeNamespace,
+        `v0.5 metadata entry retains the group-level '${wrapperKey}' ` +
+          `key; the 'ome' namespace wraps the group attributes, not each ` +
+          `multiscale entry.`,
+        "multiscales[0]",
+      );
+    }
+  }
+}
+
+/**
  * Validate each plate well's recorded indices against its `path`.
  *
  * Every `PlateWell` records a `path` of the form `"<row>/<column>"` (e.g.
@@ -776,6 +848,11 @@ export function validateWellAcquisition(
  * 8. {@link validateDatasetOrder}
  * 9. {@link validateOmeroColorHex}
  * 10. {@link validateAxisOrientation}
+ * 11. {@link validateZarrFormatForVersion}
+ * 12. {@link validateOmeNamespace}
+ *
+ * Rules 11 and 12 are the OME-Zarr v0.5 namespacing checks; they fire only for
+ * v0.5 metadata and are inert (a no-op) for v0.4.
  *
  * Under {@link ValidationLevel.SchemaOnly} this function returns immediately
  * without running any structural rule -- shape/schema validation is the
@@ -816,6 +893,8 @@ export function validateStructural(
   validateDatasetOrder(metadata);
   validateOmeroColorHex(metadata);
   validateAxisOrientation(metadata);
+  validateZarrFormatForVersion(metadata);
+  validateOmeNamespace(metadata);
 }
 
 /**

--- a/ts/test/structural_validation_parity_test.ts
+++ b/ts/test/structural_validation_parity_test.ts
@@ -52,11 +52,13 @@ import {
   type Omero,
 } from "../src/types/zarr_metadata.ts";
 
-// The locked rule manifest: every active OME-Zarr v0.4 structural rule, in
-// canonical declaration order. This identical literal list appears in the
-// Python twin so the two are directly comparable. The first nine entries are
-// the image/multiscales rules dispatched by validateStructural; the final two
-// are the HCS plate/well rules dispatched by validatePlate / validateWell.
+// The locked rule manifest: every active OME-Zarr structural rule, in canonical
+// declaration order. This identical literal list appears in the Python twin so
+// the two are directly comparable. The first eleven entries are the
+// image/multiscales rules dispatched by validateStructural -- the first nine are
+// the v0.4 rules and the next two (zarr-format, ome-namespace) are the v0.5
+// namespacing rules, inert for v0.4; the final two are the HCS plate/well rules
+// dispatched by validatePlate / validateWell.
 const CANONICAL_SPEC_RULE_IDS: string[] = [
   "axis-count",
   "axis-type",
@@ -67,6 +69,8 @@ const CANONICAL_SPEC_RULE_IDS: string[] = [
   "omero-channel-color-format",
   "axis-orientation-consistent-type",
   "axis-orientation-completeness",
+  "zarr-format",
+  "ome-namespace",
   "plate-row-index-consistency",
   "well-acquisition-missing",
 ];
@@ -79,7 +83,9 @@ const CANONICAL_SPEC_RULE_IDS: string[] = [
 // AxisOrder (positions 3-4), and validatePerDatasetScaleCount and
 // validateTransformOrder both surface GlobalCoordTransformAfterPerLevel
 // (positions 5 and 7). The two HCS rules are absent: they are not part of the
-// image/multiscales orchestrator.
+// image/multiscales orchestrator. The two v0.5 namespacing rules (zarr-format,
+// ome-namespace) run last in the orchestrator but are inert for the v0.4
+// metadata exercised here, so they never appear in the observed order.
 const EXPECTED_EVALUATION_ORDER: SpecRule[] = [
   SpecRule.AxisCount,
   SpecRule.AxisType,

--- a/ts/test/structural_validation_reader_test.ts
+++ b/ts/test/structural_validation_reader_test.ts
@@ -20,10 +20,18 @@
  * `py/test/test_structural_validation_reader.py`.
  */
 
-import { assertExists, assertRejects, assertStringIncludes } from "@std/assert";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
 import * as zarr from "zarrita";
 import { fromOmeZarr, type MemoryStore } from "../src/io/from_ngff_zarr.ts";
-import { fromZarrAttrsV04 } from "../src/utils/from_zarr_attrs.ts";
+import {
+  fromZarrAttrsV04,
+  fromZarrAttrsV05,
+} from "../src/utils/from_zarr_attrs.ts";
 import { SpecRule } from "../src/utils/structural_validation.ts";
 
 /**
@@ -75,6 +83,99 @@ function buildValidImageMetadata(): Record<string, unknown> {
     ],
   };
 }
+
+/**
+ * Build an in-memory v0.5 store: the multiscales metadata wrapped under the
+ * `ome` namespace (with `version` hoisted to `ome.version`), and a small Zarr
+ * v3 array for each declared dataset path.
+ */
+async function createImageStoreV05(
+  multiscalesMetadata: Record<string, unknown>,
+): Promise<MemoryStore> {
+  const store: MemoryStore = new Map();
+  const root = zarr.root(store);
+  await zarr.create(root, {
+    attributes: {
+      ome: { version: "0.5", multiscales: [multiscalesMetadata] },
+    },
+  });
+  const datasets = multiscalesMetadata.datasets as Array<{ path: string }>;
+  for (const dataset of datasets) {
+    await zarr.create(root.resolve(dataset.path), {
+      shape: [16, 16],
+      data_type: "uint8",
+      chunk_shape: [16, 16],
+      fill_value: 0,
+    });
+  }
+  return store;
+}
+
+/**
+ * A valid v0.5 `(y, x)` two-level multiscale entry: the v0.4 baseline with the
+ * per-entry `version` dropped (it lives on `ome.version` at v0.5).
+ */
+function buildValidImageMetadataV05(): Record<string, unknown> {
+  const metadata = buildValidImageMetadata();
+  delete metadata.version;
+  return metadata;
+}
+
+Deno.test(
+  "fromOmeZarr - valid v0.5 image passes strict validation",
+  async () => {
+    // A clean v0.5 store passes strict validation: the reader hoists
+    // `ome.version` so the structural pass sees v0.5, and the new namespacing
+    // rules accept it (no leaked group-level key, no contradictory zarr_format).
+    const store = await createImageStoreV05(buildValidImageMetadataV05());
+    const multiscales = await fromOmeZarr(store, { validate: true });
+    assertExists(multiscales);
+  },
+);
+
+Deno.test(
+  "fromOmeZarr - v0.5 ome-namespace violation throws only when validating",
+  async () => {
+    // Leak the group-level `ome` wrapper key into the multiscale entry, where
+    // it must never appear -- a double-namespaced / malformed v0.5 document.
+    const metadata = buildValidImageMetadataV05();
+    metadata.ome = { version: "0.5" };
+    const store = await createImageStoreV05(metadata);
+
+    const error = await assertRejects(
+      () => fromOmeZarr(store, { validate: true }),
+      Error,
+      SpecRule.OmeNamespace,
+    );
+    assertStringIncludes(error.message, "Spec rule [");
+
+    // The same store reads cleanly when validation is disabled.
+    const multiscales = await fromOmeZarr(store, { validate: false });
+    assertExists(multiscales);
+  },
+);
+
+Deno.test(
+  "fromOmeZarr - v0.5 zarr_format violation throws only when validating",
+  async () => {
+    // Mis-embed a non-3 `zarr_format` byte inside the multiscale entry; it
+    // belongs on the enclosing Zarr v3 group, never on the entry, and a value
+    // other than 3 contradicts the v0.5 => Zarr v3 requirement.
+    const metadata = buildValidImageMetadataV05();
+    metadata.zarr_format = 2;
+    const store = await createImageStoreV05(metadata);
+
+    const error = await assertRejects(
+      () => fromOmeZarr(store, { validate: true }),
+      Error,
+      SpecRule.ZarrFormat,
+    );
+    assertStringIncludes(error.message, "Spec rule [");
+
+    const multiscales = await fromOmeZarr(store, { validate: false });
+    assertExists(multiscales);
+  },
+);
 
 Deno.test("fromOmeZarr - valid v0.4 image passes strict validation", async () => {
   const store = await createImageStore(buildValidImageMetadata());
@@ -138,5 +239,73 @@ Deno.test(
       true,
     );
     assertExists(result.metadata);
+  },
+);
+
+Deno.test(
+  "fromZarrAttrsV05 - v0.5 namespacing validated when ome.version missing",
+  async () => {
+    // A malformed v0.5 store missing `ome.version` must still be validated with
+    // the v0.5 namespacing rules. fromZarrAttrsV05 definitionally handles v0.5,
+    // so it floors the spec version to "0.5" before the structural pass -- a
+    // leaked group-level wrapper key is therefore still caught, rather than
+    // silently treated as v0.4 (where the rule is inert). Exercised directly on
+    // fromZarrAttrsV05 because fromOmeZarr rejects a versionless `ome` store at
+    // its version-detection step.
+    const metadata = buildValidImageMetadataV05();
+    metadata.ome = { version: "0.5" }; // leaked group-level wrapper key
+    const store = await createImageStoreV05(metadata);
+
+    // An `ome` wrapper WITHOUT a version, mirroring a malformed v0.5 document.
+    const error = await assertRejects(
+      () => fromZarrAttrsV05({ ome: { multiscales: [metadata] } }, store, true),
+      Error,
+      SpecRule.OmeNamespace,
+    );
+    assertStringIncludes(error.message, "Spec rule [");
+  },
+);
+
+Deno.test(
+  "fromZarrAttrsV05 - v0.5 namespacing validated when ome.version is null",
+  async () => {
+    // A malformed v0.5 store with an explicit `ome.version: null` must still be
+    // validated with the v0.5 namespacing rules: the nullish-coalescing floor
+    // treats null like a missing version and defaults it to "0.5", so a leaked
+    // group-level wrapper key is still caught rather than silently read as v0.4.
+    const metadata = buildValidImageMetadataV05();
+    metadata.ome = { version: "0.5" }; // leaked group-level wrapper key
+    const store = await createImageStoreV05(metadata);
+
+    const error = await assertRejects(
+      () =>
+        fromZarrAttrsV05(
+          { ome: { version: null, multiscales: [metadata] } },
+          store,
+          true,
+        ),
+      Error,
+      SpecRule.OmeNamespace,
+    );
+    assertStringIncludes(error.message, "Spec rule [");
+  },
+);
+
+Deno.test(
+  "fromZarrAttrsV04 - serializer-written @type is not routed to extra",
+  async () => {
+    // `Metadata.extra` captures only leaked / mis-namespaced keys. The Python
+    // writer stamps a JSON-LD `@type` ("ngff:Image") onto every entry, so it is
+    // a recognized entry field, not a leak, and must not appear in `extra`.
+    const metadata = buildValidImageMetadata();
+    metadata["@type"] = "ngff:Image";
+    const store = await createImageStore(metadata);
+
+    const result = await fromZarrAttrsV04(
+      { multiscales: [metadata] },
+      store,
+      true,
+    );
+    assertEquals(result.metadata.extra, {});
   },
 );

--- a/ts/test/structural_validation_v05_test.ts
+++ b/ts/test/structural_validation_v05_test.ts
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+/**
+ * Unit tests for the OME-Zarr v0.5 structural-validation rules in
+ * `../src/utils/structural_validation.ts`.
+ *
+ * The two v0.5 namespacing rules -- {@link validateZarrFormatForVersion}
+ * (`zarr-format`) and {@link validateOmeNamespace} (`ome-namespace`) -- fire
+ * only for v0.5 metadata and are inert for v0.4. They inspect the leaked-key
+ * `extra` passthrough the reader fills when a malformed or double-namespaced
+ * document puts a group-level key inside a multiscale entry. Each rule is
+ * exercised directly (inert-on-v0.4, accepts-clean-v0.5, and
+ * rejects-malformed-v0.5) and once end-to-end through the
+ * {@link validateStructural} orchestrator.
+ *
+ * This suite mirrors `py/test/test_structural_validation_v05.py` so the two
+ * stay in lockstep.
+ */
+
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  SpecRule,
+  validateOmeNamespace,
+  validateStructural,
+  validateZarrFormatForVersion,
+  ValidationError,
+} from "../src/utils/structural_validation.ts";
+import { createScale, type Metadata } from "../src/types/zarr_metadata.ts";
+
+/** A fully valid v0.4 `[c, y, x]` two-level multiscales metadata. */
+function validV04Metadata(): Metadata {
+  return {
+    axes: [
+      { name: "c", type: "channel", unit: undefined },
+      { name: "y", type: "space", unit: undefined },
+      { name: "x", type: "space", unit: undefined },
+    ],
+    datasets: [
+      { path: "0", coordinateTransformations: [createScale([1.0, 1.0, 1.0])] },
+      { path: "1", coordinateTransformations: [createScale([1.0, 2.0, 2.0])] },
+    ],
+    coordinateTransformations: undefined,
+    omero: undefined,
+    name: "image",
+    version: "0.4",
+  };
+}
+
+/**
+ * The valid baseline relabeled to v0.5 with no leaked `extra` keys: the cleanly
+ * unwrapped form a v0.5 read produces (`version` hoisted out of `ome.version`).
+ */
+function validV05Metadata(): Metadata {
+  return { ...validV04Metadata(), version: "0.5" };
+}
+
+// --- zarr-format -----------------------------------------------------------
+
+Deno.test("zarr-format rule is inert on v0.4 even with a stray key", () => {
+  // Gated strictly on the v0.5 version: a v0.4 dataset is Zarr v2, so the rule
+  // must not fire even if a zarr_format key is (anomalously) present in extra.
+  const metadata = validV04Metadata();
+  metadata.extra = { zarr_format: 2 };
+  validateZarrFormatForVersion(metadata);
+});
+
+Deno.test("zarr-format rule accepts clean v0.5", () => {
+  // A clean v0.5 entry carries no zarr_format in extra; nothing to contradict
+  // Zarr v3, so the rule is inert.
+  validateZarrFormatForVersion(validV05Metadata());
+});
+
+Deno.test(
+  "zarr-format rule accepts v0.5 with an explicit zarr_format of 3",
+  () => {
+    const metadata = validV05Metadata();
+    metadata.extra = { zarr_format: 3 };
+    validateZarrFormatForVersion(metadata);
+  },
+);
+
+Deno.test("zarr-format rule rejects v0.5 with a non-3 zarr_format", () => {
+  // A v0.5 entry that declares a non-3 zarr_format is incompatible with the
+  // v0.5 => Zarr v3 requirement and must be rejected.
+  const metadata = validV05Metadata();
+  metadata.extra = { zarr_format: 2 };
+  const error = assertThrows(
+    () => validateZarrFormatForVersion(metadata),
+    ValidationError,
+  );
+  assertEquals(error.rule, SpecRule.ZarrFormat);
+  assertEquals(error.location, "multiscales[0]");
+});
+
+// --- ome-namespace ---------------------------------------------------------
+
+Deno.test(
+  "ome-namespace rule is inert on v0.4 even with a residual wrapper",
+  () => {
+    // Gated strictly on the v0.5 version: a v0.4 store has no ome wrapper, so
+    // the rule must not fire on v0.4 metadata regardless of extra.
+    const metadata = validV04Metadata();
+    metadata.extra = { ome: { version: "0.5" } };
+    validateOmeNamespace(metadata);
+  },
+);
+
+Deno.test("ome-namespace rule accepts clean v0.5", () => {
+  // A cleanly-unwrapped v0.5 entry retains no group-level wrapper key.
+  validateOmeNamespace(validV05Metadata());
+});
+
+Deno.test("ome-namespace rule rejects a residual ome wrapper", () => {
+  // A v0.5 entry that still carries the group-level ome key is
+  // double-namespaced / malformed.
+  const metadata = validV05Metadata();
+  metadata.extra = { ome: { version: "0.5", multiscales: [] } };
+  const error = assertThrows(
+    () => validateOmeNamespace(metadata),
+    ValidationError,
+  );
+  assertEquals(error.rule, SpecRule.OmeNamespace);
+  assertEquals(error.location, "multiscales[0]");
+});
+
+Deno.test("ome-namespace rule rejects a residual multiscales wrapper", () => {
+  // The multiscales array is also a group-level key; it must not appear inside
+  // a multiscale entry.
+  const metadata = validV05Metadata();
+  metadata.extra = { multiscales: [] };
+  const error = assertThrows(
+    () => validateOmeNamespace(metadata),
+    ValidationError,
+  );
+  assertEquals(error.rule, SpecRule.OmeNamespace);
+  assertEquals(error.location, "multiscales[0]");
+});
+
+// --- end-to-end through validateStructural ---------------------------------
+
+Deno.test("validateStructural accepts clean v0.5", () => {
+  // End-to-end through the orchestrator: a clean v0.5 metadata passes every
+  // rule (the new v0.5 namespacing rules included).
+  validateStructural(validV05Metadata());
+});
+
+Deno.test("validateStructural flags a malformed v0.5 ome namespace", () => {
+  const metadata = validV05Metadata();
+  metadata.extra = { ome: { version: "0.5" } };
+  const error = assertThrows(
+    () => validateStructural(metadata),
+    ValidationError,
+  );
+  assertEquals(error.rule, SpecRule.OmeNamespace);
+});
+
+Deno.test("validateStructural flags a malformed v0.5 zarr_format", () => {
+  const metadata = validV05Metadata();
+  metadata.extra = { zarr_format: 2 };
+  const error = assertThrows(
+    () => validateStructural(metadata),
+    ValidationError,
+  );
+  assertEquals(error.rule, SpecRule.ZarrFormat);
+});


### PR DESCRIPTION
## Summary

Extends structural validation to OME-Zarr **v0.5** across the Python
(`ngff-zarr`) and TypeScript (`@fideus-labs/ngff-zarr`) implementations, and
aligns the Python read-path JSON-Schema pass to validate v0.5 stores against the
v0.5 image schema. Prior to this branch, structural validation only encoded the
v0.4 spec MUSTs, and a v0.5 store's metadata was schema-checked against the v0.4
image schema.

## What changed

### Two new structural rules (version-gated; inert for v0.4)

Added to the `SpecRule` surface in both ports, mirrored byte-for-byte:

- **`zarr-format`** — a v0.5 entry implies a Zarr v3 store; a `zarr_format`
  value that leaked into the multiscale entry must be exactly `3`.
- **`ome-namespace`** — a v0.5 entry must not retain a group-level `ome` or
  `multiscales` wrapper key. The `ome` namespace wraps the group attributes, not
  each multiscale entry, so a residual wrapper signals a malformed or
  double-namespaced document.

Both rules fire only for v0.5 metadata and are a no-op for v0.4. They run last in
the `validate_structural` / `validateStructural` orchestrators.

### Leaked-key capture + version hoisting

To feed the new rules, the metadata model gains an `extra` passthrough that the
reader fills with any unrecognized `multiscales[]` entry key (mirrors the
reference Rust port's `#[serde(flatten)]` passthrough). The reader also hoists
the group-level v0.5 `version` (from `ome.version`) so the structural pass sees
the true spec version, and the v0.5 read paths floor the version to `"0.5"` —
so a malformed store missing `ome.version` is still validated with the v0.5
rules rather than silently as v0.4. The write path drops `extra` so it is never
serialized.

### v0.5 schema validation (Python read path)

The read-path JSON-Schema pass previously validated a v0.5 store's unwrapped
`ome` content against the **v0.4** image schema (the per-entry `version` is
absent at v0.5, so version detection fell back to `"0.4"`). It now selects the
schema by the group-level version and, for v0.5, re-wraps the content under the
required `ome` namespace so it validates against the vendored v0.5 image schema.
The v0.4 and v0.5 schemas share identical multiscale definitions and differ only
in the `ome` wrapper, so this is behavior-neutral on realistic read-path inputs;
it fixes the semantic wrongness of checking v0.5 content against the v0.4 schema
and future-proofs against the schemas diverging.

TypeScript needs no schema change: its read path performs no JSON/Zod schema
pass (only ad-hoc checks, RFC 4, and the structural rules), so v0.5 schema-level
coverage there is provided by the new structural namespacing rules.

## Why

The validation surface previously stopped at v0.4 even though both packages read
and write v0.5. This brings the structural rule set and the Python schema pass up
to v0.5, keeping the two language ports in lockstep (the cross-language parity
tests lock the shared `SpecRule` manifest and evaluation order).

## Implementation notes

- The two new rules are deliberately metadata-only and version-gated; the
  authoritative on-disk `zarr_format` byte remains a store-level concern.
- The cross-language `SpecRule` parity manifests and the `docs/validation/`
  rule-reference, overview, and parity pages are updated to include the two new
  rules (now 13 identifiers; entries 10–11 are the v0.5 namespacing rules).
- Behavior-neutral changes are guarded by focused tests proven to fail when
  reverted: a write-path test that `extra` is never serialized, a version-floor
  regression test (malformed store missing `ome.version` still validated as
  v0.5), and a spy test locking which schema instance/version the read path
  hands the validator.

## Testing

- Python: structural-validation (unit + parity + reader + v0.5), schema
  validation, HCS, and round-trip suites pass.
- TypeScript: structural-validation (unit + parity + reader + v0.5) and
  round-trip suites pass.
- `ruff` / pre-commit and `deno fmt` / `check` / `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OME-Zarr v0.5-only structural validation rules: **`zarr-format`** (requires Zarr v3) and **`ome-namespace`** (prevents double-namespacing).
  * Validation errors now report the specific rule and location for v0.5 namespace/zarr format violations.

* **Bug Fixes**
  * Prevented leaked/unrecognized `multiscales[]` metadata from being persisted back during read/write.
  * Improved detection of v0.4 vs v0.5 metadata layouts to apply the correct structural checks.

* **Documentation**
  * Updated structural validation, parity, and rule reference docs for v0.4 vs v0.5 MUSTs and rule ordering.

* **Tests**
  * Added/expanded Python and Deno test coverage for strict vs non-strict validation and version-gated behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->