### PR TITLE
fix(py): downsample when image size is exactly twice the chunk size (#551)

### DIFF
--- a/py/test/test_ngff_image_scale_factors.py
+++ b/py/test/test_ngff_image_scale_factors.py
@@ -21,6 +21,16 @@ rng = np.random.default_rng(12345)
                 {"x": 8, "y": 8, "z": 1},
             ],
         ),
+        # Image size exactly twice the chunk size should still downsample once.
+        # Regression tests for
+        # https://github.com/fideus-labs/ngff-zarr/issues/551
+        # Cubic 3D at the exact 2x boundary.
+        ((128, 128, 128), [{"x": 2, "y": 2, "z": 2}]),
+        # 2D at the exact 2x boundary.
+        ((128, 128), [{"x": 2, "y": 2}]),
+        # Anisotropic: the max dim is exactly 2x the chunk while z sits at the
+        # chunk size, so only y/x downsample.
+        ((64, 128, 128), [{"x": 2, "y": 2, "z": 1}]),
     ],
 )
 def test_scale_factors(shape, expected_factors):

--- a/py/test/test_to_multiscales.py
+++ b/py/test/test_to_multiscales.py
@@ -36,3 +36,17 @@ def test_to_multiscales_metadata_synced_with_data(shape, chunk_shape):
 
         # Assert scale factors are applied to the correct dimensions
         assert image.data.shape[2] == image.data.shape[3]  # 512 != 1024
+
+
+def test_downsamples_when_size_is_exactly_double_chunk():
+    # Regression test for
+    # https://github.com/fideus-labs/ngff-zarr/issues/551
+    # When the image size is exactly twice the chunk size, to_multiscales()
+    # should still produce a downsampled level rather than only the original.
+    array = rng.integers(low=0, high=2**16, size=(128, 128, 128), dtype=np.uint16)
+    input_image = to_ngff_image(array)
+    multiscales = to_multiscales(input_image, scale_factors=4, chunks=64)
+
+    assert len(multiscales.images) == 2
+    assert multiscales.images[0].data.shape == (128, 128, 128)
+    assert multiscales.images[1].data.shape == (64, 64, 64)


### PR DESCRIPTION
## Summary

Fixes [#551](https://github.com/fideus-labs/ngff-zarr/issues/551): `to_multiscales()` produced **only the original scale** (no downsampled levels) when an image's spatial dimension was exactly twice the chunk size — e.g. a `(128, 128, 128)` image with `chunks=64`.

## What changed

- **`py/ngff_zarr/to_multiscales.py`** — in `_ngff_image_scale_factors()`, relaxed the loop guard from a strict `>` to `>=` (`while (sizes_array >= double_chunks).any():`), with an explanatory comment.
- **`py/test/test_ngff_image_scale_factors.py`** — added three boundary cases to the parametrized unit test.
- **`py/test/test_to_multiscales.py`** — added an end-to-end regression test mirroring the issue's exact reproduction.

## Why

`_ngff_image_scale_factors()` decides how many resolution levels to generate by repeatedly halving spatial dimensions until they approach the chunk size. The loop was gated on `sizes_array > double_chunks` (where `double_chunks = 2 × chunk`). When a dimension was **exactly** `2 × chunk`, the condition `128 > 128` was `False`, so the loop body never ran and no scale factors were produced — yielding a single-level "multiscale" with no actual pyramid.

This is a common, sensible configuration (a 128³ volume with 64³ chunks), so silently skipping downsampling is surprising and defeats the purpose of `to_multiscales()`.

## Implementation details

- Changing `>` to `>=` allows exactly **one** downsampling iteration at the boundary. The halved result lands precisely at the chunk size (e.g. 128 → 64), and the loop's existing termination conditions (`scale_factor == previous` and the `min_length` product check) stop any further downsampling — so it does not over-generate levels or risk an infinite loop.
- The per-dimension skip logic is preserved: in the anisotropic case `(z=64, y=128, x=128)` with `chunks=64`, only `y`/`x` are downsampled (`z` already sits at the chunk size), producing `[{"z": 1, "y": 2, "x": 2}]`.
- Scope is Python-only. The TypeScript package takes explicit `scaleFactors` arrays (default `[2, 4]`) and has no integer min-length auto-computation path, so it does not share this bug.

## Testing

- Added regression coverage for all three behavioral variants the fix affects:
  - Cubic 3D boundary: `(128, 128, 128)` → `[{"x": 2, "y": 2, "z": 2}]`
  - 2D boundary: `(128, 128)` → `[{"x": 2, "y": 2}]`
  - Anisotropic boundary: `(64, 128, 128)` → `[{"x": 2, "y": 2, "z": 1}]`
  - End-to-end: `to_multiscales(img, scale_factors=4, chunks=64)` on a 128³ image now yields 2 images with shapes `(128,128,128)` and `(64,64,64)`.
- Verified each new test **fails without the fix** and passes with it.
- Full Python suite: **657 passed, 3 skipped** (no regressions). `ruff format`/`ruff check` clean.

Closes #551


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded regression test coverage for image downsampling behavior at exact 2× boundary conditions, including cubic 3D arrays, 2D arrays, and anisotropic 3D scenarios.
  * Added test to validate downsampling generates expected multi-scale output when input image dimensions are exactly twice the configured chunk size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->