### PR TITLE
Test big-endian pixel data; fix Zarr v3 dtype mapping on the TensorStore path

### DIFF
--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -192,15 +192,16 @@ def _numpy_to_zarr_dtype(dtype):
         "complex128": "complex128",
     }
 
-    dtype_str = str(dtype)
-
-    # Handle endianness - strip byte order chars
-    if dtype_str.startswith(("<", ">", "|")):
-        dtype_str = dtype_str[1:]
+    # ``np.dtype(...).name`` yields the canonical, byte-order-independent name
+    # (e.g. ">u2", "<u2", and "uint16" all resolve to "uint16"), so big-endian
+    # and other non-native dtypes map correctly.  ``str(dtype)`` would instead
+    # surface a byte-order-prefixed short code such as ">u2" for non-native
+    # dtypes, whose stripped form ("u2") is absent from ``dtype_map``.
+    dtype_name = np.dtype(dtype).name
 
     # Look up corresponding zarr dtype
     try:
-        return dtype_map[dtype_str]
+        return dtype_map[dtype_name]
     except KeyError:
         raise ValueError(f"dtype {dtype} cannot be mapped to Zarr v3 core dtype")
 

--- a/py/test/test_big_endian.py
+++ b/py/test/test_big_endian.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Big-endian pixel data round-trips and reads.
+
+OME-Zarr data produced by other tools (e.g. raw2ometiff, NGFF-Converter,
+ITK's OME-Zarr IO) can be stored big-endian.  These tests verify that
+``ngff-zarr`` reads such data with correct values and round-trips big-endian
+input without corruption, for both OME-Zarr 0.4 (Zarr v2, byte order encoded
+in the ``dtype`` string) and 0.5 (Zarr v3, byte order encoded by the ``bytes``
+codec).
+
+See https://github.com/fideus-labs/ngff-zarr/issues/97
+"""
+
+import json
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+import zarr
+from ngff_zarr import (
+    from_ngff_zarr,
+    to_multiscales,
+    to_ngff_image,
+    to_ngff_zarr,
+)
+from packaging import version as _pkg_version
+
+zarr_version = _pkg_version.parse(zarr.__version__)
+
+# OME-Zarr 0.5 writes Zarr v3, which needs a zarr-python with the v3 API
+# (major >= 3, i.e. >= 3.0.0b1).  Older zarr (resolved on some CI legs) raises on
+# the v0.5 path, so v0.5 cases are skipped there rather than failing.  The
+# 3.0.0b1 boundary matches the shared test infrastructure in ``_data.py``.
+requires_zarr_v3 = pytest.mark.skipif(
+    zarr_version < _pkg_version.parse("3.0.0b1"),
+    reason="OME-Zarr 0.5 (Zarr v3) requires zarr-python >= 3.0.0b1",
+)
+
+# Version parametrization where the 0.5 case carries the Zarr v3 guard.
+VERSION_PARAMS = ["0.4", pytest.param("0.5", marks=requires_zarr_v3)]
+
+# Multi-byte dtypes exercised in both byte orders.  ``|`` (single byte) types
+# carry no byte order, so they are not relevant here.
+BIG_ENDIAN_DTYPES = [">u2", ">i2", ">i4", ">u4", ">f4", ">f8"]
+
+
+def _native(dtype_str: str) -> np.dtype:
+    """The native-byte-order equivalent of ``dtype_str``."""
+    return np.dtype(dtype_str).newbyteorder("=")
+
+
+def _ramp(dtype_str: str, shape=(8, 8)) -> np.ndarray:
+    """A deterministic ramp image in the requested (possibly big-endian) dtype."""
+    n = int(np.prod(shape))
+    return np.arange(n, dtype=dtype_str).reshape(shape)
+
+
+def _find_array_meta(store_path: Path) -> dict:
+    """Return the parsed metadata of the first scale array in ``store_path``."""
+    # Zarr v2 -> .zarray, Zarr v3 -> zarr.json with node_type == "array".
+    zarray = sorted(store_path.rglob(".zarray"))
+    if zarray:
+        return json.loads(zarray[0].read_text())
+    for cand in sorted(store_path.rglob("zarr.json")):
+        meta = json.loads(cand.read_text())
+        if meta.get("node_type") == "array":
+            return meta
+    raise AssertionError(f"No array metadata found under {store_path}")
+
+
+def _first_array_dir(store_path: Path) -> Path:
+    """Directory of the first scale array node in a Zarr v3 store."""
+    for cand in sorted(store_path.rglob("zarr.json")):
+        meta = json.loads(cand.read_text())
+        if meta.get("node_type") == "array":
+            return cand.parent
+    raise AssertionError(f"No array node found under {store_path}")
+
+
+# ---------------------------------------------------------------------------
+# Round-trips: big-endian input in, correct values out.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype_str", BIG_ENDIAN_DTYPES)
+def test_v04_big_endian_roundtrip(tmp_path, dtype_str):
+    """OME-Zarr 0.4 preserves big-endian on disk and reads correct values."""
+    expected = _ramp(dtype_str)
+    image = to_ngff_image(expected, dims=["y", "x"])
+    multiscales = to_multiscales(image, scale_factors=[])
+
+    store_path = tmp_path / "be_v04.zarr"
+    to_ngff_zarr(str(store_path), multiscales, version="0.4")
+
+    # Zarr v2 records the byte order in the dtype string and keeps it big-endian.
+    meta = _find_array_meta(store_path)
+    assert meta["dtype"].startswith(">"), meta["dtype"]
+
+    multiscales_back = from_ngff_zarr(str(store_path))
+    back = np.asarray(multiscales_back.images[0].data)
+
+    # Values are preserved; byte order is normalized to native on read.
+    assert np.array_equal(back, expected.astype(_native(dtype_str)))
+    assert back.dtype.byteorder in ("=", "<", "|")
+
+
+@requires_zarr_v3
+@pytest.mark.parametrize("dtype_str", BIG_ENDIAN_DTYPES)
+def test_v05_big_endian_roundtrip(tmp_path, dtype_str):
+    """OME-Zarr 0.5 round-trips big-endian input with correct values."""
+    expected = _ramp(dtype_str)
+    image = to_ngff_image(expected, dims=["y", "x"])
+    multiscales = to_multiscales(image, scale_factors=[])
+
+    store_path = tmp_path / "be_v05.zarr"
+    to_ngff_zarr(str(store_path), multiscales, version="0.5")
+
+    # Zarr v3 normalizes to little-endian storage via the ``bytes`` codec.
+    meta = _find_array_meta(store_path)
+    bytes_codec = next(c for c in meta["codecs"] if c["name"] == "bytes")
+    assert bytes_codec["configuration"]["endian"] == "little"
+
+    multiscales_back = from_ngff_zarr(str(store_path))
+    back = np.asarray(multiscales_back.images[0].data)
+
+    assert np.array_equal(back, expected.astype(_native(dtype_str)))
+    assert back.dtype.byteorder in ("=", "<", "|")
+
+
+@pytest.mark.parametrize("version", VERSION_PARAMS)
+def test_big_endian_matches_little_endian(tmp_path, version):
+    """Big- and little-endian inputs with equal values read back identically."""
+    big = _ramp(">u2", shape=(4, 6))
+    little = big.astype("<u2")
+    assert np.array_equal(big, little)  # same logical values, different storage
+
+    results = []
+    for tag, arr in (("be", big), ("le", little)):
+        ms = to_multiscales(to_ngff_image(arr, dims=["y", "x"]), scale_factors=[])
+        store_path = tmp_path / f"{tag}_{version}.zarr"
+        to_ngff_zarr(str(store_path), ms, version=version)
+        results.append(np.asarray(from_ngff_zarr(str(store_path)).images[0].data))
+
+    assert np.array_equal(results[0], results[1])
+
+
+# ---------------------------------------------------------------------------
+# Reading big-endian data produced "by another tool".
+# ---------------------------------------------------------------------------
+
+
+def test_read_external_big_endian_v04(tmp_path):
+    """A Zarr v2 store whose array dtype is ``>u2`` reads with correct values."""
+    expected = _ramp(">u2")
+    ms = to_multiscales(to_ngff_image(expected, dims=["y", "x"]), scale_factors=[])
+    store_path = tmp_path / "ext_v04.zarr"
+    to_ngff_zarr(str(store_path), ms, version="0.4")
+
+    # Confirm the bytes on disk really are big-endian: the Zarr v2 ``.zarray``
+    # records the byte order in its ``dtype`` string and keeps it ``>``.  Read
+    # the metadata directly so the check does not depend on zarr-version-specific
+    # group-traversal APIs (``Group.members`` exists only in zarr-python 3).
+    meta = _find_array_meta(store_path)
+    assert meta["dtype"].startswith(">"), meta["dtype"]
+
+    back = np.asarray(from_ngff_zarr(str(store_path)).images[0].data)
+    assert np.array_equal(back, expected.astype(_native(">u2")))
+
+
+@requires_zarr_v3
+def test_read_external_big_endian_v05(tmp_path):
+    """A Zarr v3 store whose array uses an ``endian: "big"`` bytes codec reads
+    with correct values (the external-tool scenario for OME-Zarr 0.5)."""
+    from zarr.codecs import BytesCodec
+
+    expected = _ramp(">u2")
+    ms = to_multiscales(to_ngff_image(expected, dims=["y", "x"]), scale_factors=[])
+    store_path = tmp_path / "ext_v05.zarr"
+    to_ngff_zarr(str(store_path), ms, version="0.5")
+
+    # Re-encode the inner array as big-endian in place, mimicking a writer that
+    # emits ``endian: "big"``.  Reuse ngff-zarr's own group metadata so the
+    # store stays a valid OME-Zarr 0.5.
+    arr_dir = _first_array_dir(store_path)
+    src = zarr.open_array(str(arr_dir), mode="r")
+    data = np.asarray(src[:])
+    chunks = src.chunks
+    shutil.rmtree(arr_dir)
+    be = zarr.create_array(
+        store=str(arr_dir),
+        shape=data.shape,
+        chunks=chunks,
+        dtype="uint16",
+        serializer=BytesCodec(endian="big"),
+    )
+    be[:] = data
+    meta = json.loads((arr_dir / "zarr.json").read_text())
+    bytes_codec = next(c for c in meta["codecs"] if c["name"] == "bytes")
+    assert bytes_codec["configuration"]["endian"] == "big"
+    zarr.consolidate_metadata(str(store_path))
+
+    back = np.asarray(from_ngff_zarr(str(store_path)).images[0].data)
+    assert np.array_equal(back, expected.astype(_native(">u2")))
+
+
+# ---------------------------------------------------------------------------
+# Downsampling big-endian input.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype_str", [">u2", ">f4"])
+@pytest.mark.parametrize("version", VERSION_PARAMS)
+def test_big_endian_downsampling_roundtrip(tmp_path, dtype_str, version):
+    """Multiscale generation from big-endian input round-trips every scale."""
+    big = _ramp(dtype_str, shape=(16, 16))
+    image = to_ngff_image(big, dims=["y", "x"])
+    multiscales = to_multiscales(image, scale_factors=[2])
+    assert len(multiscales.images) == 2
+
+    store_path = tmp_path / f"ms_{version}.zarr"
+    to_ngff_zarr(str(store_path), multiscales, version=version)
+
+    back = from_ngff_zarr(str(store_path))
+    assert len(back.images) == len(multiscales.images)
+    for written, read in zip(multiscales.images, back.images):
+        written_native = np.asarray(written.data).astype(_native(dtype_str))
+        read_arr = np.asarray(read.data)
+        assert read_arr.shape == written_native.shape
+        np.testing.assert_allclose(read_arr, written_native, rtol=0, atol=0)
+
+
+# ---------------------------------------------------------------------------
+# TensorStore write path.
+#
+# The TensorStore Zarr v3 writer maps the array dtype to a Zarr v3 core dtype
+# name via ``_numpy_to_zarr_dtype``.  That mapping must canonicalize byte order:
+# a big-endian ``>u2`` has to resolve to ``"uint16"``, not fail.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "dtype_str,expected",
+    [
+        (">u2", "uint16"),
+        (">i2", "int16"),
+        (">i4", "int32"),
+        (">u4", "uint32"),
+        (">f4", "float32"),
+        (">f8", "float64"),
+        ("<u2", "uint16"),
+        ("uint16", "uint16"),
+    ],
+)
+def test_numpy_to_zarr_dtype_canonicalizes_byteorder(dtype_str, expected):
+    """The Zarr v3 dtype mapping is byte-order independent."""
+    from ngff_zarr.to_ngff_zarr import _numpy_to_zarr_dtype
+
+    assert _numpy_to_zarr_dtype(np.dtype(dtype_str)) == expected
+
+
+def test_numpy_to_zarr_dtype_rejects_unsupported():
+    """A dtype with no Zarr v3 core equivalent raises a clear error."""
+    from ngff_zarr.to_ngff_zarr import _numpy_to_zarr_dtype
+
+    with pytest.raises(ValueError, match="cannot be mapped to Zarr v3 core dtype"):
+        _numpy_to_zarr_dtype(np.dtype("datetime64[s]"))
+
+
+@pytest.mark.parametrize("dtype_str", [">u2", ">f4"])
+@pytest.mark.parametrize("version", VERSION_PARAMS)
+def test_big_endian_tensorstore_roundtrip(tmp_path, version, dtype_str):
+    """Writing big-endian input via the TensorStore backend round-trips."""
+    pytest.importorskip("tensorstore")
+
+    expected = _ramp(dtype_str)
+    image = to_ngff_image(expected, dims=["y", "x"])
+    multiscales = to_multiscales(image, scale_factors=[])
+
+    store_path = tmp_path / f"ts_{version}.zarr"
+    to_ngff_zarr(str(store_path), multiscales, version=version, use_tensorstore=True)
+
+    back = np.asarray(from_ngff_zarr(str(store_path)).images[0].data)
+    assert np.array_equal(back, expected.astype(_native(dtype_str)))

--- a/ts/test/big_endian_test.ts
+++ b/ts/test/big_endian_test.ts
@@ -1,0 +1,219 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+//
+// Big-endian pixel data reads.
+//
+// OME-Zarr produced by other tools (raw2ometiff, NGFF-Converter, ITK's
+// OME-Zarr IO) can store pixel data big-endian. OME-Zarr 0.4 (Zarr v2) encodes
+// byte order in the `dtype` string (`>u2`); OME-Zarr 0.5 (Zarr v3) encodes it
+// in the `bytes` codec (`endian: "big"`). These tests build stores with
+// genuinely big-endian chunk bytes (laid out by hand, independent of the
+// writer) and assert that `fromNgffZarr` decodes correct pixel values.
+//
+// See https://github.com/fideus-labs/ngff-zarr/issues/97
+import { assertEquals } from "@std/assert";
+import * as zarr from "zarrita";
+import { fromNgffZarr, type MemoryStore } from "../src/io/from_ngff_zarr.ts";
+import { zarrGet } from "../src/utils/worker_pool.ts";
+
+const enc = new TextEncoder();
+
+interface DTypeInfo {
+  /** Zarr v3 `data_type` name. */
+  dataType: string;
+  /** Zarr v2 big-endian `dtype` string. */
+  v2: string;
+  /** Bytes per element. */
+  size: number;
+  /** Write one big-endian element into a DataView. */
+  write: (dv: DataView, offset: number, value: number) => void;
+}
+
+const DTYPES: Record<string, DTypeInfo> = {
+  uint16: {
+    dataType: "uint16",
+    v2: ">u2",
+    size: 2,
+    write: (dv, o, v) => dv.setUint16(o, v, false),
+  },
+  int16: {
+    dataType: "int16",
+    v2: ">i2",
+    size: 2,
+    write: (dv, o, v) => dv.setInt16(o, v, false),
+  },
+  int32: {
+    dataType: "int32",
+    v2: ">i4",
+    size: 4,
+    write: (dv, o, v) => dv.setInt32(o, v, false),
+  },
+  float32: {
+    dataType: "float32",
+    v2: ">f4",
+    size: 4,
+    write: (dv, o, v) => dv.setFloat32(o, v, false),
+  },
+};
+
+/** Encode `values` as big-endian bytes for the given dtype. */
+function bigEndianBytes(values: number[], info: DTypeInfo): Uint8Array {
+  const buf = new ArrayBuffer(values.length * info.size);
+  const dv = new DataView(buf);
+  values.forEach((v, i) => info.write(dv, i * info.size, v));
+  return new Uint8Array(buf);
+}
+
+const SHAPE = [2, 3];
+const CHUNK = [2, 3];
+const AXES = [{ name: "y", type: "space" }, { name: "x", type: "space" }];
+
+/** A 2x3 OME-Zarr 0.4 (Zarr v2) store with a big-endian array. */
+function buildV04(values: number[], info: DTypeInfo): MemoryStore {
+  const s = new Map<string, Uint8Array>();
+  s.set("/.zgroup", enc.encode(JSON.stringify({ zarr_format: 2 })));
+  s.set(
+    "/.zattrs",
+    enc.encode(JSON.stringify({
+      multiscales: [{
+        version: "0.4",
+        name: "image",
+        axes: AXES,
+        datasets: [{
+          path: "0",
+          coordinateTransformations: [{ type: "scale", scale: [1, 1] }],
+        }],
+      }],
+    })),
+  );
+  s.set(
+    "/0/.zarray",
+    enc.encode(JSON.stringify({
+      zarr_format: 2,
+      shape: SHAPE,
+      chunks: CHUNK,
+      dtype: info.v2,
+      compressor: null,
+      fill_value: 0,
+      order: "C",
+      filters: null,
+      dimension_separator: ".",
+    })),
+  );
+  s.set(
+    "/0/.zattrs",
+    enc.encode(JSON.stringify({ _ARRAY_DIMENSIONS: ["y", "x"] })),
+  );
+  s.set("/0/0.0", bigEndianBytes(values, info));
+  return s;
+}
+
+/** A 2x3 OME-Zarr 0.5 (Zarr v3) store with an `endian: "big"` array. */
+function buildV05(values: number[], info: DTypeInfo): MemoryStore {
+  const s = new Map<string, Uint8Array>();
+  s.set(
+    "/zarr.json",
+    enc.encode(JSON.stringify({
+      zarr_format: 3,
+      node_type: "group",
+      attributes: {
+        ome: {
+          version: "0.5",
+          multiscales: [{
+            version: "0.5",
+            name: "image",
+            axes: AXES,
+            datasets: [{
+              path: "scale0",
+              coordinateTransformations: [{ type: "scale", scale: [1, 1] }],
+            }],
+          }],
+        },
+      },
+    })),
+  );
+  s.set(
+    "/scale0/zarr.json",
+    enc.encode(JSON.stringify({
+      zarr_format: 3,
+      node_type: "array",
+      shape: SHAPE,
+      data_type: info.dataType,
+      chunk_grid: { name: "regular", configuration: { chunk_shape: CHUNK } },
+      chunk_key_encoding: {
+        name: "default",
+        configuration: { separator: "/" },
+      },
+      fill_value: 0,
+      codecs: [{ name: "bytes", configuration: { endian: "big" } }],
+      attributes: {},
+      dimension_names: ["y", "x"],
+      storage_transformers: [],
+    })),
+  );
+  s.set("/scale0/c/0/0", bigEndianBytes(values, info));
+  return s;
+}
+
+async function readValues(store: MemoryStore): Promise<number[]> {
+  const ms = await fromNgffZarr(store);
+  const chunk = await zarr.get(ms.images[0].data);
+  return Array.from(chunk.data as ArrayLike<number>);
+}
+
+const VALUES = [10, 20, 30, 40, 50, 60];
+
+for (const [name, info] of Object.entries(DTYPES)) {
+  Deno.test(`fromNgffZarr reads big-endian OME-Zarr 0.4 (${info.v2})`, async () => {
+    assertEquals(await readValues(buildV04(VALUES, info)), VALUES);
+  });
+
+  Deno.test(`fromNgffZarr reads big-endian OME-Zarr 0.5 (${name}, endian:big)`, async () => {
+    assertEquals(await readValues(buildV05(VALUES, info)), VALUES);
+  });
+}
+
+Deno.test("big-endian values differ from a naive little-endian misread", async () => {
+  // Guards against a regression that silently skips the byte swap: reading the
+  // big-endian bytes as little-endian would yield byte-swapped values, not the
+  // originals. 10 (0x000A) misread little-endian is 0x0A00 = 2560.
+  const info = DTYPES.uint16;
+  const misread = [2560, 5120, 7680, 10240, 12800, 15360];
+  const v04 = await readValues(buildV04(VALUES, info));
+  const v05 = await readValues(buildV05(VALUES, info));
+  assertEquals(v04, VALUES);
+  assertEquals(v05, VALUES);
+  assertNotMisread(v04, misread);
+  assertNotMisread(v05, misread);
+});
+
+function assertNotMisread(actual: number[], misread: number[]): void {
+  assertEquals(
+    JSON.stringify(actual) === JSON.stringify(misread),
+    false,
+    "values look byte-swapped — the big-endian byte order was not honored",
+  );
+}
+
+Deno.test("repeated reads of a big-endian array via zarrGet stay correct", async () => {
+  // The production read path (worker-accelerated `zarrGet`) must not corrupt
+  // the backing store across repeated reads. A naive in-place byte swap on the
+  // stored buffer would make the second read of an in-memory store wrong.
+  const info = DTYPES.uint16;
+  const store = buildV05(VALUES, info);
+  const ms = await fromNgffZarr(store);
+  const arr = ms.images[0].data;
+
+  const r1 = Array.from((await zarrGet(arr)).data as ArrayLike<number>);
+  const r2 = Array.from((await zarrGet(arr)).data as ArrayLike<number>);
+  const r3 = Array.from((await zarrGet(arr)).data as ArrayLike<number>);
+  assertEquals(r1, VALUES);
+  assertEquals(r2, VALUES);
+  assertEquals(r3, VALUES);
+
+  // The stored chunk bytes must be unchanged after reading.
+  assertEquals(
+    Array.from(store.get("/scale0/c/0/0")!),
+    Array.from(bigEndianBytes(VALUES, info)),
+  );
+});


### PR DESCRIPTION
## Summary

Adds big-endian pixel data test coverage across the Python and TypeScript packages, and fixes a Zarr v3 dtype-mapping bug uncovered while writing those tests. Addresses #97.

OME-Zarr written by other tools — raw2ometiff, NGFF-Converter, and ITK's OME-Zarr IO (xref [ITK#4888](https://github.com/InsightSoftwareConsortium/ITK/pull/4888#issuecomment-2430095202)) — can store pixel data big-endian. OME-Zarr 0.4 (Zarr v2) encodes byte order in the `dtype` string (`>u2`); OME-Zarr 0.5 (Zarr v3) encodes it in the `bytes` codec (`endian: "big"`). This PR locks in correct handling of both.

## The fix

`_numpy_to_zarr_dtype` (`py/ngff_zarr/to_ngff_zarr.py`), used by the **TensorStore** Zarr v3 write path, stripped the byte-order prefix from `str(dtype)` — turning `">u2"` into `"u2"` — and then looked that up in a table keyed by canonical names (`"uint16"`). The key was never present, so **every non-native dtype** raised:

```
ValueError: dtype >u2 cannot be mapped to Zarr v3 core dtype
```

This meant big-endian input written with `use_tensorstore=True` and `version="0.5"` always failed — exactly the medical/ITK conversion path the issue is about.

The fix uses `np.dtype(dtype).name`, the canonical byte-order-independent name, so `">u2"`, `"<u2"`, and `"uint16"` all resolve to `"uint16"`. The change is minimal and does not affect the non-TensorStore write paths (zarr-python already normalizes byte order there).

## Tests

**Python** (`py/test/test_big_endian.py`, 33 tests):

- v0.4 and v0.5 round-trips over `>u2/>i2/>i4/>u4/>f4/>f8`, asserting values are preserved and normalized to native byte order on read
- big-endian vs little-endian equivalence (same logical values read back identically)
- reading externally-produced big-endian stores: a Zarr v2 `>u2` array, and a Zarr v3 array re-encoded with an `endian: "big"` bytes codec
- big-endian multiscale downsampling round-trips
- **TensorStore** big-endian round-trips for v0.4/v0.5 (regression coverage for the fix above)
- direct `_numpy_to_zarr_dtype` unit tests (8 byte-order cases plus an unsupported-dtype rejection)

v0.5 cases carry a `requires_zarr_v3` skip marker (`zarr < 3.0.0b1`) so they skip cleanly on the zarr-2.x CI legs, matching the boundary used by the shared `test/_data.py`.

**TypeScript** (`ts/test/big_endian_test.ts`, 10 tests):

- builds OME-Zarr 0.4 and 0.5 stores with hand-laid big-endian chunk bytes (independent of the writer) and asserts `fromNgffZarr` decodes correct pixel values across `uint16/int16/int32/float32`
- a guard asserting values are not silently byte-swapped
- a repeated-read check through the production worker-accelerated `zarrGet` path, verifying the backing store is not mutated across reads

## Findings (no fix required)

Reads already decode big-endian correctly in both languages: Python normalizes to native byte order in `v04/zarr_metadata.py` (shared by the v0.5 reader), and the TypeScript production `zarrGet` path decodes and is buffer-safe across repeated reads. The only code change needed was the TensorStore write-path dtype mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved correct decoding of big-endian pixel data for OME-Zarr v0.4 and v0.5.
  * Fixed dtype name handling for non-native byte-order inputs to match Zarr v3 core dtype behavior.

* **Tests**
  * Added extensive big-endian coverage for both OME-Zarr v0.4 (dtype string) and v0.5 (bytes codec), including multiscale and round-trip scenarios.
  * Added Deno regression tests to verify `fromNgffZarr` decoding accuracy and ensure repeated reads do not change stored bytes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->