### PR TITLE
feat!: write RFC-4 anatomical orientation automatically, drop enabled-rfcs API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,9 +348,11 @@ Methods.DASK_IMAGE_GAUSSIAN    # scipy-based fallback
 ### RFC-4 Anatomical Orientation
 
 ```python
-from ngff_zarr.rfc4 import LPS, RAS, AnatomicalOrientation
-# Use add_anatomical_orientation_to_axis() to add spatial context
-# Enable via is_rfc4_enabled() configuration
+from ngff_zarr.rfc4 import LPS, RAS, AnatomicalOrientation, orientation_from_name
+# Set NgffImage.axes_orientations, or pass orientation= to to_multiscales()
+# (a preset name like "LPS"/"RAS" or a per-axis mapping). Anatomical
+# orientation is written to the output automatically whenever it is present;
+# there is no separate enable flag.
 ```
 
 ### Error Handling Patterns

--- a/docs/rfc4.md
+++ b/docs/rfc4.md
@@ -17,34 +17,47 @@ facilitating consistent analysis and interpretation of biological data.
 
 ### Programmatic Usage
 
-#### Enabling RFC-4
+#### Writing Anatomical Orientation
 
-To enable [RFC-4] support when writing OME-NGFF Zarr data, include `4` in the
-`enabled_rfcs` parameter:
+Anatomical orientation is written to the output automatically whenever it is
+present -- there is no separate opt-in. Provide orientation either by setting
+`axes_orientations` on the `NgffImage`, or by passing the `orientation` keyword
+to `to_multiscales()` (a preset name such as `"LPS"` or `"RAS"`, or a per-axis
+mapping of `AnatomicalOrientation`):
 
 ```python
 import ngff_zarr
 
-# Enable RFC-4 when converting to NGFF Zarr
+# Provide orientation via the `orientation` keyword (a preset name here)
+multiscales = ngff_zarr.to_multiscales(ngff_image, orientation="LPS")
+
+# Orientation is written automatically -- no enable flag required
 ngff_zarr.to_ngff_zarr(
     store="output.ome.zarr",
     multiscales=multiscales,
-    enabled_rfcs=[4]  # Enable RFC-4
 )
 ```
 
+Images that carry no anatomical orientation produce standard OME-NGFF metadata
+with no `orientation` field.
+
 ### CLI Usage
 
-RFC-4 can be enabled via the command line using the `--enable-rfc` flag:
+Use the `--orientation` flag to attach anatomical orientation to the spatial
+axes. It accepts a preset coordinate system (`LPS` or `RAS`) or ordered
+dim/value pairs. Orientation is written to the output automatically when
+present:
 
 ```bash
-# Convert a medical image with RFC-4 anatomical orientation enabled
-ngff-zarr -i image.nii.gz -o output.ome.zarr --enable-rfc 4
+# Convert a medical image using the LPS coordinate system
+ngff-zarr -i image.nii.gz -o output.ome.zarr --orientation LPS
 
-# Enable multiple RFCs (when available)
-ngff-zarr -i image.nii.gz -o output.ome.zarr --enable-rfc 4 --enable-rfc 5
+# Or specify orientation per axis as ordered dim/value pairs
+ngff-zarr -i image.nii.gz -o output.ome.zarr \
+    --orientation x right-to-left y anterior-to-posterior z inferior-to-superior
 
-# Without RFC-4 (default behavior - orientation metadata filtered out)
+# Inputs that already carry orientation (e.g. NIfTI, NRRD, DICOM via ITK)
+# write it automatically with no extra flags
 ngff-zarr -i image.nii.gz -o output.ome.zarr
 ```
 
@@ -68,12 +81,12 @@ ngff_image = ngff_zarr.itk_image_to_ngff_image(
     add_anatomical_orientation=True
 )
 
-# Convert to multiscales and write to Zarr with RFC-4 enabled
+# Convert to multiscales and write to Zarr -- because the image carries
+# orientation, it is written automatically
 multiscales = ngff_zarr.to_multiscales(ngff_image)
 ngff_zarr.to_ngff_zarr(
     store="output.ome.zarr",
     multiscales=multiscales,
-    enabled_rfcs=[4]
 )
 ```
 
@@ -204,12 +217,11 @@ ngff_image = nz.NgffImage(
     axes_orientations=nz.LPS
 )
 
-# Convert to multiscales and write with RFC-4 enabled
+# Convert to multiscales and write -- orientation is written automatically
 multiscales = nz.to_multiscales(ngff_image)
 nz.to_ngff_zarr(
     store="output.ome.zarr",
     multiscales=multiscales,
-    enabled_rfcs=[4]
 )
 ```
 
@@ -248,12 +260,11 @@ ngff_image = nz.NgffImage(
     axes_orientations=ngff_zarr.RAS
 )
 
-# Convert to multiscales and write with RFC-4 enabled
+# Convert to multiscales and write -- orientation is written automatically
 multiscales = nz.to_multiscales(ngff_image)
 nz.to_ngff_zarr(
     store="brain_data.ome.zarr",
     multiscales=multiscales,
-    enabled_rfcs=[4]
 )
 ```
 
@@ -307,8 +318,8 @@ ngff_image = NgffImage(
 
 ## Metadata Format
 
-When RFC-4 is enabled, spatial axes in the OME-NGFF metadata include an
-`orientation` field:
+When anatomical orientation is present, the spatial axes in the OME-NGFF
+metadata include an `orientation` field:
 
 ```json
 {
@@ -350,6 +361,8 @@ When RFC-4 is enabled, spatial axes in the OME-NGFF metadata include an
 
 - `itk_lps_to_anatomical_orientation(axis_name)`: Map ITK LPS axes to
   orientations
+- `orientation_from_name(name)`: Resolve a preset name (`"LPS"`/`"RAS"`) to a
+  per-axis orientation mapping
 - `add_anatomical_orientation_to_axis(axis_dict, orientation)`: Add orientation
   to axis
 - `remove_anatomical_orientation_from_axis(axis_dict)`: Remove orientation from
@@ -373,14 +386,16 @@ When RFC-4 is enabled, spatial axes in the OME-NGFF metadata include an
 
 ## Compatibility
 
-When RFC-4 is not enabled (the default), orientation metadata is automatically
-filtered out during Zarr writing to maintain compatibility with standard
-OME-NGFF consumers.
+Anatomical orientation is written only when it is present on the image's axes.
+Images without orientation produce standard OME-NGFF metadata with no
+`orientation` field, so consumers that do not understand [RFC-4] are
+unaffected.
 
 ## Best Practices
 
-1. **Enable RFC-4** when working with medical/biological images where
-   orientation matters
+1. **Provide orientation** (via `axes_orientations` or the `orientation`
+   keyword of `to_multiscales`) when working with medical/biological images
+   where orientation matters
 2. **Use convenience constants** (`LPS`, `RAS`) for standard coordinate systems
 3. **Use ITK integration** for automatic LPS-based orientation when converting
    from medical image formats

--- a/mcp/ngff_zarr_mcp/models.py
+++ b/mcp/ngff_zarr_mcp/models.py
@@ -29,12 +29,16 @@ class ConversionOptions(BaseModel):
     units: dict[str, str] | None = Field(None, description="Units for each dimension")
     name: str | None = Field(None, description="Image name")
 
-    # RFC 4 - Anatomical Orientation support
+    # RFC 4 - Anatomical Orientation support. Anatomical orientation is written
+    # automatically whenever it is present, so specifying a preset here is all
+    # that is required to enable it.
     anatomical_orientation: str | None = Field(
-        None, description="Anatomical orientation preset (LPS, RAS) or custom mapping"
-    )
-    enable_rfc4: bool = Field(
-        False, description="Enable RFC 4 anatomical orientation support"
+        None,
+        description=(
+            "Anatomical orientation preset (LPS, RAS). Applies to file/array "
+            "inputs only; existing zarr-store inputs keep their source "
+            "orientation metadata."
+        ),
     )
 
     # Storage options for cloud/remote storage
@@ -66,12 +70,6 @@ class ConversionOptions(BaseModel):
         False, description="Use Dask LocalCluster for large datasets"
     )
     cache_dir: str | None = Field(None, description="Directory for caching")
-
-    # RFC and advanced features
-    enabled_rfcs: list[int] | None = Field(
-        None,
-        description="List of RFC numbers to enable (e.g., [4] for anatomical orientation)",
-    )
 
     @field_validator("dims")
     @classmethod

--- a/mcp/ngff_zarr_mcp/server.py
+++ b/mcp/ngff_zarr_mcp/server.py
@@ -51,8 +51,6 @@ async def convert_images_to_ome_zarr(
     cache_dir: str | None = None,
     # New RFC 4 and storage options
     anatomical_orientation: str | None = None,
-    enable_rfc4: bool = False,
-    enabled_rfcs: list[int] | None = None,
     storage_options: dict[str, str] | None = None,
 ) -> ConversionResult:
     """
@@ -76,9 +74,9 @@ async def convert_images_to_ome_zarr(
         use_tensorstore: Use TensorStore for I/O
         use_local_cluster: Use Dask LocalCluster for large datasets
         cache_dir: Directory for caching
-        anatomical_orientation: Anatomical orientation preset (LPS, RAS)
-        enable_rfc4: Enable RFC 4 anatomical orientation support
-        enabled_rfcs: List of RFC numbers to enable
+        anatomical_orientation: Anatomical orientation preset (LPS, RAS).
+            Applies to file/array inputs only; for existing zarr-store inputs
+            the orientation already in the source metadata is preserved.
         storage_options: Storage options for remote stores (S3, GCS, etc.)
 
     Returns:
@@ -115,8 +113,6 @@ async def convert_images_to_ome_zarr(
         use_local_cluster=use_local_cluster,
         cache_dir=cache_dir,
         anatomical_orientation=anatomical_orientation,
-        enable_rfc4=enable_rfc4,
-        enabled_rfcs=enabled_rfcs,
         storage_options=storage_options,  # type: ignore[arg-type]
     )
 

--- a/mcp/ngff_zarr_mcp/tools.py
+++ b/mcp/ngff_zarr_mcp/tools.py
@@ -104,7 +104,11 @@ async def convert_to_ome_zarr(
                     # Load input image
                     ngff_image = cli_input_to_ngff_image(backend, prepared_inputs)
 
-            # Apply metadata options (only to single NgffImage for non-zarr inputs)
+            # Apply metadata options (dims, scale, translation, name,
+            # anatomical_orientation). These overrides apply only to file/array
+            # inputs: for existing zarr-store inputs the source multiscales --
+            # including any orientation already in its metadata -- is written
+            # through unchanged.
             if not is_zarr_input and ngff_image is not None:
                 if options.dims:
                     if len(options.dims) != len(ngff_image.dims):
@@ -129,11 +133,15 @@ async def convert_to_ome_zarr(
                 if options.name:
                     ngff_image.name = options.name
 
-                # Apply anatomical orientation if requested (RFC 4)
+                # Apply anatomical orientation if requested (RFC 4). Setting the
+                # orientations on the image is enough -- orientation is written
+                # to the output automatically whenever it is present.
                 if options.anatomical_orientation:
-                    # Note: RFC4 orientation assignment may need proper implementation
-                    # For now, we'll skip this to avoid attribute errors
-                    pass
+                    from ngff_zarr import orientation_from_name
+
+                    ngff_image.axes_orientations = orientation_from_name(
+                        options.anatomical_orientation
+                    )
 
             # Setup chunking
             chunks = options.chunks
@@ -204,24 +212,12 @@ async def convert_to_ome_zarr(
                     options.compression_codec, options.compression_level
                 )
 
-            # Prepare enabled_rfcs parameter
-            # Note: Temporarily disabled due to compatibility issues
-            # enabled_rfcs = []
-            # if options.enable_rfc4 or options.enabled_rfcs:
-            #     if options.enable_rfc4:
-            #         enabled_rfcs.append(4)
-            #     if options.enabled_rfcs:
-            #         enabled_rfcs.extend(options.enabled_rfcs)
-            #     # Remove duplicates
-            #     enabled_rfcs = list(set(enabled_rfcs))
-
             to_ome_zarr(
                 output_store,
                 multiscales_obj,
                 version=options.ome_zarr_version,
                 chunks_per_shard=chunks_per_shard,
                 use_tensorstore=options.use_tensorstore,
-                # enabled_rfcs=enabled_rfcs if enabled_rfcs else None,  # Temporarily disabled
                 **kwargs,
             )
 

--- a/mcp/tests/test_convert_to_ome_zarr.py
+++ b/mcp/tests/test_convert_to_ome_zarr.py
@@ -251,3 +251,47 @@ async def test_convert_to_ome_zarr_invalid_options(test_input_file, temp_output_
     assert not result.success
     assert result.error is not None
     assert "validation" in result.error.lower() or "method" in result.error.lower()
+
+
+@pytest.mark.asyncio
+async def test_convert_with_anatomical_orientation(test_input_file, temp_output_dir):
+    """The ``anatomical_orientation`` preset is applied and written to the output."""
+    import zarr
+
+    assert test_input_file.exists(), f"Test input file not found: {test_input_file}"
+
+    output_path = Path(temp_output_dir) / "mr_head_orientation.ome.zarr"
+
+    # Request the RAS coordinate system explicitly.
+    options = ConversionOptions(
+        output_path=str(output_path),
+        ome_zarr_version="0.4",
+        method="itkwasm_gaussian",
+        scale_factors=None,
+        chunks=64,
+        anatomical_orientation="RAS",
+    )
+
+    result = await convert_to_ome_zarr([str(test_input_file)], options)
+    assert result.success, f"Conversion failed: {result.error}"
+    assert output_path.exists()
+
+    # Read the written metadata; v0.4 stores multiscales at the root.
+    zarr_group = zarr.open(str(output_path), mode="r")
+    raw_attrs = dict(zarr_group.attrs)
+    if "ome" in raw_attrs:
+        multiscales_metadata = raw_attrs["ome"]["multiscales"][0]
+    else:
+        multiscales_metadata = raw_attrs["multiscales"][0]
+    axes = multiscales_metadata["axes"]
+
+    # RAS preset values must be written to the spatial axes.
+    expected = {
+        "x": "left-to-right",
+        "y": "posterior-to-anterior",
+        "z": "inferior-to-superior",
+    }
+    by_name = {ax["name"]: ax for ax in axes}
+    for dim, value in expected.items():
+        assert by_name[dim]["orientation"]["type"] == "anatomical"
+        assert by_name[dim]["orientation"]["value"] == value

--- a/py/ngff_zarr/__init__.py
+++ b/py/ngff_zarr/__init__.py
@@ -46,9 +46,9 @@ from .rfc4 import (
     AnatomicalOrientationValues,
     add_anatomical_orientation_to_axis,
     anatomical_orientation_to_itk_direction,
-    is_rfc4_enabled,
     itk_direction_to_anatomical_orientation,
     itk_lps_to_anatomical_orientation,
+    orientation_from_name,
     remove_anatomical_orientation_from_axis,
 )
 from .rfc9_zip import (
@@ -182,7 +182,7 @@ __all__ = [
     "itk_lps_to_anatomical_orientation",
     "itk_direction_to_anatomical_orientation",
     "anatomical_orientation_to_itk_direction",
-    "is_rfc4_enabled",
+    "orientation_from_name",
     "add_anatomical_orientation_to_axis",
     "remove_anatomical_orientation_from_axis",
     # RFC 9 - Zipped OME-Zarr (.ozx)

--- a/py/ngff_zarr/cli.py
+++ b/py/ngff_zarr/cli.py
@@ -47,6 +47,11 @@ from .detect_cli_io_backend import (
 from .from_ngff_zarr import from_ome_zarr
 from .methods import Methods, methods_values
 from .ngff_image_to_itk_image import ngff_image_to_itk_image
+from .rfc4 import (
+    AnatomicalOrientation,
+    AnatomicalOrientationValues,
+    orientation_from_name,
+)
 from .rich_dask_progress import NgffProgress, NgffProgressCallback
 from .to_multiscales import to_multiscales
 from .to_ngff_zarr import to_ome_zarr
@@ -337,7 +342,6 @@ def _multiscales_to_ngff_zarr(
         progress=rich_dask_progress,
         use_tensorstore=args.use_tensorstore,
         version=args.ome_zarr_version,
-        enabled_rfcs=args.enable_rfc,
         **codec_kwargs,
     )
 
@@ -394,6 +398,46 @@ def _apply_cli_metadata_overrides(ngff_image, args, live):
         ngff_image.axes_units = unit_pairs
     if args.name:
         ngff_image.name = args.name
+    if args.orientation:
+        ngff_image.axes_orientations = _parse_orientation_arg(args.orientation, live)
+
+
+def _parse_orientation_arg(values, live):
+    """Parse the CLI ``--orientation`` argument into an axes_orientations mapping.
+
+    Accepts either a single preset name (``"LPS"``/``"RAS"``) or an even number
+    of ordered dim/value pairs, e.g.
+    ``x right-to-left y anterior-to-posterior z inferior-to-superior``.
+    """
+    if len(values) == 1:
+        try:
+            return orientation_from_name(values[0])
+        except ValueError as exc:
+            live.console.print(f"[red]{exc}")
+            sys.exit(1)
+
+    if len(values) % 2 != 0:
+        live.console.print(
+            "[red]--orientation expects either a preset name (LPS, RAS) or "
+            "dim/value pairs, e.g. x right-to-left y anterior-to-posterior"
+        )
+        sys.exit(1)
+
+    orientations: dict[str, AnatomicalOrientation] = {}
+    for pair in range(len(values) // 2):
+        dim = values[pair * 2]
+        value = values[pair * 2 + 1]
+        try:
+            orientation_value = AnatomicalOrientationValues(value)
+        except ValueError:
+            supported = ", ".join(v.value for v in AnatomicalOrientationValues)
+            live.console.print(
+                f"[red]Unsupported anatomical orientation value: {value!r}.\n"
+                f"[yellow]Supported values: {supported}"
+            )
+            sys.exit(1)
+        orientations[dim] = AnatomicalOrientation(value=orientation_value)
+    return orientations
 
 
 def _ngff_image_to_multiscales(
@@ -481,11 +525,13 @@ def main():
         choices=["0.4", "0.5"],
     )
     metadata_group.add_argument(
-        "--enable-rfc",
-        action="append",
-        type=int,
-        help="Enable specific RFC features. Can be used multiple times. Currently supported: 4 (anatomical orientation)",
-        metavar="RFC_NUMBER",
+        "--orientation",
+        nargs="+",
+        help="Anatomical orientation (RFC 4) for the spatial axes. Either a preset "
+        'coordinate system ("LPS" or "RAS") or ordered dim/value pairs, e.g. '
+        '"x" "right-to-left" "y" "anterior-to-posterior" "z" "inferior-to-superior". '
+        "Orientation is written to the output automatically when present.",
+        metavar="ORIENTATION",
     )
     metadata_group.add_argument(
         "--series",

--- a/py/ngff_zarr/rfc4.py
+++ b/py/ngff_zarr/rfc4.py
@@ -139,6 +139,47 @@ Example usage:
 """
 
 
+_ORIENTATION_PRESETS: dict[str, dict[str, AnatomicalOrientation]] = {
+    "lps": LPS,
+    "ras": RAS,
+}
+
+
+def orientation_from_name(
+    name: str,
+) -> dict[str, AnatomicalOrientation]:
+    """Resolve an anatomical orientation preset name to per-axis orientations.
+
+    Parameters
+    ----------
+    name : str
+        A preset coordinate-system name. Supported values are ``"LPS"`` and
+        ``"RAS"`` (case-insensitive).
+
+    Returns
+    -------
+    dict[str, AnatomicalOrientation]
+        A mapping of spatial axis name to :class:`AnatomicalOrientation`,
+        suitable for ``NgffImage.axes_orientations`` or the ``orientation``
+        argument of :func:`ngff_zarr.to_multiscales`.
+
+    Raises
+    ------
+    ValueError
+        If ``name`` is not a recognized preset.
+    """
+    try:
+        preset = _ORIENTATION_PRESETS[name.lower()]
+    except KeyError:
+        supported = ", ".join(sorted(p.upper() for p in _ORIENTATION_PRESETS))
+        msg = (
+            f"Unknown anatomical orientation preset: {name!r}. "
+            f"Supported presets: {supported}."
+        )
+        raise ValueError(msg) from None
+    return dict(preset)
+
+
 def itk_lps_to_anatomical_orientation(
     axis_name: str,
 ) -> AnatomicalOrientation | None:
@@ -289,11 +330,6 @@ def anatomical_orientation_to_itk_direction(
             col[axis_index] = -1.0
             return col
     return None
-
-
-def is_rfc4_enabled(enabled_rfcs: list[int] | None) -> bool:
-    """Check if RFC 4 is enabled in the list of enabled RFCs."""
-    return enabled_rfcs is not None and 4 in enabled_rfcs
 
 
 def add_anatomical_orientation_to_axis(

--- a/py/ngff_zarr/to_multiscales.py
+++ b/py/ngff_zarr/to_multiscales.py
@@ -38,6 +38,7 @@ from .methods._metadata import get_method_metadata
 from .methods._support import _spatial_dims
 from .multiscales import NgffMultiscales
 from .ngff_image import NgffImage
+from .rfc4 import AnatomicalOrientation, orientation_from_name
 from .rich_dask_progress import NgffProgress, NgffProgressCallback
 from .task_count import task_count
 from .to_ngff_image import to_ngff_image
@@ -481,6 +482,7 @@ def to_multiscales(
     | None = None,
     progress: NgffProgress | NgffProgressCallback | None = None,
     cache: bool | None = None,
+    orientation: str | Mapping[str, AnatomicalOrientation] | None = None,
 ) -> NgffMultiscales:
     """
     Generate multiple resolution scales for the OME-NGFF standard data model.
@@ -506,6 +508,13 @@ def to_multiscales(
 
     :param progress: Optional progress logger
     :type  progress: NgffProgress, NgffProgressCallback
+
+    :param orientation: Anatomical orientation (RFC 4) for the spatial axes. Either a preset
+        coordinate-system name (``"LPS"`` or ``"RAS"``, case-insensitive) or a mapping of axis
+        name to :class:`AnatomicalOrientation`. When provided, it takes precedence over any
+        ``axes_orientations`` on the input image. Anatomical orientation is written to the
+        output automatically whenever it is present; no separate opt-in is required.
+    :type  orientation: str or mapping of str to AnatomicalOrientation, optional
 
     :return: NgffImage for each resolution and NGFF multiscales metadata
     :rtype : NgffMultiscales
@@ -648,18 +657,28 @@ def to_multiscales(
                 if img.channel_colors is None and src_channel_colors is not None:
                     img.channel_colors = list(src_channel_colors)
 
+    # Resolve anatomical orientation (RFC 4). An explicit ``orientation``
+    # argument (preset name or mapping) takes precedence over any orientations
+    # carried on the input image.
+    if orientation is None:
+        axes_orientations = ngff_image.axes_orientations
+    elif isinstance(orientation, str):
+        axes_orientations = orientation_from_name(orientation)
+    else:
+        axes_orientations = orientation
+
     axes = []
     for dim in ngff_image.dims:
         unit = None
         if ngff_image.axes_units and dim in ngff_image.axes_units:
             unit = ngff_image.axes_units[dim]
 
-        orientation = None
-        if ngff_image.axes_orientations and dim in ngff_image.axes_orientations:
-            orientation = ngff_image.axes_orientations[dim]
+        axis_orientation = None
+        if axes_orientations and dim in axes_orientations:
+            axis_orientation = axes_orientations[dim]
 
         if dim in {"x", "y", "z"}:
-            axis = Axis(name=dim, type="space", unit=unit, orientation=orientation)
+            axis = Axis(name=dim, type="space", unit=unit, orientation=axis_orientation)
         elif dim == "c":
             axis = Axis(name=dim, type="channel", unit=unit)
         elif dim == "t":

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -29,7 +29,6 @@ from .config import config
 from .memory_usage import memory_usage
 from .methods._support import _dim_scale_factors
 from .multiscales import NgffMultiscales
-from .rfc4 import is_rfc4_enabled
 from .rfc9_zip import is_ozx_path, write_store_to_zip
 from .rich_dask_progress import NgffProgress, NgffProgressCallback
 from .to_multiscales import to_multiscales
@@ -127,26 +126,19 @@ def _remove_none_values(obj: Any) -> Any:
     return obj
 
 
-def _pop_metadata_optionals(
-    metadata_dict: dict, enabled_rfcs: list[int] | None = None
-) -> dict:
+def _pop_metadata_optionals(metadata_dict: dict) -> dict:
     """Strip optional metadata fields that must not be serialized.
 
-    Removes the draft RFC 4 ``orientation`` from every axis unless RFC 4 is
-    enabled, then recursively culls all remaining ``None``-valued keys.
+    Recursively culls all ``None``-valued keys. Axes that carry a populated
+    RFC 4 ``orientation`` keep it -- anatomical orientation is written whenever
+    it is present -- while axes whose ``orientation`` is ``None`` have the key
+    dropped by the ``None`` stripping below.
     """
     # ``Metadata.extra`` is a read-side validation aid (leaked-key capture for
     # the v0.5 namespacing rules), never part of the written multiscale entry.
     # It is an empty dict on every clean read, which ``_remove_none_values``
     # would not strip, so drop it explicitly.
     metadata_dict.pop("extra", None)
-    # RFC 4 anatomical orientation is a draft feature gated behind an explicit
-    # opt-in. Drop it from every axis (even when populated) unless RFC 4 is
-    # enabled; populated orientations on enabled writes survive the None
-    # stripping below.
-    if not is_rfc4_enabled(enabled_rfcs):
-        for ax in metadata_dict.get("axes", []):
-            ax.pop("orientation", None)
 
     return _remove_none_values(metadata_dict)
 
@@ -437,7 +429,7 @@ def _validate_ngff_parameters(
 
 
 def _prepare_metadata(
-    multiscales: NgffMultiscales, version: str, enabled_rfcs: list[int] | None = None
+    multiscales: NgffMultiscales, version: str
 ) -> tuple[Metadata_v04 | Metadata_v05, tuple[str, ...], dict]:
     """Prepare and convert metadata to the proper version format."""
     metadata = multiscales.metadata
@@ -1394,7 +1386,6 @@ def to_ome_zarr(
     chunk_store: StoreLike | None = None,
     progress: NgffProgress | NgffProgressCallback | None = None,
     chunks_per_shard: int | tuple[int, ...] | dict[str, int] | None = None,
-    enabled_rfcs: list[int] | None = None,
     scale_strategy: ScaleStrategy = "pad",
     **kwargs,
 ) -> None:
@@ -1427,8 +1418,6 @@ def to_ome_zarr(
     :param chunks_per_shard: Number of chunks along each axis in a shard. If None, no sharding. For .ozx files, defaults to 2 if not specified. Requires OME-Zarr version >= 0.5.
     :type  chunks_per_shard: int, tuple, or dict, optional
 
-    :param enabled_rfcs: List of RFC numbers to enable. If RFC 4 is included, anatomical orientation metadata will be preserved in the output.
-    :type  enabled_rfcs: list of int, optional
 
     :param scale_strategy: Strategy for handling non-power-of-2 scale factors during
         multiscale writing. "pad" (default) always uses incremental downsampling from
@@ -1440,6 +1429,18 @@ def to_ome_zarr(
 
     :param **kwargs: Passed to the zarr.create_array() or zarr.creation.create() function, e.g., compression options.
     """
+    # ``enabled_rfcs`` was removed: RFC-4 anatomical orientation is now written
+    # automatically whenever it is present. Reject it explicitly so a legacy
+    # caller gets a clear migration message instead of an opaque error from the
+    # downstream zarr-creation kwargs.
+    if "enabled_rfcs" in kwargs:
+        raise TypeError(
+            "to_ome_zarr()/to_ngff_zarr() no longer accepts 'enabled_rfcs'. "
+            "RFC-4 anatomical orientation is now written automatically whenever "
+            "it is present. Set NgffImage.axes_orientations, or pass "
+            "orientation= to to_multiscales()."
+        )
+
     # RFC-9: Handle .ozx (zipped OME-Zarr) files
     if isinstance(store, (str, Path)) and is_ozx_path(store):
         if version != "0.5":
@@ -1486,7 +1487,6 @@ def to_ome_zarr(
                 chunk_store=None,
                 progress=progress,
                 chunks_per_shard=chunks_per_shard,
-                enabled_rfcs=enabled_rfcs,
                 scale_strategy=scale_strategy,
                 **kwargs,
             )
@@ -1519,7 +1519,6 @@ def to_ome_zarr(
         chunk_store=chunk_store,
         progress=progress,
         chunks_per_shard=chunks_per_shard,
-        enabled_rfcs=enabled_rfcs,
         scale_strategy=scale_strategy,
         **kwargs,
     )
@@ -1538,7 +1537,6 @@ def _to_ngff_zarr_impl(
     chunk_store: StoreLike | None = None,
     progress: NgffProgress | NgffProgressCallback | None = None,
     chunks_per_shard: int | tuple[int, ...] | dict[str, int] | None = None,
-    enabled_rfcs: list[int] | None = None,
     scale_strategy: ScaleStrategy = "pad",
     **kwargs,
 ) -> None:
@@ -1550,10 +1548,10 @@ def _to_ngff_zarr_impl(
 
     _validate_ngff_parameters(version, chunks_per_shard, use_tensorstore, store)
     metadata, dimension_names, dimension_names_kwargs = _prepare_metadata(
-        multiscales, version, enabled_rfcs
+        multiscales, version
     )
     metadata_dict = asdict(metadata)
-    metadata_dict = _pop_metadata_optionals(metadata_dict, enabled_rfcs)
+    metadata_dict = _pop_metadata_optionals(metadata_dict)
     metadata_dict["@type"] = "ngff:Image"
 
     # Create Zarr root

--- a/py/test/test_cli_orientation.py
+++ b/py/test/test_cli_orientation.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Tests for the CLI ``--orientation`` flag (RFC 4 anatomical orientation)."""
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import packaging.version
+import pytest
+import zarr
+
+from ._data import test_data_dir
+
+zarr_version = packaging.version.parse(zarr.__version__)
+
+
+class _FakeConsole:
+    def __init__(self):
+        self.messages = []
+
+    def print(self, *args, **kwargs):
+        self.messages.append(" ".join(str(a) for a in args))
+
+
+class _FakeLive:
+    def __init__(self):
+        self.console = _FakeConsole()
+
+
+def test_parse_orientation_arg_preset():
+    """A single preset name resolves to the matching coordinate-system mapping."""
+    from ngff_zarr.cli import _parse_orientation_arg
+
+    live = _FakeLive()
+    result = _parse_orientation_arg(["LPS"], live)
+    assert {dim: o.value.value for dim, o in result.items()} == {
+        "x": "right-to-left",
+        "y": "anterior-to-posterior",
+        "z": "inferior-to-superior",
+    }
+
+
+def test_parse_orientation_arg_preset_case_insensitive():
+    """Preset names are case-insensitive."""
+    from ngff_zarr.cli import _parse_orientation_arg
+
+    live = _FakeLive()
+    result = _parse_orientation_arg(["ras"], live)
+    assert {dim: o.value.value for dim, o in result.items()} == {
+        "x": "left-to-right",
+        "y": "posterior-to-anterior",
+        "z": "inferior-to-superior",
+    }
+
+
+def test_parse_orientation_arg_pairs():
+    """Ordered dim/value pairs map each axis to its orientation."""
+    from ngff_zarr.cli import _parse_orientation_arg
+
+    live = _FakeLive()
+    result = _parse_orientation_arg(
+        ["x", "right-to-left", "y", "anterior-to-posterior"], live
+    )
+    assert {dim: o.value.value for dim, o in result.items()} == {
+        "x": "right-to-left",
+        "y": "anterior-to-posterior",
+    }
+
+
+def test_parse_orientation_arg_unknown_preset_exits():
+    """An unknown single value (not a preset) exits with an error."""
+    from ngff_zarr.cli import _parse_orientation_arg
+
+    live = _FakeLive()
+    with pytest.raises(SystemExit):
+        _parse_orientation_arg(["FOO"], live)
+    assert any("orientation preset" in m for m in live.console.messages)
+
+
+def test_parse_orientation_arg_odd_pairs_exits():
+    """An odd number of pair arguments exits with an error."""
+    from ngff_zarr.cli import _parse_orientation_arg
+
+    live = _FakeLive()
+    with pytest.raises(SystemExit):
+        _parse_orientation_arg(["x", "right-to-left", "y"], live)
+    assert any("dim/value pairs" in m for m in live.console.messages)
+
+
+def test_parse_orientation_arg_invalid_value_exits():
+    """An unsupported orientation value in a pair exits with an error."""
+    from ngff_zarr.cli import _parse_orientation_arg
+
+    live = _FakeLive()
+    with pytest.raises(SystemExit):
+        _parse_orientation_arg(["x", "not-a-real-orientation"], live)
+    assert any("Unsupported anatomical orientation" in m for m in live.console.messages)
+
+
+def _run_ngff_zarr(*args):
+    """Run ngff-zarr CLI as a subprocess and return the result."""
+    cmd = [
+        sys.executable,
+        "-c",
+        "from ngff_zarr.cli import main; main()",
+    ] + list(args)
+    env = {**os.environ, "PYTHONIOENCODING": "utf-8"}
+    # Bound the run so a CLI regression cannot hang the test job indefinitely.
+    return subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=120)
+
+
+def _read_axes_metadata(store_path):
+    zarr_group = zarr.open(str(store_path), mode="r")
+    raw_attrs = dict(zarr_group.attrs)
+    if "ome" in raw_attrs:
+        multiscales_metadata = raw_attrs["ome"]["multiscales"][0]
+    else:
+        multiscales_metadata = raw_attrs["multiscales"][0]
+    return multiscales_metadata["axes"]
+
+
+@pytest.mark.skipif(
+    zarr_version < packaging.version.parse("3.0.0b1"),
+    reason="zarr version >= 3.0.0b1 required for OME-Zarr version >= 0.5",
+)
+def test_cli_orientation_preset_end_to_end(input_images):
+    """``--orientation LPS`` writes anatomical orientation to the output store."""
+    input_path = str(test_data_dir / "input" / "cthead1.png")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_path = str(Path(temp_dir) / "cthead1.ome.zarr")
+
+        result = _run_ngff_zarr(
+            "-i", input_path, "-o", output_path, "--orientation", "LPS"
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+
+        axes_metadata = _read_axes_metadata(output_path)
+        # cthead1 is a 2D image (y, x); both spatial axes carry LPS orientation.
+        spatial = {ax["name"]: ax for ax in axes_metadata if ax["name"] in ("x", "y")}
+        assert spatial["x"]["orientation"]["value"] == "right-to-left"
+        assert spatial["y"]["orientation"]["value"] == "anterior-to-posterior"
+
+
+@pytest.mark.skipif(
+    zarr_version < packaging.version.parse("3.0.0b1"),
+    reason="zarr version >= 3.0.0b1 required for OME-Zarr version >= 0.5",
+)
+def test_cli_itk_input_writes_orientation_automatically(input_images):
+    """ITK-backed inputs supply orientation, which is written without any flag.
+
+    Reading ``cthead1.png`` through the ITK backend attaches anatomical
+    orientation (identity direction -> LPS). With the data-driven model, that
+    orientation is written to the output automatically -- no ``--orientation``
+    or opt-in flag required.
+    """
+    input_path = str(test_data_dir / "input" / "cthead1.png")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_path = str(Path(temp_dir) / "cthead1.ome.zarr")
+
+        result = _run_ngff_zarr("-i", input_path, "-o", output_path)
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+
+        axes_metadata = _read_axes_metadata(output_path)
+        spatial = {ax["name"]: ax for ax in axes_metadata if ax["name"] in ("x", "y")}
+        assert spatial["x"]["orientation"]["type"] == "anatomical"
+        assert spatial["y"]["orientation"]["type"] == "anatomical"

--- a/py/test/test_metadata_none_removal.py
+++ b/py/test/test_metadata_none_removal.py
@@ -84,12 +84,23 @@ def _sample_metadata_dict():
     }
 
 
-def test_pop_optionals_rfc4_disabled_drops_populated_orientation():
-    """With RFC 4 disabled, orientation and all ``None`` fields are removed."""
-    result = _pop_metadata_optionals(_sample_metadata_dict(), enabled_rfcs=None)
-    for axis in result["axes"]:
-        assert "orientation" not in axis
-        assert "unit" not in axis  # None units are stripped too
+def test_pop_optionals_keeps_populated_drops_null_orientation():
+    """Populated orientation is kept; ``None`` orientation and fields are culled.
+
+    Anatomical orientation (RFC 4) is written whenever it is present, with no
+    separate opt-in. ``None`` orientations and other ``None`` fields are culled.
+    """
+    result = _pop_metadata_optionals(_sample_metadata_dict())
+    by_name = {axis["name"]: axis for axis in result["axes"]}
+    # Populated orientation survives.
+    assert by_name["x"]["orientation"] == {
+        "type": "anatomical",
+        "value": "left-to-right",
+    }
+    # None units are stripped too.
+    assert "unit" not in by_name["x"]
+    # A None orientation on a non-spatial axis is culled, not serialized.
+    assert "orientation" not in by_name["c"]
     # All None-valued top-level fields are gone.
     assert "coordinateTransformations" not in result
     assert "omero" not in result
@@ -97,16 +108,3 @@ def test_pop_optionals_rfc4_disabled_drops_populated_orientation():
     assert "metadata" not in result
     # Valid data, including a zero scale value, is preserved.
     assert result["datasets"][0]["coordinateTransformations"][0]["scale"] == [1.0, 0.0]
-
-
-def test_pop_optionals_rfc4_enabled_keeps_populated_drops_null_orientation():
-    """With RFC 4 enabled, populated orientation stays but ``None`` is culled."""
-    result = _pop_metadata_optionals(_sample_metadata_dict(), enabled_rfcs=[4])
-    by_name = {axis["name"]: axis for axis in result["axes"]}
-    # Populated orientation survives when RFC 4 is enabled.
-    assert by_name["x"]["orientation"] == {
-        "type": "anatomical",
-        "value": "left-to-right",
-    }
-    # A None orientation on a non-spatial axis is culled, not serialized.
-    assert "orientation" not in by_name["c"]

--- a/py/test/test_rfc4.py
+++ b/py/test/test_rfc4.py
@@ -4,13 +4,15 @@
 
 import pytest
 from ngff_zarr.rfc4 import (
+    LPS,
+    RAS,
     AnatomicalOrientation,
     AnatomicalOrientationValues,
     add_anatomical_orientation_to_axis,
     anatomical_orientation_to_itk_direction,
-    is_rfc4_enabled,
     itk_direction_to_anatomical_orientation,
     itk_lps_to_anatomical_orientation,
+    orientation_from_name,
     remove_anatomical_orientation_from_axis,
 )
 
@@ -47,13 +49,18 @@ def test_itk_lps_to_anatomical_orientation():
     assert c_orientation is None
 
 
-def test_is_rfc4_enabled():
-    """Test RFC 4 enablement check."""
-    assert is_rfc4_enabled([4]) is True
-    assert is_rfc4_enabled([1, 2, 4, 5]) is True
-    assert is_rfc4_enabled([1, 2, 3]) is False
-    assert is_rfc4_enabled([]) is False
-    assert is_rfc4_enabled(None) is False
+def test_orientation_from_name():
+    """Test resolving anatomical orientation presets by name."""
+    assert orientation_from_name("LPS") == LPS
+    assert orientation_from_name("RAS") == RAS
+    # Case-insensitive
+    assert orientation_from_name("lps") == LPS
+    assert orientation_from_name("ras") == RAS
+    # Returns a copy, not the shared module-level constant
+    assert orientation_from_name("LPS") is not LPS
+    # Unknown presets raise ValueError
+    with pytest.raises(ValueError, match="Unknown anatomical orientation preset"):
+        orientation_from_name("FOO")
 
 
 def test_add_anatomical_orientation_to_axis():

--- a/py/test/test_rfc4_integration.py
+++ b/py/test/test_rfc4_integration.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 import zarr
-from ngff_zarr import NgffImage, to_multiscales, to_ngff_zarr
+from ngff_zarr import LPS, RAS, NgffImage, to_multiscales, to_ngff_zarr
 from ngff_zarr.rfc4 import AnatomicalOrientation, AnatomicalOrientationValues
 from packaging import version
 
@@ -20,8 +20,19 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_rfc4_integration_with_enabled_rfcs():
-    """Test RFC 4 anatomical orientation when enabled."""
+def _read_axes_metadata(store_path):
+    zarr_group = zarr.open(str(store_path), mode="r")
+    # v0.5 stores metadata under "ome", v0.4 at root
+    raw_attrs = dict(zarr_group.attrs)
+    if "ome" in raw_attrs:
+        multiscales_metadata = raw_attrs["ome"]["multiscales"][0]
+    else:
+        multiscales_metadata = raw_attrs["multiscales"][0]
+    return multiscales_metadata["axes"]
+
+
+def test_rfc4_orientation_written_automatically_when_present():
+    """Anatomical orientation is written whenever it is present, no opt-in."""
     # Create a simple 3D image
     data = np.random.rand(10, 20, 30).astype(np.float32)
 
@@ -52,22 +63,10 @@ def test_rfc4_integration_with_enabled_rfcs():
     with tempfile.TemporaryDirectory() as temp_dir:
         store_path = Path(temp_dir) / "test.zarr"
 
-        # Test with RFC 4 enabled
-        to_ngff_zarr(store=str(store_path), multiscales=multiscales, enabled_rfcs=[4])
+        # No opt-in flag: orientation is written because it is present
+        to_ngff_zarr(store=str(store_path), multiscales=multiscales)
 
-        # Read back and check metadata
-        import zarr
-
-        zarr_group = zarr.open(str(store_path), mode="r")
-
-        # Check that multiscales metadata contains orientation
-        # v0.5 stores metadata under "ome", v0.4 at root
-        raw_attrs = dict(zarr_group.attrs)
-        if "ome" in raw_attrs:
-            multiscales_metadata = raw_attrs["ome"]["multiscales"][0]
-        else:
-            multiscales_metadata = raw_attrs["multiscales"][0]
-        axes_metadata = multiscales_metadata["axes"]
+        axes_metadata = _read_axes_metadata(store_path)
 
         # Find spatial axes and check for orientation
         spatial_axes_with_orientation = [
@@ -93,29 +92,16 @@ def test_rfc4_integration_with_enabled_rfcs():
                 assert axis["orientation"]["value"] == "superior-to-inferior"
 
 
-def test_rfc4_integration_without_enabled_rfcs():
-    """Test RFC 4 anatomical orientation when not enabled."""
-    # Create a simple 3D image
+def test_rfc4_no_orientation_written_when_absent():
+    """When no orientation metadata is present, none is written."""
+    # Create a simple 3D image without any orientation metadata
     data = np.random.rand(10, 20, 30).astype(np.float32)
 
-    # Create orientations for spatial axes
-    orientations = {
-        "x": AnatomicalOrientation(value=AnatomicalOrientationValues.left_to_right),
-        "y": AnatomicalOrientation(
-            value=AnatomicalOrientationValues.posterior_to_anterior
-        ),
-        "z": AnatomicalOrientation(
-            value=AnatomicalOrientationValues.superior_to_inferior
-        ),
-    }
-
-    # Create NgffImage with orientation metadata
     ngff_image = NgffImage(
         data=data,
         dims=("z", "y", "x"),
         scale={"x": 1.0, "y": 1.0, "z": 1.0},
         translation={"x": 0.0, "y": 0.0, "z": 0.0},
-        axes_orientations=orientations,
     )
 
     # Convert to multiscales
@@ -125,86 +111,40 @@ def test_rfc4_integration_without_enabled_rfcs():
     with tempfile.TemporaryDirectory() as temp_dir:
         store_path = Path(temp_dir) / "test.zarr"
 
-        # Test with RFC 4 NOT enabled (default)
-        to_ngff_zarr(
-            store=str(store_path),
-            multiscales=multiscales,
-            # enabled_rfcs not specified, so RFC 4 should be filtered out
-        )
+        to_ngff_zarr(store=str(store_path), multiscales=multiscales)
 
-        # Read back and check metadata
-        import zarr
-
-        zarr_group = zarr.open(str(store_path), mode="r")
-
-        # Check that multiscales metadata does NOT contain orientation
-        # v0.5 stores metadata under "ome", v0.4 at root
-        raw_attrs = dict(zarr_group.attrs)
-        if "ome" in raw_attrs:
-            multiscales_metadata = raw_attrs["ome"]["multiscales"][0]
-        else:
-            multiscales_metadata = raw_attrs["multiscales"][0]
-        axes_metadata = multiscales_metadata["axes"]
+        axes_metadata = _read_axes_metadata(store_path)
 
         # Check that no spatial axes have orientation
         for axis in axes_metadata:
             assert "orientation" not in axis, (
-                f"Axis {axis['name']} should not have orientation when RFC 4 is disabled"
+                f"Axis {axis['name']} should not have orientation when none "
+                "was specified"
             )
 
 
-def test_rfc4_integration_with_other_rfcs():
-    """Test RFC 4 anatomical orientation when enabled alongside other RFCs."""
-    # Create a simple 3D image
+def test_rfc4_orientation_keyword_preset():
+    """The ``orientation`` keyword on to_multiscales accepts a preset name."""
+    # Create a simple 3D image without orientation metadata on the image
     data = np.random.rand(5, 10, 15).astype(np.float32)
 
-    # Create orientations for spatial axes
-    orientations = {
-        "x": AnatomicalOrientation(value=AnatomicalOrientationValues.left_to_right),
-        "y": AnatomicalOrientation(
-            value=AnatomicalOrientationValues.posterior_to_anterior
-        ),
-        "z": AnatomicalOrientation(
-            value=AnatomicalOrientationValues.superior_to_inferior
-        ),
-    }
-
-    # Create NgffImage with orientation metadata
     ngff_image = NgffImage(
         data=data,
         dims=("z", "y", "x"),
         scale={"x": 1.0, "y": 1.0, "z": 1.0},
         translation={"x": 0.0, "y": 0.0, "z": 0.0},
-        axes_orientations=orientations,
     )
 
-    # Convert to multiscales
-    multiscales = to_multiscales(ngff_image, scale_factors=[2])
+    # Request the LPS coordinate system explicitly via the orientation keyword
+    multiscales = to_multiscales(ngff_image, scale_factors=[2], orientation="LPS")
 
     # Create temporary directory for testing
     with tempfile.TemporaryDirectory() as temp_dir:
         store_path = Path(temp_dir) / "test.zarr"
 
-        # Test with RFC 4 enabled alongside hypothetical other RFCs
-        to_ngff_zarr(
-            store=str(store_path),
-            multiscales=multiscales,
-            enabled_rfcs=[1, 2, 4, 5],  # RFC 4 is enabled
-        )
+        to_ngff_zarr(store=str(store_path), multiscales=multiscales)
 
-        # Read back and check metadata
-        import zarr
-
-        zarr_group = zarr.open(str(store_path), mode="r")
-
-        # Check that multiscales metadata contains orientation
-        # v0.5 stores metadata under "ome", v0.4 at root
-        raw_attrs = dict(zarr_group.attrs)
-        if "ome" in raw_attrs:
-            multiscales_metadata = raw_attrs["ome"]["multiscales"][0]
-        else:
-            multiscales_metadata = raw_attrs["multiscales"][0]
-        axes_metadata = multiscales_metadata["axes"]
+        axes_metadata = _read_axes_metadata(store_path)
 
         # Find spatial axes and check for orientation
         spatial_axes_with_orientation = [
@@ -214,9 +154,100 @@ def test_rfc4_integration_with_other_rfcs():
             len(spatial_axes_with_orientation) == 3
         )  # x, y, z should have orientation
 
+        # LPS preset orientations
+        expected = {
+            "x": "right-to-left",
+            "y": "anterior-to-posterior",
+            "z": "inferior-to-superior",
+        }
+        for axis in axes_metadata:
+            if axis["name"] in expected:
+                assert axis["orientation"]["type"] == "anatomical"
+                assert axis["orientation"]["value"] == expected[axis["name"]]
+
+
+def test_rfc4_orientation_keyword_mapping():
+    """The ``orientation`` keyword on to_multiscales accepts a per-axis mapping."""
+    data = np.random.rand(5, 10, 15).astype(np.float32)
+
+    ngff_image = NgffImage(
+        data=data,
+        dims=("z", "y", "x"),
+        scale={"x": 1.0, "y": 1.0, "z": 1.0},
+        translation={"x": 0.0, "y": 0.0, "z": 0.0},
+    )
+
+    orientations = {
+        "x": AnatomicalOrientation(value=AnatomicalOrientationValues.left_to_right),
+        "y": AnatomicalOrientation(
+            value=AnatomicalOrientationValues.posterior_to_anterior
+        ),
+        "z": AnatomicalOrientation(
+            value=AnatomicalOrientationValues.superior_to_inferior
+        ),
+    }
+
+    multiscales = to_multiscales(
+        ngff_image, scale_factors=[2], orientation=orientations
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        store_path = Path(temp_dir) / "test.zarr"
+
+        to_ngff_zarr(store=str(store_path), multiscales=multiscales)
+
+        axes_metadata = _read_axes_metadata(store_path)
+
+        expected = {
+            "x": "left-to-right",
+            "y": "posterior-to-anterior",
+            "z": "superior-to-inferior",
+        }
+        for axis in axes_metadata:
+            if axis["name"] in expected:
+                assert axis["orientation"]["type"] == "anatomical"
+                assert axis["orientation"]["value"] == expected[axis["name"]]
+
+
+def test_rfc4_orientation_keyword_overrides_image_orientations():
+    """The ``orientation`` keyword takes precedence over image axes_orientations."""
+    data = np.random.rand(5, 10, 15).astype(np.float32)
+
+    # Image carries LPS orientation...
+    ngff_image = NgffImage(
+        data=data,
+        dims=("z", "y", "x"),
+        scale={"x": 1.0, "y": 1.0, "z": 1.0},
+        translation={"x": 0.0, "y": 0.0, "z": 0.0},
+        axes_orientations=LPS,
+    )
+
+    # ...but the explicit orientation keyword (RAS) wins.
+    multiscales = to_multiscales(ngff_image, scale_factors=[2], orientation="RAS")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        store_path = Path(temp_dir) / "test.zarr"
+
+        to_ngff_zarr(store=str(store_path), multiscales=multiscales)
+
+        axes_metadata = _read_axes_metadata(store_path)
+
+        by_name = {axis["name"]: axis for axis in axes_metadata}
+        # RAS values, not LPS, must be written.
+        assert (
+            by_name["x"]["orientation"]["value"]
+            == RAS["x"].value.value
+            == "left-to-right"
+        )
+        assert (
+            by_name["y"]["orientation"]["value"]
+            == RAS["y"].value.value
+            == "posterior-to-anterior"
+        )
+
 
 def test_rfc4_no_null_orientation_on_non_spatial_axes():
-    """Non-spatial axes must not emit ``orientation: null`` when RFC 4 is on.
+    """Non-spatial axes must not emit ``orientation: null``.
 
     Only the spatial axes carry an anatomical orientation. The time and
     channel axes have ``orientation=None``, which must be culled rather than
@@ -247,15 +278,9 @@ def test_rfc4_no_null_orientation_on_non_spatial_axes():
     with tempfile.TemporaryDirectory() as temp_dir:
         store_path = Path(temp_dir) / "test.zarr"
 
-        to_ngff_zarr(store=str(store_path), multiscales=multiscales, enabled_rfcs=[4])
+        to_ngff_zarr(store=str(store_path), multiscales=multiscales)
 
-        zarr_group = zarr.open(str(store_path), mode="r")
-        raw_attrs = dict(zarr_group.attrs)
-        if "ome" in raw_attrs:
-            multiscales_metadata = raw_attrs["ome"]["multiscales"][0]
-        else:
-            multiscales_metadata = raw_attrs["multiscales"][0]
-        axes_metadata = multiscales_metadata["axes"]
+        axes_metadata = _read_axes_metadata(store_path)
 
         for axis in axes_metadata:
             if axis["name"] in ("t", "c"):
@@ -265,3 +290,29 @@ def test_rfc4_no_null_orientation_on_non_spatial_axes():
                 )
             else:
                 assert axis["orientation"]["type"] == "anatomical"
+
+
+def test_rfc4_legacy_enabled_rfcs_kwarg_rejected():
+    """The removed ``enabled_rfcs`` kwarg raises a clear migration error.
+
+    ``enabled_rfcs`` was dropped in favor of automatic orientation writing.
+    A legacy caller passing it must get an explicit message rather than an
+    opaque error from the downstream zarr-creation kwargs.
+    """
+    data = np.random.rand(4, 8, 12).astype(np.float32)
+
+    ngff_image = NgffImage(
+        data=data,
+        dims=("z", "y", "x"),
+        scale={"x": 1.0, "y": 1.0, "z": 1.0},
+        translation={"x": 0.0, "y": 0.0, "z": 0.0},
+    )
+    multiscales = to_multiscales(ngff_image, scale_factors=[2])
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        store_path = Path(temp_dir) / "test.zarr"
+
+        with pytest.raises(TypeError, match="no longer accepts 'enabled_rfcs'"):
+            to_ngff_zarr(
+                store=str(store_path), multiscales=multiscales, enabled_rfcs=[4]
+            )

--- a/py/test/test_rfc4_integration_validation.py
+++ b/py/test/test_rfc4_integration_validation.py
@@ -32,7 +32,7 @@ def test_rfc4_validation_integration_with_lps():
     # Convert to multiscales and store to zarr
     multiscales = to_multiscales(ngff_image)
     store = MemoryStore()
-    to_ngff_zarr(store, multiscales, version="0.4", enabled_rfcs=[4])
+    to_ngff_zarr(store, multiscales, version="0.4")
 
     # Read back with validation enabled - should pass (no validation errors)
     multiscales_back = from_ngff_zarr(store, validate=True)
@@ -61,7 +61,7 @@ def test_rfc4_validation_integration_with_ras():
     # Convert to multiscales and store to zarr
     multiscales = to_multiscales(ngff_image)
     store = MemoryStore()
-    to_ngff_zarr(store, multiscales, version="0.4", enabled_rfcs=[4])
+    to_ngff_zarr(store, multiscales, version="0.4")
 
     # Read back with validation enabled - should pass (no validation errors)
     multiscales_back = from_ngff_zarr(store, validate=True)
@@ -90,7 +90,7 @@ def test_rfc4_validation_integration_mixed_axes():
     # Convert to multiscales and store to zarr
     multiscales = to_multiscales(ngff_image)
     store = MemoryStore()
-    to_ngff_zarr(store, multiscales, version="0.4", enabled_rfcs=[4])
+    to_ngff_zarr(store, multiscales, version="0.4")
 
     # Read back with validation enabled - should pass (no validation errors)
     multiscales_back = from_ngff_zarr(store, validate=True)

--- a/ts/src/io/to_ngff_zarr-browser.ts
+++ b/ts/src/io/to_ngff_zarr-browser.ts
@@ -12,7 +12,7 @@ import { createWriteQueue, zarrGet, zarrSet } from "../utils/worker_pool.ts";
 import type { MemoryStore } from "./from_ngff_zarr-browser.ts";
 import { memoryStoreToZip } from "./rfc9_zip.ts";
 import {
-  processAxesForRfcs,
+  processAxes,
   writeNgffMultiscalesToMemoryStore,
 } from "./to_ngff_zarr_ozx_common.ts";
 
@@ -22,8 +22,6 @@ export interface ToOmeZarrOptions {
   overwrite?: boolean;
   version?: "0.4" | "0.5";
   chunksPerShard?: number | number[] | Record<string, number>;
-  /** List of RFC numbers to enable (e.g., [4] for RFC 4 anatomical orientation) */
-  enabledRfcs?: number[];
   /**
    * Custom codec pipeline for array compression. When omitted the default
    * ``blosc(zstd)`` pipeline from {@link defaultCodecs} is used. Use
@@ -40,8 +38,6 @@ export type ToNgffZarrOptions = ToOmeZarrOptions;
  * Note: chunksPerShard is NOT supported for .ozx files and will throw an error.
  */
 export interface ToOmeZarrOzxOptions {
-  /** List of RFC numbers to enable (e.g., [4] for RFC 4 anatomical orientation) */
-  enabledRfcs?: number[] | undefined;
   /**
    * Optional progress callback invoked after each chunk is written.
    * Reports cumulative progress across all scale levels.
@@ -69,7 +65,6 @@ export async function toOmeZarr(
 ): Promise<void> {
   const _overwrite = options.overwrite ?? true;
   const _version = options.version ?? "0.4";
-  const enabledRfcs = options.enabledRfcs;
 
   try {
     // Determine the appropriate store type based on the path
@@ -94,11 +89,8 @@ export async function toOmeZarr(
     // Create root location and group with zarrita v0.5.2 API
     const root = zarr.root(_resolvedStore);
 
-    // Process axes - filter orientation based on enabledRfcs
-    const processedAxes = processAxesForRfcs(
-      multiscales.metadata.axes,
-      enabledRfcs,
-    );
+    // Process axes (orientation included when present)
+    const processedAxes = processAxes(multiscales.metadata.axes);
 
     // Prepare multiscales metadata
     const multiscalesMetadata = {
@@ -534,8 +526,6 @@ export async function toOmeZarrOzx(
   multiscales: NgffMultiscales,
   _options: ToOmeZarrOzxOptions = {},
 ): Promise<Uint8Array> {
-  const enabledRfcs = _options.enabledRfcs;
-
   // Create a memory store to hold the zarr data
   const memoryStore: MemoryStore = new Map<string, Uint8Array>();
 
@@ -543,7 +533,6 @@ export async function toOmeZarrOzx(
   await writeNgffMultiscalesToMemoryStore(
     memoryStore,
     multiscales,
-    enabledRfcs,
     _writeImage,
     _options.onProgress ?? null,
   );

--- a/ts/src/io/to_ngff_zarr.ts
+++ b/ts/src/io/to_ngff_zarr.ts
@@ -10,7 +10,7 @@ import { createWriteQueue, zarrGet, zarrSet } from "../utils/worker_pool.ts";
 import type { MemoryStore } from "./from_ngff_zarr.ts";
 import { isOzxPath, memoryStoreToZip } from "./rfc9_zip.ts";
 import {
-  processAxesForRfcs,
+  processAxes,
   writeNgffMultiscalesToMemoryStore,
 } from "./to_ngff_zarr_ozx_common.ts";
 
@@ -24,8 +24,6 @@ export interface ToOmeZarrOptions {
    */
   version?: "0.4" | "0.5";
   chunksPerShard?: number | number[] | Record<string, number>;
-  /** List of RFC numbers to enable (e.g., [4] for RFC 4 anatomical orientation) */
-  enabledRfcs?: number[];
   /**
    * Custom codec pipeline for array compression. When omitted the default
    * ``blosc(zstd)`` pipeline from {@link defaultCodecs} is used. Use
@@ -42,8 +40,6 @@ export type ToNgffZarrOptions = ToOmeZarrOptions;
  * Note: chunksPerShard is NOT supported for .ozx files and will throw an error.
  */
 export interface ToOmeZarrOzxOptions {
-  /** List of RFC numbers to enable (e.g., [4] for RFC 4 anatomical orientation) */
-  enabledRfcs?: number[] | undefined;
   /**
    * Optional progress callback invoked after each chunk is written.
    * Reports cumulative progress across all scale levels.
@@ -91,7 +87,6 @@ export async function toOmeZarr(
 ): Promise<void> {
   const _overwrite = options.overwrite ?? true;
   const _version = options.version ?? "0.5";
-  const enabledRfcs = options.enabledRfcs;
 
   // Handle .ozx paths (RFC-9)
   if (typeof store === "string" && isOzxPath(store)) {
@@ -115,7 +110,7 @@ export async function toOmeZarr(
     }
 
     // Delegate to toOmeZarrOzx (which always uses version 0.5)
-    await toOmeZarrOzx(store, multiscales, { enabledRfcs });
+    await toOmeZarrOzx(store, multiscales);
     return;
   }
 
@@ -156,11 +151,8 @@ export async function toOmeZarr(
     // Create root location and group with zarrita v0.5.2 API
     const root = zarr.root(_resolvedStore as MemoryStore);
 
-    // Process axes - filter orientation based on enabledRfcs
-    const processedAxes = processAxesForRfcs(
-      multiscales.metadata.axes,
-      enabledRfcs,
-    );
+    // Process axes (orientation included when present)
+    const processedAxes = processAxes(multiscales.metadata.axes);
 
     // Prepare multiscales metadata
     const multiscalesMetadata = {
@@ -647,8 +639,6 @@ export async function toOmeZarrOzxData(
   multiscales: NgffMultiscales,
   options: ToOmeZarrOzxOptions = {},
 ): Promise<Uint8Array> {
-  const enabledRfcs = options.enabledRfcs;
-
   // Create a memory store to hold the zarr data
   const memoryStore: MemoryStore = new Map<string, Uint8Array>();
 
@@ -658,7 +648,6 @@ export async function toOmeZarrOzxData(
   await _writeToMemoryStore(
     memoryStore,
     multiscales,
-    enabledRfcs,
     options.onProgress ?? null,
   );
 
@@ -678,13 +667,11 @@ export const toNgffZarrOzxData = toOmeZarrOzxData;
 async function _writeToMemoryStore(
   store: MemoryStore,
   multiscales: NgffMultiscales,
-  enabledRfcs?: number[],
   onProgress?: ((completedChunks: number, totalChunks: number) => void) | null,
 ): Promise<void> {
   await writeNgffMultiscalesToMemoryStore(
     store,
     multiscales,
-    enabledRfcs,
     _writeImage,
     onProgress,
   );

--- a/ts/src/io/to_ngff_zarr_ozx_common.ts
+++ b/ts/src/io/to_ngff_zarr_ozx_common.ts
@@ -9,21 +9,17 @@ import * as zarr from "zarrita";
 
 import type { NgffMultiscales } from "../types/multiscales.ts";
 import type { NgffImage } from "../types/ngff_image.ts";
-import { isRfc4Enabled } from "../types/rfc4.ts";
 import type { Axis } from "../types/zarr_metadata.ts";
 import type { MemoryStore } from "./rfc9_zip.ts";
 
 /**
- * Process axes for RFC enablement.
- * If RFC 4 is enabled, include orientation metadata.
- * If RFC 4 is not enabled, strip orientation from axes.
+ * Process axes for serialization.
+ * Anatomical orientation (RFC 4) is included whenever an axis carries it;
+ * axes without orientation simply omit the field.
  */
-export function processAxesForRfcs(
+export function processAxes(
   axes: Axis[],
-  enabledRfcs?: number[],
 ): Record<string, unknown>[] {
-  const rfc4Enabled = isRfc4Enabled(enabledRfcs);
-
   return axes.map((axis) => {
     const result: Record<string, unknown> = {
       name: axis.name,
@@ -35,8 +31,8 @@ export function processAxesForRfcs(
       result.unit = axis.unit;
     }
 
-    // Include orientation only if RFC 4 is enabled and orientation exists
-    if (rfc4Enabled && axis.orientation) {
+    // Include orientation whenever it is present
+    if (axis.orientation) {
       result.orientation = {
         type: axis.orientation.type,
         value: axis.orientation.value,
@@ -65,23 +61,19 @@ export function validateRfc9Version(multiscales: NgffMultiscales): void {
 
 /**
  * Prepare multiscales metadata for RFC-9 export.
- * This includes processing axes for RFC enablement and setting version to 0.5.
+ * Processes axes (anatomical orientation is serialized whenever present) and
+ * sets version to 0.5.
  *
  * @param multiscales - Source multiscales data
- * @param enabledRfcs - Optional list of RFC numbers to enable
  * @returns Prepared metadata object
  */
 export function prepareRfc9Metadata(
   multiscales: NgffMultiscales,
-  enabledRfcs?: number[],
 ): Record<string, unknown> {
   const _version = "0.5";
 
-  // Process axes - filter orientation based on enabledRfcs
-  const processedAxes = processAxesForRfcs(
-    multiscales.metadata.axes,
-    enabledRfcs,
-  );
+  // Process axes (orientation included when present)
+  const processedAxes = processAxes(multiscales.metadata.axes);
 
   return {
     version: _version,
@@ -147,7 +139,6 @@ export function createRfc9RootAttributes(
  *
  * @param store - Memory store to write to
  * @param multiscales - NgffMultiscales data to write
- * @param enabledRfcs - Optional list of RFC numbers to enable
  * @param writeImage - Function to write individual images
  * @param onProgress - Optional progress callback for cumulative chunk
  *   progress across all scale levels
@@ -155,7 +146,6 @@ export function createRfc9RootAttributes(
 export async function writeNgffMultiscalesToMemoryStore(
   store: MemoryStore,
   multiscales: NgffMultiscales,
-  enabledRfcs: number[] | undefined,
   writeImage: (
     group: zarr.Group<MemoryStore>,
     image: NgffImage,
@@ -173,7 +163,7 @@ export async function writeNgffMultiscalesToMemoryStore(
   const root = zarr.root(store);
 
   // Prepare metadata
-  const multiscalesMetadata = prepareRfc9Metadata(multiscales, enabledRfcs);
+  const multiscalesMetadata = prepareRfc9Metadata(multiscales);
 
   // Create root attributes
   const attributes = createRfc9RootAttributes(multiscalesMetadata, multiscales);

--- a/ts/src/process/to_multiscales-shared.ts
+++ b/ts/src/process/to_multiscales-shared.ts
@@ -20,6 +20,8 @@ import {
   createNgffMultiscales,
 } from "../utils/factory.ts";
 import { getMethodMetadata } from "../utils/method_metadata.ts";
+import type { AnatomicalOrientation } from "../types/rfc4.ts";
+import { orientationFromName } from "../types/rfc4.ts";
 
 export type { ZarrCodec };
 
@@ -27,6 +29,15 @@ export interface ToMultiscalesOptions {
   scaleFactors?: (Record<string, number> | number)[];
   method?: Methods;
   chunks?: number | number[] | Record<string, number>;
+
+  /**
+   * Anatomical orientation (RFC 4) for the spatial axes. Either a preset
+   * coordinate-system name ("LPS" or "RAS", case-insensitive) or a mapping of
+   * axis name to {@link AnatomicalOrientation}. When provided, it takes
+   * precedence over any `axesOrientations` on the input image. Orientation is
+   * written to the output automatically whenever it is present.
+   */
+  orientation?: string | Record<string, AnatomicalOrientation>;
 
   /**
    * Codec pipeline for intermediate zarr arrays created during
@@ -71,7 +82,18 @@ export async function toMultiscalesCore(
     method = Methods.ITKWASM_GAUSSIAN,
     chunks: _chunks,
     codecs,
+    orientation,
   } = options;
+
+  // Resolve anatomical orientation (RFC 4). An explicit `orientation` option
+  // (preset name or mapping) takes precedence over the input image's
+  // axesOrientations.
+  const axesOrientations: Record<string, AnatomicalOrientation> | undefined =
+    orientation === undefined
+      ? image.axesOrientations
+      : typeof orientation === "string"
+      ? orientationFromName(orientation)
+      : orientation;
 
   let images: NgffImage[];
 
@@ -103,12 +125,12 @@ export async function toMultiscalesCore(
   // Create axes from image dimensions, including orientation if present
   const axes = image.dims.map((dim) => {
     if (dim === "x" || dim === "y" || dim === "z") {
-      const orientation = image.axesOrientations?.[dim];
+      const axisOrientation = axesOrientations?.[dim];
       return createAxis(
         dim as "x" | "y" | "z",
         "space",
         image.axesUnits?.[dim],
-        orientation,
+        axisOrientation,
       );
     } else if (dim === "c") {
       return createAxis(dim as "c", "channel");

--- a/ts/src/types/rfc4.ts
+++ b/ts/src/types/rfc4.ts
@@ -121,6 +121,40 @@ export const RAS: Record<string, AnatomicalOrientation> = {
 };
 
 /**
+ * Preset anatomical orientation coordinate systems, keyed by lowercased name.
+ */
+const ORIENTATION_PRESETS: Record<
+  string,
+  Record<string, AnatomicalOrientation>
+> = {
+  lps: LPS,
+  ras: RAS,
+};
+
+/**
+ * Resolve an anatomical orientation preset name to per-axis orientations.
+ *
+ * @param name - A preset coordinate-system name: "LPS" or "RAS" (case-insensitive)
+ * @returns A mapping of spatial axis name to AnatomicalOrientation
+ * @throws Error if the name is not a recognized preset
+ */
+export function orientationFromName(
+  name: string,
+): Record<string, AnatomicalOrientation> {
+  const preset = ORIENTATION_PRESETS[name.toLowerCase()];
+  if (preset === undefined) {
+    const supported = Object.keys(ORIENTATION_PRESETS)
+      .map((p) => p.toUpperCase())
+      .join(", ");
+    throw new Error(
+      `Unknown anatomical orientation preset: "${name}". ` +
+        `Supported presets: ${supported}.`,
+    );
+  }
+  return { ...preset };
+}
+
+/**
  * Convert ITK LPS coordinate system to anatomical orientation.
  *
  * ITK uses the LPS (Left-Posterior-Superior) coordinate system by default.
@@ -271,13 +305,6 @@ export function anatomicalOrientationToItkDirection(
     }
   }
   return undefined;
-}
-
-/**
- * Check if RFC 4 is enabled in the list of enabled RFCs.
- */
-export function isRfc4Enabled(enabledRfcs?: number[]): boolean {
-  return enabledRfcs !== undefined && enabledRfcs.includes(4);
 }
 
 /**

--- a/ts/test/baseline_comparison_test.ts
+++ b/ts/test/baseline_comparison_test.ts
@@ -320,7 +320,13 @@ Deno.test("MR-head - ITKWASM_GAUSSIAN scale factors [2, 3, 4]", async () => {
   const inputPath = join(INPUT_DIR, "MR-head.nrrd");
   const itkImage = await readImageNode(inputPath);
   assertExists(itkImage);
-  const ngffImage = await itkImageToNgffImage(itkImage);
+  // The baseline store predates automatic anatomical-orientation writing and
+  // carries no orientation, so its ITK direction is identity. Disable
+  // orientation here to compare downsampled pixel output apples-to-apples; the
+  // orientation round-trip itself is covered by rfc4_integration_test.ts.
+  const ngffImage = await itkImageToNgffImage(itkImage, {
+    addAnatomicalOrientation: false,
+  });
 
   // Generate multiscales
   const multiscales = await toMultiscales(ngffImage, {

--- a/ts/test/rfc4_integration_test.ts
+++ b/ts/test/rfc4_integration_test.ts
@@ -136,6 +136,62 @@ async function createMultiscalesWithOrientation(
   return { multiscales, store };
 }
 
+// Helper function to create a NgffMultiscales without any orientation
+async function createMultiscalesWithoutOrientation(
+  dims: string[] = ["z", "y", "x"],
+  shape: number[] = [10, 20, 30],
+): Promise<{ multiscales: NgffMultiscales; store: MemoryStore }> {
+  const store: MemoryStore = new Map();
+  const zarrArray = await createTestZarrArray(store, "test_array", shape);
+
+  const scale: Record<string, number> = {};
+  const translation: Record<string, number> = {};
+  dims.forEach((dim) => {
+    scale[dim] = 1.0;
+    translation[dim] = 0.0;
+  });
+
+  const ngffImage = new NgffImage({
+    data: zarrArray,
+    dims,
+    scale,
+    translation,
+    name: "test_no_orientation",
+    axesUnits: undefined,
+    axesOrientations: undefined,
+    computedCallbacks: undefined,
+  });
+
+  const axes = dims.map((dim) => {
+    if (dim === "x" || dim === "y" || dim === "z") {
+      return createAxis(dim as "x" | "y" | "z", "space", "micrometer");
+    } else if (dim === "c") {
+      return createAxis(dim as "c", "channel");
+    } else if (dim === "t") {
+      return createAxis(dim as "t", "time", "second");
+    } else {
+      throw new Error(`Unsupported dimension: ${dim}`);
+    }
+  });
+
+  const dataset = createDataset(
+    "scale0",
+    dims.map((dim) => scale[dim]),
+    dims.map((dim) => translation[dim]),
+  );
+  const metadata = createMetadata(axes, [dataset], "test_no_orientation");
+
+  const multiscales = new NgffMultiscales({
+    images: [ngffImage],
+    metadata,
+    scaleFactors: undefined,
+    method: undefined,
+    chunks: undefined,
+  });
+
+  return { multiscales, store };
+}
+
 // Helper to read zarr attributes
 async function readZarrAttrs(
   store: MemoryStore,
@@ -155,7 +211,7 @@ function getNgffMultiscalesArray(
   return attrs.multiscales as unknown[];
 }
 
-Deno.test("toNgffZarr writes orientation when enabledRfcs includes 4", async () => {
+Deno.test("toNgffZarr writes orientation automatically when present", async () => {
   const orientations: Record<string, AnatomicalOrientation> = {
     x: createAnatomicalOrientation(AnatomicalOrientationValues.LeftToRight),
     y: createAnatomicalOrientation(
@@ -168,9 +224,9 @@ Deno.test("toNgffZarr writes orientation when enabledRfcs includes 4", async () 
 
   const { multiscales } = await createMultiscalesWithOrientation(orientations);
 
-  // Write to a new store with RFC 4 enabled
+  // No opt-in flag: orientation is written because it is present
   const outputStore: MemoryStore = new Map();
-  await toNgffZarr(outputStore, multiscales, { enabledRfcs: [4] });
+  await toNgffZarr(outputStore, multiscales, {});
 
   // Read back and check metadata
   const attrs = await readZarrAttrs(outputStore);
@@ -222,24 +278,11 @@ Deno.test("toNgffZarr writes orientation when enabledRfcs includes 4", async () 
   }
 });
 
-Deno.test("toNgffZarr omits orientation when enabledRfcs is undefined", async () => {
-  const orientations: Record<string, AnatomicalOrientation> = {
-    x: createAnatomicalOrientation(AnatomicalOrientationValues.LeftToRight),
-    y: createAnatomicalOrientation(
-      AnatomicalOrientationValues.PosteriorToAnterior,
-    ),
-    z: createAnatomicalOrientation(
-      AnatomicalOrientationValues.SuperiorToInferior,
-    ),
-  };
+Deno.test("toNgffZarr omits orientation when none is present", async () => {
+  const { multiscales } = await createMultiscalesWithoutOrientation();
 
-  const { multiscales } = await createMultiscalesWithOrientation(orientations);
-
-  // Write to a new store WITHOUT RFC 4 enabled (default)
   const outputStore: MemoryStore = new Map();
-  await toNgffZarr(outputStore, multiscales, {
-    // enabledRfcs not specified
-  });
+  await toNgffZarr(outputStore, multiscales, {});
 
   // Read back and check metadata
   const attrs = await readZarrAttrs(outputStore);
@@ -254,76 +297,9 @@ Deno.test("toNgffZarr omits orientation when enabledRfcs is undefined", async ()
     assertEquals(
       "orientation" in axis,
       false,
-      `Axis ${axis.name} should not have orientation when RFC 4 is disabled`,
+      `Axis ${axis.name} should not have orientation when none was specified`,
     );
   }
-});
-
-Deno.test("toNgffZarr omits orientation when enabledRfcs is empty", async () => {
-  const orientations: Record<string, AnatomicalOrientation> = {
-    x: createAnatomicalOrientation(AnatomicalOrientationValues.LeftToRight),
-    y: createAnatomicalOrientation(
-      AnatomicalOrientationValues.PosteriorToAnterior,
-    ),
-    z: createAnatomicalOrientation(
-      AnatomicalOrientationValues.SuperiorToInferior,
-    ),
-  };
-
-  const { multiscales } = await createMultiscalesWithOrientation(orientations);
-
-  // Write to a new store with empty enabledRfcs
-  const outputStore: MemoryStore = new Map();
-  await toNgffZarr(outputStore, multiscales, { enabledRfcs: [] });
-
-  // Read back and check metadata
-  const attrs = await readZarrAttrs(outputStore);
-  const multiscalesArray = getNgffMultiscalesArray(attrs);
-  const multiscalesMetadata = multiscalesArray[0] as Record<string, unknown>;
-  const axesMetadata = multiscalesMetadata.axes as Array<
-    Record<string, unknown>
-  >;
-
-  // Check that no spatial axes have orientation
-  for (const axis of axesMetadata) {
-    assertEquals(
-      "orientation" in axis,
-      false,
-      `Axis ${axis.name} should not have orientation when RFC 4 is disabled`,
-    );
-  }
-});
-
-Deno.test("toNgffZarr writes orientation when enabledRfcs=[1,2,4,5]", async () => {
-  const orientations: Record<string, AnatomicalOrientation> = {
-    x: createAnatomicalOrientation(AnatomicalOrientationValues.LeftToRight),
-    y: createAnatomicalOrientation(
-      AnatomicalOrientationValues.PosteriorToAnterior,
-    ),
-    z: createAnatomicalOrientation(
-      AnatomicalOrientationValues.SuperiorToInferior,
-    ),
-  };
-
-  const { multiscales } = await createMultiscalesWithOrientation(orientations);
-
-  // Write to a new store with RFC 4 enabled alongside other RFCs
-  const outputStore: MemoryStore = new Map();
-  await toNgffZarr(outputStore, multiscales, { enabledRfcs: [1, 2, 4, 5] });
-
-  // Read back and check metadata
-  const attrs = await readZarrAttrs(outputStore);
-  const multiscalesArray = getNgffMultiscalesArray(attrs);
-  const multiscalesMetadata = multiscalesArray[0] as Record<string, unknown>;
-  const axesMetadata = multiscalesMetadata.axes as Array<
-    Record<string, unknown>
-  >;
-
-  // Find spatial axes and check for orientation
-  const spatialAxesWithOrientation = axesMetadata.filter(
-    (ax) => ax.orientation,
-  );
-  assertEquals(spatialAxesWithOrientation.length, 3); // x, y, z should have orientation
 });
 
 // Round-trip integration tests (from py/test/test_rfc4_integration_validation.py)
@@ -331,9 +307,8 @@ Deno.test("toNgffZarr writes orientation when enabledRfcs=[1,2,4,5]", async () =
 Deno.test("Round-trip with LPS orientation - write and read back", async () => {
   const { multiscales } = await createMultiscalesWithOrientation(LPS);
 
-  // Write to store with RFC 4 enabled
   const outputStore: MemoryStore = new Map();
-  await toNgffZarr(outputStore, multiscales, { enabledRfcs: [4] });
+  await toNgffZarr(outputStore, multiscales, {});
 
   // Read back with validation enabled - should pass
   const multiscalesBack = await fromNgffZarr(outputStore, { validate: true });
@@ -344,9 +319,8 @@ Deno.test("Round-trip with LPS orientation - write and read back", async () => {
 Deno.test("Round-trip with RAS orientation - write and read back", async () => {
   const { multiscales } = await createMultiscalesWithOrientation(RAS);
 
-  // Write to store with RFC 4 enabled
   const outputStore: MemoryStore = new Map();
-  await toNgffZarr(outputStore, multiscales, { enabledRfcs: [4] });
+  await toNgffZarr(outputStore, multiscales, {});
 
   // Read back with validation enabled - should pass
   const multiscalesBack = await fromNgffZarr(outputStore, { validate: true });
@@ -363,7 +337,7 @@ Deno.test("fromNgffZarr preserves RFC 4 orientation on parsed metadata.axes", as
   const { multiscales } = await createMultiscalesWithOrientation(LPS);
 
   const outputStore: MemoryStore = new Map();
-  await toNgffZarr(outputStore, multiscales, { enabledRfcs: [4] });
+  await toNgffZarr(outputStore, multiscales, {});
 
   const multiscalesBack = await fromNgffZarr(outputStore, { validate: true });
   const axisByName = new Map(
@@ -386,9 +360,8 @@ Deno.test("Round-trip with 5D mixed axes (t,c,z,y,x) and LPS orientation", async
     [3, 2, 5, 10, 15],
   );
 
-  // Write to store with RFC 4 enabled
   const outputStore: MemoryStore = new Map();
-  await toNgffZarr(outputStore, multiscales, { enabledRfcs: [4] });
+  await toNgffZarr(outputStore, multiscales, {});
 
   // Read back with validation enabled - should pass
   const multiscalesBack = await fromNgffZarr(outputStore, { validate: true });
@@ -397,48 +370,8 @@ Deno.test("Round-trip with 5D mixed axes (t,c,z,y,x) and LPS orientation", async
 });
 
 Deno.test("Round-trip without orientation passes validation", async () => {
-  // Create multiscales without orientation
-  const store: MemoryStore = new Map();
-  const zarrArray = await createTestZarrArray(store, "test_array", [
-    10,
-    20,
-    30,
-  ]);
+  const { multiscales } = await createMultiscalesWithoutOrientation();
 
-  const dims = ["z", "y", "x"];
-  const scale: Record<string, number> = { z: 2.5, y: 1.0, x: 1.0 };
-  const translation: Record<string, number> = { z: 0.0, y: 0.0, x: 0.0 };
-
-  const ngffImage = new NgffImage({
-    data: zarrArray,
-    dims,
-    scale,
-    translation,
-    name: "test_no_orientation",
-    axesUnits: undefined,
-    axesOrientations: undefined, // No orientations
-    computedCallbacks: undefined,
-  });
-
-  const axes = dims.map((dim) =>
-    createAxis(dim as "x" | "y" | "z", "space", "micrometer")
-  );
-  const dataset = createDataset(
-    "scale0",
-    dims.map((dim) => scale[dim]),
-    dims.map((dim) => translation[dim]),
-  );
-  const metadata = createMetadata(axes, [dataset], "test_no_orientation");
-
-  const multiscales = new NgffMultiscales({
-    images: [ngffImage],
-    metadata,
-    scaleFactors: undefined,
-    method: undefined,
-    chunks: undefined,
-  });
-
-  // Write to store (no RFC 4 enabled)
   const outputStore: MemoryStore = new Map();
   await toNgffZarr(outputStore, multiscales, {});
 
@@ -453,9 +386,8 @@ Deno.test("Round-trip without orientation passes validation", async () => {
 Deno.test("fromNgffZarr extracts LPS orientation into NgffImage.axesOrientations", async () => {
   const { multiscales } = await createMultiscalesWithOrientation(LPS);
 
-  // Write to store with RFC 4 enabled
   const outputStore: MemoryStore = new Map();
-  await toNgffZarr(outputStore, multiscales, { enabledRfcs: [4] });
+  await toNgffZarr(outputStore, multiscales, {});
 
   // Read back
   const multiscalesBack = await fromNgffZarr(outputStore, { validate: true });
@@ -482,9 +414,8 @@ Deno.test("fromNgffZarr extracts LPS orientation into NgffImage.axesOrientations
 Deno.test("fromNgffZarr extracts RAS orientation into NgffImage.axesOrientations", async () => {
   const { multiscales } = await createMultiscalesWithOrientation(RAS);
 
-  // Write to store with RFC 4 enabled
   const outputStore: MemoryStore = new Map();
-  await toNgffZarr(outputStore, multiscales, { enabledRfcs: [4] });
+  await toNgffZarr(outputStore, multiscales, {});
 
   // Read back
   const multiscalesBack = await fromNgffZarr(outputStore, { validate: true });
@@ -509,48 +440,8 @@ Deno.test("fromNgffZarr extracts RAS orientation into NgffImage.axesOrientations
 });
 
 Deno.test("fromNgffZarr returns undefined axesOrientations when no orientation in metadata", async () => {
-  // Create multiscales without orientation
-  const store: MemoryStore = new Map();
-  const zarrArray = await createTestZarrArray(store, "test_array", [
-    10,
-    20,
-    30,
-  ]);
+  const { multiscales } = await createMultiscalesWithoutOrientation();
 
-  const dims = ["z", "y", "x"];
-  const scale: Record<string, number> = { z: 1.0, y: 1.0, x: 1.0 };
-  const translation: Record<string, number> = { z: 0.0, y: 0.0, x: 0.0 };
-
-  const ngffImage = new NgffImage({
-    data: zarrArray,
-    dims,
-    scale,
-    translation,
-    name: "test",
-    axesUnits: undefined,
-    axesOrientations: undefined,
-    computedCallbacks: undefined,
-  });
-
-  const axes = dims.map((dim) =>
-    createAxis(dim as "x" | "y" | "z", "space", "micrometer")
-  );
-  const dataset = createDataset(
-    "scale0",
-    dims.map((dim) => scale[dim]),
-    dims.map((dim) => translation[dim]),
-  );
-  const metadata = createMetadata(axes, [dataset], "test");
-
-  const multiscales = new NgffMultiscales({
-    images: [ngffImage],
-    metadata,
-    scaleFactors: undefined,
-    method: undefined,
-    chunks: undefined,
-  });
-
-  // Write to store without orientation
   const outputStore: MemoryStore = new Map();
   await toNgffZarr(outputStore, multiscales, {});
 
@@ -562,10 +453,11 @@ Deno.test("fromNgffZarr returns undefined axesOrientations when no orientation i
   assertEquals(image.axesOrientations, undefined);
 });
 
-// Browser parity tests (issue #481): the browser toOmeZarr must honor the
-// enabledRfcs option identically to the Node implementation.
+// Browser parity tests (issue #481): the browser toOmeZarr must serialize
+// orientation identically to the Node implementation -- written automatically
+// whenever it is present.
 
-Deno.test("toOmeZarr (browser) writes orientation when enabledRfcs includes 4", async () => {
+Deno.test("toOmeZarr (browser) writes orientation automatically when present", async () => {
   const orientations: Record<string, AnatomicalOrientation> = {
     x: createAnatomicalOrientation(AnatomicalOrientationValues.LeftToRight),
     y: createAnatomicalOrientation(
@@ -578,9 +470,8 @@ Deno.test("toOmeZarr (browser) writes orientation when enabledRfcs includes 4", 
 
   const { multiscales } = await createMultiscalesWithOrientation(orientations);
 
-  // Write to a new store with RFC 4 enabled using the browser implementation
   const outputStore: MemoryStore = new Map();
-  await toOmeZarrBrowser(outputStore, multiscales, { enabledRfcs: [4] });
+  await toOmeZarrBrowser(outputStore, multiscales, {});
 
   // Read back and check metadata
   const attrs = await readZarrAttrs(outputStore);
@@ -617,20 +508,9 @@ Deno.test("toOmeZarr (browser) writes orientation when enabledRfcs includes 4", 
   }
 });
 
-Deno.test("toOmeZarr (browser) omits orientation when enabledRfcs is undefined", async () => {
-  const orientations: Record<string, AnatomicalOrientation> = {
-    x: createAnatomicalOrientation(AnatomicalOrientationValues.LeftToRight),
-    y: createAnatomicalOrientation(
-      AnatomicalOrientationValues.PosteriorToAnterior,
-    ),
-    z: createAnatomicalOrientation(
-      AnatomicalOrientationValues.SuperiorToInferior,
-    ),
-  };
+Deno.test("toOmeZarr (browser) omits orientation when none is present", async () => {
+  const { multiscales } = await createMultiscalesWithoutOrientation();
 
-  const { multiscales } = await createMultiscalesWithOrientation(orientations);
-
-  // Write without RFC 4 enabled (default) using the browser implementation
   const outputStore: MemoryStore = new Map();
   await toOmeZarrBrowser(outputStore, multiscales, {});
 
@@ -647,53 +527,19 @@ Deno.test("toOmeZarr (browser) omits orientation when enabledRfcs is undefined",
     assertEquals(
       "orientation" in axis,
       false,
-      `Axis ${axis.name} should not have orientation when RFC 4 is disabled`,
-    );
-  }
-});
-
-Deno.test("toOmeZarr (browser) omits orientation when enabledRfcs is empty", async () => {
-  const orientations: Record<string, AnatomicalOrientation> = {
-    x: createAnatomicalOrientation(AnatomicalOrientationValues.LeftToRight),
-    y: createAnatomicalOrientation(
-      AnatomicalOrientationValues.PosteriorToAnterior,
-    ),
-    z: createAnatomicalOrientation(
-      AnatomicalOrientationValues.SuperiorToInferior,
-    ),
-  };
-
-  const { multiscales } = await createMultiscalesWithOrientation(orientations);
-
-  // Write with empty enabledRfcs using the browser implementation
-  const outputStore: MemoryStore = new Map();
-  await toOmeZarrBrowser(outputStore, multiscales, { enabledRfcs: [] });
-
-  // Read back and check metadata
-  const attrs = await readZarrAttrs(outputStore);
-  const multiscalesArray = getNgffMultiscalesArray(attrs);
-  const multiscalesMetadata = multiscalesArray[0] as Record<string, unknown>;
-  const axesMetadata = multiscalesMetadata.axes as Array<
-    Record<string, unknown>
-  >;
-
-  // Check that no spatial axes have orientation
-  for (const axis of axesMetadata) {
-    assertEquals(
-      "orientation" in axis,
-      false,
-      `Axis ${axis.name} should not have orientation when RFC 4 is disabled`,
+      `Axis ${axis.name} should not have orientation when none was specified`,
     );
   }
 });
 
 Deno.test("toOmeZarr (browser) preserves axis name, type, and unit", async () => {
-  // Guards the switch from raw metadata.axes to processAxesForRfcs output:
-  // the standard OME-Zarr axis fields must survive regardless of enabledRfcs.
+  // Guards the switch from raw metadata.axes to processAxes output:
+  // the standard OME-Zarr axis fields must survive, and orientation present on
+  // the source axes is written through.
   const { multiscales } = await createMultiscalesWithOrientation(LPS);
 
   const outputStore: MemoryStore = new Map();
-  await toOmeZarrBrowser(outputStore, multiscales, {}); // RFC 4 not enabled
+  await toOmeZarrBrowser(outputStore, multiscales, {});
 
   const attrs = await readZarrAttrs(outputStore);
   const multiscalesArray = getNgffMultiscalesArray(attrs);
@@ -710,8 +556,8 @@ Deno.test("toOmeZarr (browser) preserves axis name, type, and unit", async () =>
   for (const axis of axesMetadata) {
     assertEquals(axis.type, "space");
     assertEquals(axis.unit, "micrometer");
-    // Orientation is stripped when RFC 4 is not enabled
-    assertEquals("orientation" in axis, false);
+    // Orientation is present because the source axes carry it
+    assertEquals("orientation" in axis, true);
   }
 });
 
@@ -721,7 +567,6 @@ Deno.test("toOmeZarr (browser) writes orientation under ome namespace for versio
   const outputStore: MemoryStore = new Map();
   await toOmeZarrBrowser(outputStore, multiscales, {
     version: "0.5",
-    enabledRfcs: [4],
   });
 
   // Version 0.5 nests multiscales metadata under the "ome" attribute

--- a/ts/test/rfc4_test.ts
+++ b/ts/test/rfc4_test.ts
@@ -5,15 +5,15 @@
  * Ported from py/test/test_rfc4.py
  */
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import {
   addAnatomicalOrientationToAxis,
   anatomicalOrientationToItkDirection,
   AnatomicalOrientationValues,
   createAnatomicalOrientation,
-  isRfc4Enabled,
   itkLpsToAnatomicalOrientation,
   LPS,
+  orientationFromName,
   RAS,
   removeAnatomicalOrientationFromAxis,
 } from "../src/types/rfc4.ts";
@@ -61,18 +61,20 @@ Deno.test("itkLpsToAnatomicalOrientation - non-spatial axis returns undefined", 
   assertEquals(tOrientation, undefined);
 });
 
-Deno.test("isRfc4Enabled - returns true when 4 is in list", () => {
-  assertEquals(isRfc4Enabled([4]), true);
-  assertEquals(isRfc4Enabled([1, 2, 4, 5]), true);
+Deno.test("orientationFromName - resolves LPS and RAS presets", () => {
+  assertEquals(orientationFromName("LPS"), LPS);
+  assertEquals(orientationFromName("RAS"), RAS);
+  // Case-insensitive
+  assertEquals(orientationFromName("lps"), LPS);
+  assertEquals(orientationFromName("ras"), RAS);
 });
 
-Deno.test("isRfc4Enabled - returns false when 4 is not in list", () => {
-  assertEquals(isRfc4Enabled([1, 2, 3]), false);
-  assertEquals(isRfc4Enabled([]), false);
-});
-
-Deno.test("isRfc4Enabled - returns false for undefined", () => {
-  assertEquals(isRfc4Enabled(undefined), false);
+Deno.test("orientationFromName - throws on unknown preset", () => {
+  assertThrows(
+    () => orientationFromName("FOO"),
+    Error,
+    "Unknown anatomical orientation preset",
+  );
 });
 
 Deno.test("addAnatomicalOrientationToAxis - adds orientation to axis dict", () => {

--- a/ts/test/to_multiscales_itkwasm_test.ts
+++ b/ts/test/to_multiscales_itkwasm_test.ts
@@ -13,6 +13,8 @@ import {
 } from "../src/process/to_multiscales-node.ts";
 import { toNgffZarr } from "../src/mod.ts";
 import type { MemoryStore } from "../src/io/from_ngff_zarr.ts";
+import { NgffImage } from "../src/types/ngff_image.ts";
+import { LPS, RAS } from "../src/types/rfc4.ts";
 
 Deno.test("downsample czyx", async () => {
   const data = new Uint8Array(2 * 32 * 64 * 64);
@@ -423,6 +425,64 @@ Deno.test("itkwasm label image many channels (>8)", async () => {
   assertEquals(multiscales.images[1].data.shape[0], numChannels); // c unchanged
   assertEquals(multiscales.images[1].data.shape[1], 16); // y: 32/2
   assertEquals(multiscales.images[1].data.shape[2], 16); // x: 32/2
+});
+
+Deno.test("toMultiscales orientation option (preset) populates spatial axes", async () => {
+  const data = new Uint8Array(16 * 32 * 32);
+  for (let i = 0; i < data.length; i++) {
+    data[i] = i % 256;
+  }
+
+  const image = await toNgffImage(data, {
+    dims: ["z", "y", "x"],
+    shape: [16, 32, 32],
+  });
+
+  const multiscales = await toMultiscales(image, {
+    scaleFactors: [2],
+    orientation: "LPS",
+  });
+
+  const byName = new Map(multiscales.metadata.axes.map((ax) => [ax.name, ax]));
+  // LPS preset values
+  assertEquals(byName.get("x")?.orientation?.value, "right-to-left");
+  assertEquals(byName.get("y")?.orientation?.value, "anterior-to-posterior");
+  assertEquals(byName.get("z")?.orientation?.value, "inferior-to-superior");
+});
+
+Deno.test("toMultiscales orientation option overrides image axesOrientations", async () => {
+  const data = new Uint8Array(16 * 32 * 32);
+  for (let i = 0; i < data.length; i++) {
+    data[i] = i % 256;
+  }
+
+  // Build an image that already carries LPS orientation...
+  const base = await toNgffImage(data, {
+    dims: ["z", "y", "x"],
+    shape: [16, 32, 32],
+  });
+  const image = new NgffImage({
+    data: base.data,
+    dims: base.dims,
+    scale: base.scale,
+    translation: base.translation,
+    name: base.name,
+    axesUnits: base.axesUnits,
+    axesOrientations: LPS,
+    computedCallbacks: base.computedCallbacks,
+  });
+
+  // ...but the explicit orientation option (RAS) takes precedence.
+  const multiscales = await toMultiscales(image, {
+    scaleFactors: [2],
+    orientation: RAS,
+  });
+
+  const byName = new Map(multiscales.metadata.axes.map((ax) => [ax.name, ax]));
+  // RAS values, not LPS
+  assertEquals(byName.get("x")?.orientation?.value, "left-to-right");
+  assertEquals(byName.get("y")?.orientation?.value, "posterior-to-anterior");
+  assertEquals(byName.get("z")?.orientation?.value, "inferior-to-superior");
 });
 
 console.log("✅ All ITK-Wasm downsampling tests completed!");


### PR DESCRIPTION
## Summary

Makes RFC-4 anatomical orientation **data-driven**: orientation is written to
OME-Zarr output whenever it is present on an image's axes, rather than being
gated behind an explicit opt-in. The previous `enabled-rfcs` API (an RFC-number
allowlist that had to include `4`) is removed across all three packages.

Practically:

- Inputs that already carry orientation — NIfTI/NRRD/DICOM via ITK, or an
  `NgffImage` with `axes_orientations` set — now serialize it with **no extra
  flags**.
- Images without orientation produce standard OME-NGFF metadata, unchanged and
  fully compatible with consumers that don't understand RFC-4.
- Orientation can be requested explicitly via a new `orientation=` keyword on
  `to_multiscales` (and `--orientation` on the CLI), accepting a preset
  (`LPS`/`RAS`) or a per-axis mapping.

## Why

The opt-in flag was redundant and a usability trap: orientation was computed and
attached during conversion (e.g. from an ITK direction matrix) only to be
silently dropped on write unless the caller also remembered to pass
`enabled_rfcs=[4]`. Driving serialization off the presence of the metadata
removes that footgun and the parallel flag surface in every package.

## Changes by package

**Python (`py/`)**
- Drop `enabled_rfcs` from `to_ngff_zarr`/`to_ome_zarr`, `_to_ngff_zarr_impl`,
  `_prepare_metadata`, and `_pop_metadata_optionals`. The optionals stripper now
  keeps populated `orientation` and only culls `None` values (so non-spatial
  axes still never emit `orientation: null`).
- Remove `is_rfc4_enabled`; add `orientation_from_name(name)` (resolves
  `"LPS"`/`"RAS"`, case-insensitive).
- Add an `orientation=` keyword to `to_multiscales` — a preset name or a
  `Mapping[str, AnatomicalOrientation]` — taking precedence over the image's
  `axes_orientations`.
- Replace the `--enable-rfc` CLI flag with `--orientation`, which accepts a
  preset or ordered `dim value` pairs
  (e.g. `--orientation x right-to-left y anterior-to-posterior z inferior-to-superior`).

**TypeScript (`ts/`)**
- Remove `enabledRfcs` from every write option (`toNgffZarr`, browser variant,
  OZX/RFC-9) and delete `isRfc4Enabled`.
- Rename `processAxesForRfcs` → `processAxes`, which emits orientation whenever
  an axis carries it.
- Add `orientationFromName` and an `orientation` option to `toMultiscales`.

**MCP (`mcp/`)**
- Remove the dead `enable_rfc4`/`enabled_rfcs` parameters.
- Wire the previously no-op `anatomical_orientation` preset through to
  `to_multiscales`. This applies to file/array inputs; existing zarr-store
  inputs keep their source orientation metadata (documented in the tool).

**Docs**
- Rewrite `docs/rfc4.md` and the `AGENTS.md` RFC-4 snippet for the data-driven
  model.

## Implementation notes

- ITK/NIfTI conversions add orientation by default, so those round-trips now
  **preserve direction** that was previously dropped. The `MR-head`
  baseline-comparison test (`ts/`) compares against an orientation-free pooch
  baseline, so it explicitly passes `addAnatomicalOrientation: false` for that
  input — matching the convention already used there for `cthead1`.

## Testing

- **Python**: new `test_cli_orientation.py` (preset/pairs parsing, error-exit
  paths, end-to-end CLI write, ITK auto-write); extended
  `test_rfc4_integration.py` with the `orientation=` mapping and
  precedence-over-`axes_orientations` cases. Full suite passes.
- **TypeScript**: added `toMultiscales({ orientation })` preset and precedence
  tests; full suite (403) passes, `deno lint`/`fmt` clean.
- **MCP**: added an `anatomical_orientation="RAS"` write test; suite (15) passes.
- Reviewed with CodeRabbit (`coderabbit review --agent`): its one finding (MCP
  orientation ignored for zarr-store inputs) was an intentional pre-existing
  design and is now documented; re-review returned 0 findings.

## Breaking change / migration

The `enabled_rfcs` parameter (Python `to_ngff_zarr`/`to_ome_zarr`), the
`--enable-rfc` CLI flag, the `enabledRfcs` TypeScript write option, and the MCP
`enable_rfc4`/`enabled_rfcs` fields are **removed**.

To write RFC-4 anatomical orientation, just make sure it is present — supply it
via `NgffImage.axes_orientations`, the new `orientation=` argument to
`to_multiscales`, or the `--orientation` CLI flag. No opt-in flag is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated RFC-4 guidance and examples to reflect that anatomical orientation metadata is written automatically whenever spatial axis orientations are available.
* **New Features**
  * Added CLI `--orientation` support (preset `LPS`/`RAS` and per-axis mappings) and multiscales `orientation` options.
  * Updated the image conversion tool interface to accept `anatomical_orientation`.
* **Changes**
  * Removed RFC-4 enablement/feature-flag controls across Python, CLI, and browser/Node APIs; legacy `enabledRfcs`/`enabled_rfcs` is rejected.
  * `orientation` overrides image-provided axis orientations when explicitly set.
* **Tests**
  * Added and updated CLI/unit/integration tests (Node + browser + v0.4/v0.5 layouts) to verify serialization, absence/presence behavior, and override precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->