### PR TITLE
feat(ts): add OME-Zarr v0.6 (RFC-5) coordinate systems and transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The TypeScript package provides universal OME-Zarr support for modern JavaScript
 - 🦕 **Deno-first** with first-class TypeScript support
 - 📦 **Universal compatibility** - Works in Deno, Node.js, and browsers
 - 🔍 **Type-safe** with Zod schema validation
-- 🗂️ **OME-Zarr v0.4 and v0.5** support
+- 🗂️ **OME-Zarr v0.4, v0.5, and v0.6** support (v0.6 adds RFC-5 coordinate systems and transformations)
 - 🌐 **Web ready** - No filesystem dependencies, works with remote stores
 - 🏗️ **Mirrors Python API** - Familiar interfaces for Python users
 - 📚 **Lazy loading** - Efficient handling of large datasets

--- a/ts/src/io/from_ngff_zarr-browser.ts
+++ b/ts/src/io/from_ngff_zarr-browser.ts
@@ -10,6 +10,7 @@ import { NgffImage } from "../types/ngff_image.ts";
 import type { Units } from "../types/units.ts";
 import type { Metadata, Omero } from "../types/zarr_metadata.ts";
 import { extractMethodMetadata } from "../utils/parse_metadata.ts";
+import { fromZarrAttrsV06 } from "../utils/from_zarr_attrs.ts";
 
 export type { ChunkCache } from "../utils/worker_pool.ts";
 
@@ -17,7 +18,7 @@ export interface FromOmeZarrOptions {
   /** Enable schema validation of OME-Zarr metadata. */
   validate?: boolean;
   /** Expected OME-Zarr version. */
-  version?: "0.4" | "0.5";
+  version?: "0.4" | "0.5" | "0.6";
   /**
    * Optional decoded-chunk cache passed to `zarrGet` calls.
    *
@@ -88,6 +89,47 @@ export async function fromOmeZarr(
       kind: "group",
     });
     const attrs = root.attrs as unknown;
+
+    // OME-Zarr v0.6 (RFC 5) uses a different on-disk shape (coordinateSystems +
+    // per-dataset sequence transforms) than the inline v0.4/v0.5 parser below,
+    // so delegate to the shared, environment-agnostic v0.6 reader.
+    const rootAttrsForVersion = attrs as Record<string, unknown>;
+    const omeForVersion = rootAttrsForVersion.ome as
+      | Record<string, unknown>
+      | undefined;
+    if (omeForVersion && omeForVersion.version === "0.6") {
+      // Gate the requested-version mismatch behind `validate`, matching the node
+      // reader and the v0.4/v0.5 path below; otherwise behavior diverges by
+      // version and environment.
+      if (validate && version && version !== "0.6") {
+        throw new Error(`Expected OME-Zarr version ${version}, but found 0.6`);
+      }
+      const result = await fromZarrAttrsV06(
+        rootAttrsForVersion,
+        resolvedStore,
+        validate,
+      );
+      const entry = (omeForVersion.multiscales as unknown[])[0] as Record<
+        string,
+        unknown
+      >;
+      const { method, methodType, methodMetadata } = extractMethodMetadata(
+        entry,
+      );
+      if (methodType) {
+        result.metadata.type = methodType;
+      }
+      if (methodMetadata) {
+        result.metadata.metadata = methodMetadata;
+      }
+      return new NgffMultiscales({
+        images: result.images,
+        metadata: result.metadata,
+        scaleFactors: undefined,
+        method,
+        chunks: undefined,
+      });
+    }
 
     // Handle both 0.4 (multiscales at root) and 0.5 (multiscales under ome) formats
     let multiscalesArray: unknown[];

--- a/ts/src/io/from_ngff_zarr-browser.ts
+++ b/ts/src/io/from_ngff_zarr-browser.ts
@@ -11,6 +11,7 @@ import type { Units } from "../types/units.ts";
 import type { Metadata, Omero } from "../types/zarr_metadata.ts";
 import { extractMethodMetadata } from "../utils/parse_metadata.ts";
 import { fromZarrAttrsV06 } from "../utils/from_zarr_attrs.ts";
+import { isV06Version } from "../types/supported_versions.ts";
 
 export type { ChunkCache } from "../utils/worker_pool.ts";
 
@@ -97,12 +98,18 @@ export async function fromOmeZarr(
     const omeForVersion = rootAttrsForVersion.ome as
       | Record<string, unknown>
       | undefined;
-    if (omeForVersion && omeForVersion.version === "0.6") {
+    if (
+      omeForVersion && typeof omeForVersion.version === "string" &&
+      isV06Version(omeForVersion.version)
+    ) {
       // Gate the requested-version mismatch behind `validate`, matching the node
       // reader and the v0.4/v0.5 path below; otherwise behavior diverges by
-      // version and environment.
-      if (validate && version && version !== "0.6") {
-        throw new Error(`Expected OME-Zarr version ${version}, but found 0.6`);
+      // version and environment. The v0.6 family (`0.6` and draft `0.6.dev4`)
+      // is treated as equivalent.
+      if (validate && version && !isV06Version(version)) {
+        throw new Error(
+          `Expected OME-Zarr version ${version}, but found ${omeForVersion.version}`,
+        );
       }
       const result = await fromZarrAttrsV06(
         rootAttrsForVersion,

--- a/ts/src/io/from_ngff_zarr.ts
+++ b/ts/src/io/from_ngff_zarr.ts
@@ -3,7 +3,7 @@
 import * as zarr from "zarrita";
 
 import { NgffMultiscales } from "../types/multiscales.ts";
-import { NgffVersion } from "../types/supported_versions.ts";
+import { isV06Version, NgffVersion } from "../types/supported_versions.ts";
 import {
   fromZarrAttrsV04,
   fromZarrAttrsV05,
@@ -127,18 +127,23 @@ export async function fromOmeZarr(
     // Detect version from attributes
     const detectedVersion = detectVersion(rootAttrs);
 
-    // Validate version if requested
+    // Validate version if requested. Treat the v0.6 family as equivalent so a
+    // store tagged `0.6.dev4` on disk satisfies a requested version of `"0.6"`
+    // (and vice versa).
     if (validate && requestedVersion) {
-      if (detectedVersion !== requestedVersion) {
+      const versionsMatch = detectedVersion === requestedVersion ||
+        (isV06Version(detectedVersion) && isV06Version(requestedVersion));
+      if (!versionsMatch) {
         throw new Error(
           `Expected OME-Zarr version ${requestedVersion}, but found ${detectedVersion}`,
         );
       }
     }
 
-    // Parse metadata using version-specific function
+    // Parse metadata using version-specific function. The v0.6 reader handles
+    // both `0.6` and the draft `0.6.dev4` on-disk version strings.
     let result;
-    if (detectedVersion === NgffVersion.V06) {
+    if (isV06Version(detectedVersion)) {
       result = await fromZarrAttrsV06(rootAttrs, resolvedStore, validate);
     } else if (detectedVersion === NgffVersion.V05) {
       result = await fromZarrAttrsV05(rootAttrs, resolvedStore, validate);

--- a/ts/src/io/from_ngff_zarr.ts
+++ b/ts/src/io/from_ngff_zarr.ts
@@ -7,6 +7,7 @@ import { NgffVersion } from "../types/supported_versions.ts";
 import {
   fromZarrAttrsV04,
   fromZarrAttrsV05,
+  fromZarrAttrsV06,
 } from "../utils/from_zarr_attrs.ts";
 import {
   detectVersion,
@@ -20,7 +21,7 @@ export interface FromOmeZarrOptions {
   /** Enable schema validation of OME-Zarr metadata. */
   validate?: boolean;
   /** Expected OME-Zarr version. */
-  version?: "0.4" | "0.5";
+  version?: "0.4" | "0.5" | "0.6";
   /**
    * Optional decoded-chunk cache passed to `zarrGet` calls.
    *
@@ -137,7 +138,9 @@ export async function fromOmeZarr(
 
     // Parse metadata using version-specific function
     let result;
-    if (detectedVersion === NgffVersion.V05) {
+    if (detectedVersion === NgffVersion.V06) {
+      result = await fromZarrAttrsV06(rootAttrs, resolvedStore, validate);
+    } else if (detectedVersion === NgffVersion.V05) {
       result = await fromZarrAttrsV05(rootAttrs, resolvedStore, validate);
     } else {
       result = await fromZarrAttrsV04(rootAttrs, resolvedStore, validate);

--- a/ts/src/io/to_ngff_zarr-browser.ts
+++ b/ts/src/io/to_ngff_zarr-browser.ts
@@ -15,12 +15,16 @@ import {
   processAxes,
   writeNgffMultiscalesToMemoryStore,
 } from "./to_ngff_zarr_ozx_common.ts";
+import {
+  buildV06MultiscalesEntry,
+  legacyTopLevelTransforms,
+} from "../utils/v06_metadata.ts";
 
 export { isOzxPath } from "./rfc9_zip.ts";
 
 export interface ToOmeZarrOptions {
   overwrite?: boolean;
-  version?: "0.4" | "0.5";
+  version?: "0.4" | "0.5" | "0.6";
   chunksPerShard?: number | number[] | Record<string, number>;
   /**
    * Custom codec pipeline for array compression. When omitted the default
@@ -92,43 +96,65 @@ export async function toOmeZarr(
     // Process axes (orientation included when present)
     const processedAxes = processAxes(multiscales.metadata.axes);
 
-    // Prepare multiscales metadata
-    const multiscalesMetadata = {
-      version: _version,
-      name: multiscales.metadata.name,
-      axes: processedAxes,
-      datasets: multiscales.metadata.datasets,
-      ...(multiscales.metadata.coordinateTransformations && {
-        coordinateTransformations:
-          multiscales.metadata.coordinateTransformations,
-      }),
-      ...(multiscales.metadata.type && {
-        type: multiscales.metadata.type,
-      }),
-      ...(multiscales.metadata.metadata && {
-        metadata: multiscales.metadata.metadata,
-      }),
-    };
-
-    // Create the root group with OME-Zarr metadata
-    // For version 0.5, wrap metadata under "ome" property (including omero)
-    // For version 0.4, place multiscales and omero directly at root
-    const attributes: Record<string, unknown> = _version === "0.5"
-      ? {
+    // Create the root group with OME-Zarr metadata.
+    // - v0.6 (RFC 5): coordinate systems + per-dataset sequence transforms,
+    //   wrapped under the "ome" property.
+    // - v0.5: axes carried directly, wrapped under "ome".
+    // - v0.4: axes carried directly, placed at the root.
+    let attributes: Record<string, unknown>;
+    if (_version === "0.6") {
+      const v06Entry = buildV06MultiscalesEntry(
+        multiscales.metadata,
+        processedAxes,
+      );
+      attributes = {
         ome: {
           version: _version,
-          multiscales: [multiscalesMetadata],
+          multiscales: [v06Entry],
           ...(multiscales.metadata.omero && {
             omero: multiscales.metadata.omero,
           }),
         },
-      }
-      : {
-        multiscales: [multiscalesMetadata],
-        ...(multiscales.metadata.omero && {
-          omero: multiscales.metadata.omero,
+      };
+    } else {
+      // v0.4/v0.5 only support the simple scale/translation subset of top-level
+      // transformations; drop richer v0.6 transforms when downgrading.
+      const legacyTransforms = legacyTopLevelTransforms(
+        multiscales.metadata.coordinateTransformations,
+      );
+      const multiscalesMetadata = {
+        version: _version,
+        name: multiscales.metadata.name,
+        axes: processedAxes,
+        datasets: multiscales.metadata.datasets,
+        ...(legacyTransforms && {
+          coordinateTransformations: legacyTransforms,
+        }),
+        ...(multiscales.metadata.type && {
+          type: multiscales.metadata.type,
+        }),
+        ...(multiscales.metadata.metadata && {
+          metadata: multiscales.metadata.metadata,
         }),
       };
+
+      attributes = _version === "0.5"
+        ? {
+          ome: {
+            version: _version,
+            multiscales: [multiscalesMetadata],
+            ...(multiscales.metadata.omero && {
+              omero: multiscales.metadata.omero,
+            }),
+          },
+        }
+        : {
+          multiscales: [multiscalesMetadata],
+          ...(multiscales.metadata.omero && {
+            omero: multiscales.metadata.omero,
+          }),
+        };
+    }
 
     const rootGroup = await zarr.create(root, { attributes });
 

--- a/ts/src/io/to_ngff_zarr-browser.ts
+++ b/ts/src/io/to_ngff_zarr-browser.ts
@@ -10,6 +10,7 @@ import type { ZarrCodec } from "../utils/codecs.ts";
 import { defaultCodecs } from "../utils/codecs.ts";
 import { createWriteQueue, zarrGet, zarrSet } from "../utils/worker_pool.ts";
 import type { MemoryStore } from "./from_ngff_zarr-browser.ts";
+import { V06_ONDISK_VERSION } from "../types/supported_versions.ts";
 import { memoryStoreToZip } from "./rfc9_zip.ts";
 import {
   processAxes,
@@ -109,7 +110,9 @@ export async function toOmeZarr(
       );
       attributes = {
         ome: {
-          version: _version,
+          // The v0.6 spec is still a draft; tag the store with the development
+          // version `0.6.dev4` even though the requested version is `"0.6"`.
+          version: V06_ONDISK_VERSION,
           multiscales: [v06Entry],
           ...(multiscales.metadata.omero && {
             omero: multiscales.metadata.omero,

--- a/ts/src/io/to_ngff_zarr.ts
+++ b/ts/src/io/to_ngff_zarr.ts
@@ -8,6 +8,7 @@ import type { ZarrCodec } from "../utils/codecs.ts";
 import { defaultCodecs } from "../utils/codecs.ts";
 import { createWriteQueue, zarrGet, zarrSet } from "../utils/worker_pool.ts";
 import type { MemoryStore } from "./from_ngff_zarr.ts";
+import { V06_ONDISK_VERSION } from "../types/supported_versions.ts";
 import { isOzxPath, memoryStoreToZip } from "./rfc9_zip.ts";
 import {
   processAxes,
@@ -172,7 +173,9 @@ export async function toOmeZarr(
       );
       attributes = {
         ome: {
-          version: _version,
+          // The v0.6 spec is still a draft; tag the store with the development
+          // version `0.6.dev4` even though the requested version is `"0.6"`.
+          version: V06_ONDISK_VERSION,
           multiscales: [v06Entry],
           ...(multiscales.metadata.omero && {
             omero: multiscales.metadata.omero,

--- a/ts/src/io/to_ngff_zarr.ts
+++ b/ts/src/io/to_ngff_zarr.ts
@@ -13,16 +13,21 @@ import {
   processAxes,
   writeNgffMultiscalesToMemoryStore,
 } from "./to_ngff_zarr_ozx_common.ts";
+import {
+  buildV06MultiscalesEntry,
+  legacyTopLevelTransforms,
+} from "../utils/v06_metadata.ts";
 
 export interface ToOmeZarrOptions {
   overwrite?: boolean;
   /**
    * OME-Zarr version to write. Defaults to "0.5" for regular Zarr files.
+   * Version "0.6" writes RFC 5 coordinate systems and transformations.
    * For .ozx files (RFC-9), this must be version 0.5. If omitted for .ozx files,
    * it defaults to 0.5. If explicitly set to any other value for .ozx files,
    * an error will be thrown.
    */
-  version?: "0.4" | "0.5";
+  version?: "0.4" | "0.5" | "0.6";
   chunksPerShard?: number | number[] | Record<string, number>;
   /**
    * Custom codec pipeline for array compression. When omitted the default
@@ -154,43 +159,65 @@ export async function toOmeZarr(
     // Process axes (orientation included when present)
     const processedAxes = processAxes(multiscales.metadata.axes);
 
-    // Prepare multiscales metadata
-    const multiscalesMetadata = {
-      version: _version,
-      name: multiscales.metadata.name,
-      axes: processedAxes,
-      datasets: multiscales.metadata.datasets,
-      ...(multiscales.metadata.coordinateTransformations && {
-        coordinateTransformations:
-          multiscales.metadata.coordinateTransformations,
-      }),
-      ...(multiscales.metadata.type && {
-        type: multiscales.metadata.type,
-      }),
-      ...(multiscales.metadata.metadata && {
-        metadata: multiscales.metadata.metadata,
-      }),
-    };
-
-    // Create the root group with OME-Zarr metadata
-    // For version 0.5, wrap metadata under "ome" property (including omero)
-    // For version 0.4, place multiscales and omero directly at root
-    const attributes: Record<string, unknown> = _version === "0.5"
-      ? {
+    // Create the root group with OME-Zarr metadata.
+    // - v0.6 (RFC 5): coordinate systems + per-dataset sequence transforms,
+    //   wrapped under the "ome" property.
+    // - v0.5: axes carried directly, wrapped under "ome".
+    // - v0.4: axes carried directly, placed at the root.
+    let attributes: Record<string, unknown>;
+    if (_version === "0.6") {
+      const v06Entry = buildV06MultiscalesEntry(
+        multiscales.metadata,
+        processedAxes,
+      );
+      attributes = {
         ome: {
           version: _version,
-          multiscales: [multiscalesMetadata],
+          multiscales: [v06Entry],
           ...(multiscales.metadata.omero && {
             omero: multiscales.metadata.omero,
           }),
         },
-      }
-      : {
-        multiscales: [multiscalesMetadata],
-        ...(multiscales.metadata.omero && {
-          omero: multiscales.metadata.omero,
+      };
+    } else {
+      // v0.4/v0.5 only support the simple scale/translation subset of top-level
+      // transformations; drop richer v0.6 transforms when downgrading.
+      const legacyTransforms = legacyTopLevelTransforms(
+        multiscales.metadata.coordinateTransformations,
+      );
+      const multiscalesMetadata = {
+        version: _version,
+        name: multiscales.metadata.name,
+        axes: processedAxes,
+        datasets: multiscales.metadata.datasets,
+        ...(legacyTransforms && {
+          coordinateTransformations: legacyTransforms,
+        }),
+        ...(multiscales.metadata.type && {
+          type: multiscales.metadata.type,
+        }),
+        ...(multiscales.metadata.metadata && {
+          metadata: multiscales.metadata.metadata,
         }),
       };
+
+      attributes = _version === "0.5"
+        ? {
+          ome: {
+            version: _version,
+            multiscales: [multiscalesMetadata],
+            ...(multiscales.metadata.omero && {
+              omero: multiscales.metadata.omero,
+            }),
+          },
+        }
+        : {
+          multiscales: [multiscalesMetadata],
+          ...(multiscales.metadata.omero && {
+            omero: multiscales.metadata.omero,
+          }),
+        };
+    }
 
     const rootGroup = await zarr.create(root, { attributes });
 

--- a/ts/src/io/to_ngff_zarr_ozx_common.ts
+++ b/ts/src/io/to_ngff_zarr_ozx_common.ts
@@ -10,6 +10,7 @@ import * as zarr from "zarrita";
 import type { NgffMultiscales } from "../types/multiscales.ts";
 import type { NgffImage } from "../types/ngff_image.ts";
 import type { Axis } from "../types/zarr_metadata.ts";
+import { legacyTopLevelTransforms } from "../utils/v06_metadata.ts";
 import type { MemoryStore } from "./rfc9_zip.ts";
 
 /**
@@ -75,13 +76,22 @@ export function prepareRfc9Metadata(
   // Process axes (orientation included when present)
   const processedAxes = processAxes(multiscales.metadata.axes);
 
+  // RFC-9 (.ozx) is always v0.5, which only supports the simple
+  // scale/translation subset of top-level transforms. Reduce any v0.6-only
+  // transforms (rotation/affine/sequence, or input/output/name on a
+  // scale/translation) to that subset so they cannot leak into the store,
+  // matching the v0.4/v0.5 branch of the regular writer.
+  const legacyTransforms = legacyTopLevelTransforms(
+    multiscales.metadata.coordinateTransformations,
+  );
+
   return {
     version: _version,
     name: multiscales.metadata.name,
     axes: processedAxes,
     datasets: multiscales.metadata.datasets,
-    ...(multiscales.metadata.coordinateTransformations && {
-      coordinateTransformations: multiscales.metadata.coordinateTransformations,
+    ...(legacyTransforms && {
+      coordinateTransformations: legacyTransforms,
     }),
     ...(multiscales.metadata.type && {
       type: multiscales.metadata.type,

--- a/ts/src/mod.ts
+++ b/ts/src/mod.ts
@@ -59,7 +59,11 @@ export {
   createNgffImage,
   createNgffMultiscales,
 } from "./utils/factory.ts";
-export { fromZarrAttrsV04, fromZarrAttrsV05 } from "./utils/from_zarr_attrs.ts";
+export {
+  fromZarrAttrsV04,
+  fromZarrAttrsV05,
+  fromZarrAttrsV06,
+} from "./utils/from_zarr_attrs.ts";
 export { getMethodMetadata } from "./utils/method_metadata.ts";
 export {
   detectVersion,

--- a/ts/src/process/to_multiscales-shared.ts
+++ b/ts/src/process/to_multiscales-shared.ts
@@ -22,6 +22,10 @@ import {
 import { getMethodMetadata } from "../utils/method_metadata.ts";
 import type { AnatomicalOrientation } from "../types/rfc4.ts";
 import { orientationFromName } from "../types/rfc4.ts";
+import {
+  createCoordinateSystem,
+  INTRINSIC_COORDINATE_SYSTEM_NAME,
+} from "../types/zarr_metadata.ts";
 
 export type { ZarrCodec };
 
@@ -153,6 +157,12 @@ export async function toMultiscalesCore(
   // Create metadata with method information
   const methodMetadata = getMethodMetadata(method);
   const metadata = createMetadata(axes, datasets, image.name);
+  // RFC 5 / v0.6 exposes the implicit "intrinsic" coordinate system (the axes
+  // of the full-resolution image); each dataset maps into it. Older versions
+  // ignore this field on write. Mirrors the Python v0.6 `to_multiscales`.
+  metadata.coordinateSystems = [
+    createCoordinateSystem(INTRINSIC_COORDINATE_SYSTEM_NAME, axes),
+  ];
   // The 'type' field, part of the OME-Zarr specification, in metadata is used here to
   // record the downsampling method applied to generate multiscale images for provenance.
   metadata.type = method;

--- a/ts/src/types/supported_versions.ts
+++ b/ts/src/types/supported_versions.ts
@@ -12,8 +12,23 @@ export enum NgffVersion {
   V04 = "0.4",
   V05 = "0.5",
   V06 = "0.6",
-  LATEST = "0.6",
+  /**
+   * Draft development version of the OME-Zarr v0.6 (RFC-5) spec. Stores are
+   * tagged on disk with this string while the spec is still in development;
+   * see {@link V06_ONDISK_VERSION}. Temporary — tracks the upstream dev release.
+   */
+  V06dev4 = "0.6.dev4",
+  LATEST = "0.6.dev4",
 }
+
+/**
+ * The on-disk `ome.version` string written for OME-Zarr v0.6. The v0.6 / RFC-5
+ * spec is still a draft, so stores are tagged with the development version
+ * `0.6.dev4` even though the library's public `version` option is `"0.6"`.
+ * This is a temporary shim that tracks the upstream spec's dev releases;
+ * mirrors the Python port writing `"0.6.dev4"` for a requested version `"0.6"`.
+ */
+export const V06_ONDISK_VERSION: NgffVersion = NgffVersion.V06dev4;
 
 /**
  * Supported NGFF specification versions
@@ -25,6 +40,7 @@ export const SUPPORTED_VERSIONS: readonly NgffVersion[] = [
   NgffVersion.V04,
   NgffVersion.V05,
   NgffVersion.V06,
+  NgffVersion.V06dev4,
 ] as const;
 
 /**
@@ -32,4 +48,14 @@ export const SUPPORTED_VERSIONS: readonly NgffVersion[] = [
  */
 export function isSupportedVersion(version: string): version is NgffVersion {
   return Object.values(NgffVersion).includes(version as NgffVersion);
+}
+
+/**
+ * Whether an `ome.version` string identifies an OME-Zarr v0.6 store, including
+ * draft development versions such as `0.6.dev4`. Mirrors the Python port's
+ * `version.startswith("0.6")` check so a store written by either implementation
+ * reads back as v0.6.
+ */
+export function isV06Version(version: string): boolean {
+  return version.startsWith("0.6");
 }

--- a/ts/src/types/supported_versions.ts
+++ b/ts/src/types/supported_versions.ts
@@ -11,7 +11,8 @@ export enum NgffVersion {
   V03 = "0.3",
   V04 = "0.4",
   V05 = "0.5",
-  LATEST = "0.5",
+  V06 = "0.6",
+  LATEST = "0.6",
 }
 
 /**
@@ -23,6 +24,7 @@ export const SUPPORTED_VERSIONS: readonly NgffVersion[] = [
   NgffVersion.V03,
   NgffVersion.V04,
   NgffVersion.V05,
+  NgffVersion.V06,
 ] as const;
 
 /**

--- a/ts/src/types/zarr_metadata.ts
+++ b/ts/src/types/zarr_metadata.ts
@@ -6,6 +6,13 @@ import type { NgffImage } from "./ngff_image.ts";
 import type { AnatomicalOrientation } from "./rfc4.ts";
 
 /**
+ * Name of the implicit coordinate system generated for a multiscale image,
+ * matching the Python port. Datasets map their array index space into this
+ * system via a scale + translation sequence.
+ */
+export const INTRINSIC_COORDINATE_SYSTEM_NAME = "intrinsic";
+
+/**
  * Orientation metadata for spatial axes (RFC 4).
  * This interface represents the serialized form in the zarr metadata.
  */
@@ -21,21 +28,96 @@ export interface Axis {
   orientation?: AxisOrientation | AnatomicalOrientation | undefined;
 }
 
+/**
+ * RFC 5 / OME-Zarr v0.6 coordinate-system reference used by the `input` and
+ * `output` fields of a transformation. Mirrors the Python
+ * `CoordinateSystemIdentifier` dataclass and the spec `inputOutput` object: a
+ * transformation references either a coordinate system by `name` or a dataset
+ * array by `path`.
+ */
+export interface CoordinateSystemIdentifier {
+  path?: string;
+  name?: string;
+}
+
+/**
+ * RFC 5 / OME-Zarr v0.6 coordinate system: a named set of axes. The implicit
+ * "intrinsic" coordinate system is generated for the multiscale image.
+ */
+export interface CoordinateSystem {
+  name: string;
+  axes: Axis[];
+}
+
 export interface Identity {
   type: "identity";
+  input?: CoordinateSystemIdentifier;
+  output?: CoordinateSystemIdentifier;
+  name?: string;
 }
 
 export interface Scale {
   scale: number[];
   type: "scale";
+  input?: CoordinateSystemIdentifier;
+  output?: CoordinateSystemIdentifier;
+  name?: string;
 }
 
 export interface Translation {
   translation: number[];
   type: "translation";
+  input?: CoordinateSystemIdentifier;
+  output?: CoordinateSystemIdentifier;
+  name?: string;
 }
 
+/** RFC 5 rotation transformation (v0.6). */
+export interface Rotation {
+  rotation: number[][];
+  type: "rotation";
+  path?: string;
+  input?: CoordinateSystemIdentifier;
+  output?: CoordinateSystemIdentifier;
+  name?: string;
+}
+
+/** RFC 5 affine transformation (v0.6). */
+export interface Affine {
+  affine: number[][];
+  type: "affine";
+  path?: string;
+  input?: CoordinateSystemIdentifier;
+  output?: CoordinateSystemIdentifier;
+  name?: string;
+}
+
+/** RFC 5 sequence transformation, chaining sub-transformations (v0.6). */
+export interface TransformSequence {
+  transformations: V06Transform[];
+  type: "sequence";
+  input?: CoordinateSystemIdentifier;
+  output?: CoordinateSystemIdentifier;
+  name?: string;
+}
+
+/**
+ * Simple per-dataset transform used by the v0.4/v0.5 in-memory model and as the
+ * extracted scale/translation of a v0.6 dataset.
+ */
 export type Transform = Scale | Translation;
+
+/**
+ * Full RFC 5 / v0.6 transformation union. Used for top-level multiscale
+ * `coordinateTransformations` and the per-dataset `sequence` on the wire.
+ */
+export type V06Transform =
+  | Identity
+  | Scale
+  | Translation
+  | Rotation
+  | Affine
+  | TransformSequence;
 
 export interface Dataset {
   path: string;
@@ -73,7 +155,18 @@ export interface MethodMetadata {
 export interface MetadataInterface {
   axes: Axis[];
   datasets: Dataset[];
-  coordinateTransformations: Transform[] | undefined;
+  /**
+   * Top-level multiscale transformations. For v0.4/v0.5 these are simple
+   * {@link Transform}s; for RFC 5 / v0.6 they may be any {@link V06Transform}
+   * (rotation, affine, sequence, ...) referencing coordinate systems.
+   */
+  coordinateTransformations: V06Transform[] | undefined;
+  /**
+   * RFC 5 / OME-Zarr v0.6 coordinate systems. Populated when reading a v0.6
+   * store and by `toMultiscales` (the implicit "intrinsic" system). Unused when
+   * serializing v0.4/v0.5, where axes live on the multiscale entry directly.
+   */
+  coordinateSystems?: CoordinateSystem[];
   omero: Omero | undefined;
   name: string;
   version: string;
@@ -140,6 +233,17 @@ export function createMetadataWithVersion(
       ...metadata,
       version: "0.5",
     };
+  } else if (version === NgffVersion.V06) {
+    // The in-memory model is version-agnostic (axes + per-dataset scale and
+    // translation); v0.6 additionally exposes coordinate systems. Synthesize
+    // the implicit "intrinsic" system from the axes when one is not present, so
+    // a value converted to v0.6 carries the field the writer expects.
+    return {
+      ...metadata,
+      version: "0.6",
+      coordinateSystems: metadata.coordinateSystems ??
+        [{ name: INTRINSIC_COORDINATE_SYSTEM_NAME, axes: metadata.axes }],
+    };
   } else {
     throw new Error(
       `Unsupported version conversion: ${metadata.version} -> ${version}`,
@@ -170,4 +274,25 @@ export function createTranslation(translation: number[]): Translation {
 
 export function createIdentity(): Identity {
   return { type: "identity" };
+}
+
+export function createRotation(rotation: number[][]): Rotation {
+  return { rotation: rotation.map((row) => [...row]), type: "rotation" };
+}
+
+export function createAffine(affine: number[][]): Affine {
+  return { affine: affine.map((row) => [...row]), type: "affine" };
+}
+
+export function createTransformSequence(
+  transformations: V06Transform[],
+): TransformSequence {
+  return { transformations: [...transformations], type: "sequence" };
+}
+
+export function createCoordinateSystem(
+  name: string,
+  axes: Axis[],
+): CoordinateSystem {
+  return { name, axes: [...axes] };
 }

--- a/ts/src/utils/from_zarr_attrs.ts
+++ b/ts/src/utils/from_zarr_attrs.ts
@@ -8,6 +8,7 @@
 import * as zarr from "zarrita";
 import type {
   Axis,
+  CoordinateSystem,
   Dataset,
   FromZarrAttrsResult,
   MetadataInterface,
@@ -15,8 +16,10 @@ import type {
   Scale,
   Transform,
   Translation,
+  V06Transform,
 } from "../types/zarr_metadata.ts";
 import { SUPPORTED_DIMS } from "../types/zarr_metadata.ts";
+import { extractScaleTranslation, parseV06Transforms } from "./v06_metadata.ts";
 import { NgffImage } from "../types/ngff_image.ts";
 import type { AxesType, SupportedDims, Units } from "../types/units.ts";
 import { parseOmero } from "./parse_metadata.ts";
@@ -527,4 +530,248 @@ export async function fromZarrAttrsV05(
   result.metadata.version = "0.5";
 
   return result;
+}
+
+/**
+ * Parse Metadata and NgffImages from OME-Zarr v0.6 (RFC 5) root attributes.
+ *
+ * Unlike v0.4/v0.5, a v0.6 multiscale entry carries `coordinateSystems` instead
+ * of a top-level `axes` list, and maps each dataset's array index space into the
+ * implicit "intrinsic" system through a `sequence` of scale + translation. This
+ * reader recovers the version-agnostic in-memory model (axes + per-dataset scale
+ * and translation) while preserving the coordinate systems and any top-level
+ * transformations for round-tripping. Mirrors the Python
+ * `v06.zarr_metadata.Metadata._from_zarr_attrs`.
+ */
+export async function fromZarrAttrsV06(
+  rootAttrs: Record<string, unknown>,
+  store: MemoryStore | zarr.FetchStore | zarr.Readable,
+  validate = false,
+): Promise<FromZarrAttrsResult> {
+  // v0.6 wraps the multiscales under the "ome" key; tolerate a root-level
+  // layout for symmetry with the v0.5 reader.
+  const omeData = rootAttrs.ome as Record<string, unknown> | undefined;
+  let entry: Record<string, unknown>;
+  let omeroRaw: unknown;
+  if (omeData && "multiscales" in omeData) {
+    const multiscales = omeData.multiscales as unknown[];
+    if (!Array.isArray(multiscales) || multiscales.length === 0) {
+      throw new Error("No multiscales metadata found in root attributes");
+    }
+    entry = multiscales[0] as Record<string, unknown>;
+    omeroRaw = omeData.omero ?? rootAttrs.omero;
+  } else if ("multiscales" in rootAttrs) {
+    const multiscales = rootAttrs.multiscales as unknown[];
+    if (!Array.isArray(multiscales) || multiscales.length === 0) {
+      throw new Error("No multiscales metadata found in root attributes");
+    }
+    entry = multiscales[0] as Record<string, unknown>;
+    omeroRaw = rootAttrs.omero;
+  } else {
+    throw new Error(
+      "No multiscales metadata found in root attributes for v0.6 format",
+    );
+  }
+
+  const coordinateSystemsRaw = entry.coordinateSystems as
+    | Array<Record<string, unknown>>
+    | undefined;
+  if (
+    !Array.isArray(coordinateSystemsRaw) || coordinateSystemsRaw.length === 0
+  ) {
+    throw new Error(
+      "Invalid OME-Zarr v0.6 metadata: missing 'coordinateSystems' in " +
+        "multiscales metadata.",
+    );
+  }
+
+  const coordinateSystems: CoordinateSystem[] = coordinateSystemsRaw.map(
+    (cs, csIndex) => {
+      // Guard the untrusted-input boundary: a missing/non-array `axes` would
+      // otherwise surface as a generic `.map` TypeError rather than a clear
+      // metadata error. (Per-axis name/type are still coerced, mirroring the
+      // v0.4 reader's tolerance.)
+      if (!Array.isArray(cs.axes)) {
+        throw new Error(
+          "Invalid OME-Zarr v0.6 metadata: " +
+            `coordinateSystems[${csIndex}].axes must be an array.`,
+        );
+      }
+      return {
+        name: String(cs.name),
+        axes: (cs.axes as Array<Record<string, unknown>>).map((axis) => ({
+          name: String(axis.name) as SupportedDims,
+          type: String(axis.type) as AxesType,
+          unit: axis.unit as Units | undefined,
+          ...(axis.orientation !== undefined && axis.orientation !== null
+            ? { orientation: axis.orientation as Axis["orientation"] }
+            : {}),
+        })),
+      };
+    },
+  );
+  const coordinateSystemNames = coordinateSystems.map((cs) => cs.name);
+
+  // The intrinsic coordinate system (the first one) backs the multiscale image
+  // dimensions, units, and anatomical orientations.
+  const intrinsic = coordinateSystems[0];
+  const intrinsicRawAxes = coordinateSystemsRaw[0].axes as Array<
+    Record<string, unknown> | string
+  >;
+  const dims = intrinsic.axes.map((axis) => String(axis.name));
+
+  const units: Record<string, Units> = {};
+  for (const axis of intrinsic.axes) {
+    if (axis.unit !== undefined && axis.unit !== null) {
+      units[axis.name] = axis.unit;
+    }
+  }
+  const axesOrientations = extractOrientationsFromAxes(intrinsicRawAxes);
+
+  // RFC 4 anatomical-orientation validation, mirroring the v0.4 reader.
+  if (validate) {
+    const axesDicts = intrinsicRawAxes.filter(
+      (axis): axis is Record<string, unknown> =>
+        typeof axis === "object" && axis !== null,
+    );
+    if (axesDicts.length > 0 && hasRfc4OrientationMetadata(axesDicts)) {
+      validateRfc4Orientation(axesDicts);
+    }
+  }
+
+  // Open root group for array access (reuse consolidated metadata if present).
+  let optimizedStore: MemoryStore | zarr.FetchStore | zarr.Readable;
+  try {
+    const tryWithConsolidated: ((s: unknown) => Promise<unknown>) | undefined =
+      (zarr as unknown as {
+        tryWithConsolidated?: (s: unknown) => Promise<unknown>;
+      }).tryWithConsolidated;
+    optimizedStore = tryWithConsolidated
+      ? (await tryWithConsolidated(store)) as
+        | MemoryStore
+        | zarr.FetchStore
+        | zarr.Readable
+      : store;
+  } catch {
+    optimizedStore = store;
+  }
+  const root = await zarr.open(optimizedStore as zarr.Readable, {
+    kind: "group",
+  });
+
+  const datasetsData = entry.datasets as Array<Record<string, unknown>>;
+  if (!Array.isArray(datasetsData) || datasetsData.length === 0) {
+    throw new Error(
+      "Invalid OME-Zarr metadata: 'datasets' must be a non-empty array",
+    );
+  }
+
+  const images: NgffImage[] = [];
+  const datasets: Dataset[] = [];
+
+  for (const dataset of datasetsData) {
+    const path = String(dataset.path);
+    const zarrArray = (await zarr.open(root.resolve(path), {
+      kind: "array",
+    })) as zarr.Array<zarr.DataType, zarr.Readable>;
+
+    let scaleValues = dims.map(() => 1.0);
+    let translationValues = dims.map(() => 0.0);
+    if ("coordinateTransformations" in dataset) {
+      if (!Array.isArray(dataset.coordinateTransformations)) {
+        throw new Error(
+          "Invalid OME-Zarr v0.6 metadata: " +
+            `dataset '${path}' coordinateTransformations must be an array.`,
+        );
+      }
+      const parsed = parseV06Transforms(
+        dataset.coordinateTransformations as Array<Record<string, unknown>>,
+        coordinateSystemNames,
+      );
+      const extracted = extractScaleTranslation(parsed, dims);
+      scaleValues = extracted.scale;
+      translationValues = extracted.translation;
+    }
+
+    const scale: Record<string, number> = {};
+    const translation: Record<string, number> = {};
+    dims.forEach((dim, i) => {
+      scale[dim] = i < scaleValues.length ? scaleValues[i] : 1.0;
+      translation[dim] = i < translationValues.length
+        ? translationValues[i]
+        : 0.0;
+    });
+
+    datasets.push({
+      path,
+      coordinateTransformations: [
+        { type: "scale", scale: scaleValues } as Scale,
+        { type: "translation", translation: translationValues } as Translation,
+      ],
+    });
+
+    images.push(
+      new NgffImage({
+        data: zarrArray,
+        dims,
+        scale,
+        translation,
+        name: (entry.name as string) ?? "image",
+        axesUnits: Object.keys(units).length > 0 ? units : undefined,
+        axesOrientations,
+        computedCallbacks: undefined,
+      }),
+    );
+  }
+
+  let coordinateTransformations: V06Transform[] | undefined;
+  if ("coordinateTransformations" in entry) {
+    if (!Array.isArray(entry.coordinateTransformations)) {
+      throw new Error(
+        "Invalid OME-Zarr v0.6 metadata: multiscales " +
+          "coordinateTransformations must be an array.",
+      );
+    }
+    coordinateTransformations = parseV06Transforms(
+      entry.coordinateTransformations as Array<Record<string, unknown>>,
+      coordinateSystemNames,
+    );
+  }
+
+  const omero: Omero | undefined = parseOmero(
+    omeroRaw as Record<string, unknown> | undefined,
+  );
+
+  const metadata: MetadataInterface = {
+    axes: intrinsic.axes,
+    datasets,
+    coordinateSystems,
+    coordinateTransformations,
+    name: (entry.name as string) ?? "image",
+    version: "0.6",
+    omero,
+    ...(entry.type !== undefined && entry.type !== null
+      ? { type: String(entry.type) }
+      : {}),
+    ...(entry.metadata !== undefined && entry.metadata !== null
+      ? {
+        metadata: entry.metadata as {
+          description: string;
+          method: string;
+          version: string;
+        },
+      }
+      : {}),
+  };
+
+  // Run the structural pass against the normalized metadata (axes + per-dataset
+  // scale/translation), matching the v0.4/v0.5 readers. The metadata is
+  // reconstructed into the same shape, so the same rules apply. Full RFC-5 wire
+  // validation (coordinate-system graphs, arbitrary transform chains) remains
+  // deferred.
+  if (validate) {
+    validateStructural(metadata, { level: ValidationLevel.Strict });
+  }
+
+  return { metadata, images };
 }

--- a/ts/src/utils/parse_metadata.ts
+++ b/ts/src/utils/parse_metadata.ts
@@ -7,6 +7,7 @@
 
 import {
   isSupportedVersion,
+  isV06Version,
   NgffVersion,
 } from "../types/supported_versions.ts";
 import type { Methods } from "../types/methods.ts";
@@ -176,6 +177,13 @@ export function detectVersion(
 
   if (versionStr === undefined) {
     throw new Error("Could not detect NGFF version from root attributes.");
+  }
+
+  // Any 0.6-family version, including draft development tags such as
+  // `0.6.dev4`, is read as v0.6. Mirrors the Python port's
+  // `version.startswith("0.6")` read check so dev releases remain readable.
+  if (isV06Version(versionStr)) {
+    return NgffVersion.V06;
   }
 
   if (!isSupportedVersion(versionStr)) {

--- a/ts/src/utils/rfc4_validation.ts
+++ b/ts/src/utils/rfc4_validation.ts
@@ -51,12 +51,29 @@ export function hasRfc4OrientationMetadata(
       typeof axis === "object" &&
       axis !== null &&
       axis.type === "space" &&
-      "orientation" in axis
+      "orientation" in axis &&
+      // Orientation value has to be non-empty for it to count as orientation
+      // metadata, mirroring the Python `if axis['orientation']:` guard (null,
+      // {}, and "" are all treated as "no orientation").
+      isNonEmptyOrientation(axis.orientation)
     ) {
       return true;
     }
   }
   return false;
+}
+
+function isNonEmptyOrientation(orientation: unknown): boolean {
+  if (orientation === null || orientation === undefined) {
+    return false;
+  }
+  if (typeof orientation === "object") {
+    return Object.keys(orientation as Record<string, unknown>).length > 0;
+  }
+  if (typeof orientation === "string") {
+    return orientation.length > 0;
+  }
+  return Boolean(orientation);
 }
 
 /**

--- a/ts/src/utils/structural_validation.ts
+++ b/ts/src/utils/structural_validation.ts
@@ -29,6 +29,7 @@ import {
   type Dataset,
   type Metadata,
   type Transform,
+  type V06Transform,
   validateColor,
 } from "../types/zarr_metadata.ts";
 import type { PlateMetadata, WellMetadata } from "../types/hcs.ts";
@@ -150,7 +151,7 @@ export class ValidationError extends Error {
  * transform's vector length disagrees with `axesLen`; otherwise `null`.
  */
 function transformLenMismatch(
-  transform: Transform,
+  transform: Transform | V06Transform,
   axesLen: number,
 ): [kind: string, actual: number] | null {
   if (transform.type === "scale") {

--- a/ts/src/utils/v06_metadata.ts
+++ b/ts/src/utils/v06_metadata.ts
@@ -1,0 +1,372 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * RFC 5 / OME-Zarr v0.6 coordinate-transformation serialization helpers.
+ *
+ * The in-memory {@link MetadataInterface} model is version-agnostic: axes plus a
+ * per-dataset scale and translation. On the wire, v0.6 instead carries
+ * `coordinateSystems` and represents each dataset's mapping into the implicit
+ * "intrinsic" system as a `sequence` of scale + translation. These helpers
+ * convert between the two, mirroring `py/ngff_zarr/v06/zarr_metadata.py`.
+ */
+
+import type {
+  CoordinateSystem,
+  CoordinateSystemIdentifier,
+  MetadataInterface,
+  Transform,
+  V06Transform,
+} from "../types/zarr_metadata.ts";
+import { INTRINSIC_COORDINATE_SYSTEM_NAME } from "../types/zarr_metadata.ts";
+
+/**
+ * Build the on-disk v0.6 `multiscales[0]` entry from the version-agnostic
+ * in-memory metadata. `processedAxes` are the RFC-processed axes (orientation
+ * filtered per enabled RFCs); they back the intrinsic coordinate system so v0.6
+ * matches the v0.4/v0.5 writers.
+ */
+export function buildV06MultiscalesEntry(
+  metadata: MetadataInterface,
+  processedAxes: Array<Record<string, unknown>>,
+): Record<string, unknown> {
+  const coordinateSystems: CoordinateSystem[] =
+    metadata.coordinateSystems && metadata.coordinateSystems.length > 0
+      ? metadata.coordinateSystems
+      : [{ name: INTRINSIC_COORDINATE_SYSTEM_NAME, axes: metadata.axes }];
+  const intrinsicName = coordinateSystems[0].name;
+
+  // The first (intrinsic) coordinate system uses the RFC-processed axes; any
+  // additional systems (e.g. a user-supplied output space) are serialized
+  // verbatim.
+  const serializedCoordinateSystems = coordinateSystems.map((cs, index) => ({
+    name: cs.name,
+    axes: index === 0 ? processedAxes : cs.axes,
+  }));
+
+  const datasets = metadata.datasets.map((ds, index) => {
+    let scale: number[] | undefined;
+    let translation: number[] | undefined;
+    for (const transform of ds.coordinateTransformations) {
+      if (transform.type === "scale") {
+        scale = transform.scale;
+      } else if (transform.type === "translation") {
+        translation = transform.translation;
+      }
+    }
+
+    const transformations: Array<Record<string, unknown>> = [];
+    if (scale !== undefined) {
+      transformations.push({ type: "scale", scale });
+    }
+    if (translation !== undefined) {
+      transformations.push({ type: "translation", translation });
+    }
+
+    return {
+      path: ds.path,
+      coordinateTransformations: [
+        {
+          type: "sequence",
+          name: `scale${index}_to_${intrinsicName}`,
+          input: { path: ds.path },
+          output: { name: intrinsicName },
+          transformations,
+        },
+      ],
+    };
+  });
+
+  const entry: Record<string, unknown> = {
+    name: metadata.name,
+    coordinateSystems: serializedCoordinateSystems,
+    datasets,
+  };
+
+  if (
+    metadata.coordinateTransformations &&
+    metadata.coordinateTransformations.length > 0
+  ) {
+    entry.coordinateTransformations = metadata.coordinateTransformations.map(
+      serializeV06Transform,
+    );
+  }
+  if (metadata.type !== undefined) {
+    entry.type = metadata.type;
+  }
+  if (metadata.metadata !== undefined) {
+    entry.metadata = metadata.metadata;
+  }
+
+  return entry;
+}
+
+/** Serialize a single v0.6 transformation to its on-disk dictionary form. */
+export function serializeV06Transform(
+  transform: V06Transform,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { type: transform.type };
+  if (transform.name !== undefined) {
+    out.name = transform.name;
+  }
+  if (transform.input !== undefined) {
+    const input = identifierToDict(transform.input);
+    if (input !== undefined) {
+      out.input = input;
+    }
+  }
+  if (transform.output !== undefined) {
+    const output = identifierToDict(transform.output);
+    if (output !== undefined) {
+      out.output = output;
+    }
+  }
+
+  switch (transform.type) {
+    case "identity":
+      break;
+    case "scale":
+      out.scale = transform.scale;
+      break;
+    case "translation":
+      out.translation = transform.translation;
+      break;
+    case "rotation":
+      out.rotation = transform.rotation;
+      if (transform.path !== undefined) {
+        out.path = transform.path;
+      }
+      break;
+    case "affine":
+      out.affine = transform.affine;
+      if (transform.path !== undefined) {
+        out.path = transform.path;
+      }
+      break;
+    case "sequence":
+      out.transformations = transform.transformations.map(
+        serializeV06Transform,
+      );
+      break;
+  }
+
+  return out;
+}
+
+/**
+ * Parse a list of (possibly nested) v0.6 transformation dictionaries into typed
+ * {@link V06Transform}s. `coordinateSystemNames` gates which `input`/`output`
+ * `name` references are retained, matching the Python `_parse_transforms`: a
+ * `name` is kept only when it identifies a known coordinate system, while a
+ * `path` (a dataset array reference) is always kept.
+ */
+export function parseV06Transforms(
+  raw: Array<Record<string, unknown>>,
+  coordinateSystemNames: string[],
+): V06Transform[] {
+  return raw.map((entry) => parseV06Transform(entry, coordinateSystemNames));
+}
+
+function parseV06Transform(
+  entry: Record<string, unknown>,
+  coordinateSystemNames: string[],
+): V06Transform {
+  const type = String(entry.type);
+  let transform: V06Transform;
+
+  switch (type) {
+    case "identity":
+      transform = { type: "identity" };
+      break;
+    case "scale":
+      transform = { type: "scale", scale: asNumberArray(entry.scale, "scale") };
+      break;
+    case "translation":
+      transform = {
+        type: "translation",
+        translation: asNumberArray(entry.translation, "translation"),
+      };
+      break;
+    case "rotation":
+      transform = {
+        type: "rotation",
+        rotation: asNumberMatrix(entry.rotation, "rotation"),
+      };
+      if (typeof entry.path === "string") {
+        transform.path = entry.path;
+      }
+      break;
+    case "affine":
+      transform = {
+        type: "affine",
+        affine: asNumberMatrix(entry.affine, "affine"),
+      };
+      if (typeof entry.path === "string") {
+        transform.path = entry.path;
+      }
+      break;
+    case "sequence":
+      if (!Array.isArray(entry.transformations)) {
+        throw new Error(
+          "Invalid sequence transform: 'transformations' must be an array",
+        );
+      }
+      transform = {
+        type: "sequence",
+        transformations: parseV06Transforms(
+          entry.transformations as Array<Record<string, unknown>>,
+          coordinateSystemNames,
+        ),
+      };
+      break;
+    default:
+      throw new Error(`Unsupported transform type: ${type}`);
+  }
+
+  const input = dictToIdentifier(entry.input, coordinateSystemNames);
+  if (input !== undefined) {
+    transform.input = input;
+  }
+  const output = dictToIdentifier(entry.output, coordinateSystemNames);
+  if (output !== undefined) {
+    transform.output = output;
+  }
+  if (typeof entry.name === "string") {
+    transform.name = entry.name;
+  }
+
+  return transform;
+}
+
+/**
+ * Extract the effective scale and translation from a dataset's v0.6
+ * transformations (unwrapping a `sequence`), defaulting to identity. Mirrors
+ * the convenience extraction in the Python `_from_zarr_attrs`.
+ */
+export function extractScaleTranslation(
+  transforms: V06Transform[],
+  dims: string[],
+): { scale: number[]; translation: number[] } {
+  let scale = dims.map(() => 1.0);
+  let translation = dims.map(() => 0.0);
+
+  for (const transform of transforms) {
+    if (transform.type === "sequence") {
+      for (const sub of transform.transformations) {
+        if (sub.type === "scale") {
+          scale = sub.scale;
+        } else if (sub.type === "identity") {
+          // Within a sequence an identity resets only the scale, not the
+          // translation, matching the Python reference `_from_zarr_attrs`. A
+          // sibling translation composes with the identity (identity ∘
+          // translation = translation), so it must be preserved. Spec-conformant
+          // dataset sequences are `[scale, translation]` and never include an
+          // identity, so this branch is defensive.
+          scale = dims.map(() => 1.0);
+        } else if (sub.type === "translation") {
+          translation = sub.translation;
+        }
+      }
+    } else if (transform.type === "scale") {
+      scale = transform.scale;
+    } else if (transform.type === "translation") {
+      translation = transform.translation;
+    } else if (transform.type === "identity") {
+      scale = dims.map(() => 1.0);
+      translation = dims.map(() => 0.0);
+    }
+  }
+
+  return { scale, translation };
+}
+
+/**
+ * Reduce v0.6 top-level transformations to the simple scale/translation subset
+ * permitted by v0.4/v0.5, dropping richer transforms (rotation, affine,
+ * sequence) and the coordinate-system references they carry. Used when writing
+ * a value read at v0.6 back out at an older version.
+ */
+export function legacyTopLevelTransforms(
+  transforms: V06Transform[] | undefined,
+): Transform[] | undefined {
+  if (!transforms) {
+    return undefined;
+  }
+  const simple: Transform[] = [];
+  for (const transform of transforms) {
+    if (transform.type === "scale") {
+      simple.push({ type: "scale", scale: transform.scale });
+    } else if (transform.type === "translation") {
+      simple.push({ type: "translation", translation: transform.translation });
+    }
+  }
+  return simple.length > 0 ? simple : undefined;
+}
+
+/**
+ * Validate that a parsed transform field is a flat array of numbers. The reader
+ * consumes untrusted on-disk metadata, so a malformed value (missing, a string,
+ * a nested array) is rejected with a clear message rather than passed through an
+ * unchecked `as number[]` cast that surfaces as a confusing error downstream.
+ */
+function asNumberArray(value: unknown, field: string): number[] {
+  if (
+    !Array.isArray(value) || !value.every((v) => typeof v === "number")
+  ) {
+    throw new Error(
+      `Invalid ${field} transform: '${field}' must be an array of numbers`,
+    );
+  }
+  return value as number[];
+}
+
+/** Validate that a parsed transform field is a 2D array of numbers. */
+function asNumberMatrix(value: unknown, field: string): number[][] {
+  if (
+    !Array.isArray(value) ||
+    !value.every(
+      (row) => Array.isArray(row) && row.every((v) => typeof v === "number"),
+    )
+  ) {
+    throw new Error(
+      `Invalid ${field} transform: '${field}' must be a 2D array of numbers`,
+    );
+  }
+  return value as number[][];
+}
+
+function identifierToDict(
+  id: CoordinateSystemIdentifier,
+): Record<string, unknown> | undefined {
+  const out: Record<string, unknown> = {};
+  if (id.path !== undefined) {
+    out.path = id.path;
+  }
+  if (id.name !== undefined) {
+    out.name = id.name;
+  }
+  // An identifier carrying neither `path` nor `name` is meaningless and invalid
+  // per the v0.6 schema (input requires a path, output requires a name); omit
+  // it rather than emitting `input: {}` / `output: {}`.
+  return out.path !== undefined || out.name !== undefined ? out : undefined;
+}
+
+function dictToIdentifier(
+  value: unknown,
+  coordinateSystemNames: string[],
+): CoordinateSystemIdentifier | undefined {
+  if (value === null || typeof value !== "object") {
+    return undefined;
+  }
+  const dict = value as Record<string, unknown>;
+  const id: CoordinateSystemIdentifier = {};
+  if (
+    typeof dict.name === "string" && coordinateSystemNames.includes(dict.name)
+  ) {
+    id.name = dict.name;
+  }
+  if (typeof dict.path === "string") {
+    id.path = dict.path;
+  }
+  return id.name !== undefined || id.path !== undefined ? id : undefined;
+}

--- a/ts/test/rfc4_validation_test.ts
+++ b/ts/test/rfc4_validation_test.ts
@@ -46,6 +46,37 @@ Deno.test("hasRfc4OrientationMetadata - returns true when spatial axes have orie
   assertEquals(hasRfc4OrientationMetadata(axesWithOrientation), true);
 });
 
+Deno.test("hasRfc4OrientationMetadata - empty or null orientation does not count", () => {
+  // Mirrors the Python `if axis['orientation']:` guard: a spatial axis whose
+  // orientation is present but falsy ({}, null, "") carries no real
+  // orientation metadata and must not trigger RFC-4 validation.
+  const emptyObject = [
+    { name: "x", type: "space", unit: "micrometer", orientation: {} },
+  ];
+  assertEquals(hasRfc4OrientationMetadata(emptyObject), false);
+
+  const nullOrientation = [
+    { name: "y", type: "space", unit: "micrometer", orientation: null },
+  ];
+  assertEquals(hasRfc4OrientationMetadata(nullOrientation), false);
+
+  const emptyString = [
+    { name: "z", type: "space", unit: "micrometer", orientation: "" },
+  ];
+  assertEquals(hasRfc4OrientationMetadata(emptyString), false);
+
+  // A non-empty orientation on the same axis shape still counts.
+  const populated = [
+    {
+      name: "x",
+      type: "space",
+      unit: "micrometer",
+      orientation: { type: "anatomical", value: "right-to-left" },
+    },
+  ];
+  assertEquals(hasRfc4OrientationMetadata(populated), true);
+});
+
 Deno.test("validateRfc4Orientation - valid LPS orientation passes", () => {
   const axesLps = [
     {

--- a/ts/test/v06_coordinate_transformations_test.ts
+++ b/ts/test/v06_coordinate_transformations_test.ts
@@ -22,6 +22,8 @@ import {
   createTransformSequence,
   createTranslation,
   fromOmeZarr,
+  isSupportedVersion,
+  isV06Version,
   type MemoryStore,
   NgffImage,
   type NgffMultiscales,
@@ -95,6 +97,25 @@ function mutateRootEntry(
   throw new Error("No root group with an 'ome' attribute found in the store");
 }
 
+// Overwrite the root group's `ome.version` string in place, so the reader can
+// be exercised against an on-disk version tag independent of what the writer
+// currently emits (e.g. a plain `0.6` store, or a future draft tag).
+function setOmeVersion(store: MemoryStore, version: string): void {
+  for (const [key, bytes] of store.entries()) {
+    if (!key.endsWith("zarr.json")) continue;
+    const node = JSON.parse(new TextDecoder().decode(bytes));
+    if (
+      node.node_type === "group" && node.attributes &&
+      typeof node.attributes === "object" && "ome" in node.attributes
+    ) {
+      (node.attributes.ome as { version: string }).version = version;
+      store.set(key, new TextEncoder().encode(JSON.stringify(node)));
+      return;
+    }
+  }
+  throw new Error("No root group with an 'ome' attribute found in the store");
+}
+
 Deno.test("v0.6 write produces coordinate systems and sequence transforms", async () => {
   const multiscales = await buildMultiscales();
   const store: MemoryStore = new Map();
@@ -104,7 +125,9 @@ Deno.test("v0.6 write produces coordinate systems and sequence transforms", asyn
     version: string;
     multiscales: Array<Record<string, unknown>>;
   };
-  assertEquals(ome.version, "0.6");
+  // The v0.6 spec is still a draft, so the on-disk version is tagged
+  // `0.6.dev4` even though the requested version is `"0.6"`.
+  assertEquals(ome.version, "0.6.dev4");
 
   const entry = ome.multiscales[0];
   // v0.6 carries axes inside coordinate systems, not at the entry level.
@@ -633,4 +656,78 @@ Deno.test("RFC-9 metadata drops a v0.6-only rotation but keeps a scale", async (
   // The v0.6-only input/output/name fields are stripped from the kept transform.
   assertEquals("input" in kept[0], false);
   assertEquals("output" in kept[0], false);
+});
+
+// --- OME-Zarr v0.6 draft "0.6.dev4" version handling (temporary) ---
+
+// Writing version "0.6" tags the store with the draft "0.6.dev4" on disk while
+// keeping the in-memory metadata version at "0.6".
+Deno.test("v0.6 write tags the store 0.6.dev4 but reads back as 0.6", async () => {
+  const multiscales = await buildMultiscales();
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+
+  const ome = readOmeAttributes(store) as { version: string };
+  assertEquals(ome.version, "0.6.dev4");
+
+  const imported = await fromOmeZarr(store);
+  assertEquals(imported.metadata.version, "0.6");
+});
+
+// Round-trip with an explicit requested version "0.6" and validation: the
+// draft "0.6.dev4" on disk must satisfy the requested "0.6" (family match).
+Deno.test("v0.6 round-trip with validate accepts the 0.6.dev4 on-disk tag", async () => {
+  const multiscales = await buildMultiscales();
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+
+  const imported = await fromOmeZarr(store, { version: "0.6", validate: true });
+  assertEquals(imported.metadata.version, "0.6");
+  assertEquals(imported.images.length, multiscales.images.length);
+});
+
+// A store tagged with a plain "0.6" (e.g. a stricter writer) still reads as
+// v0.6 -- isV06Version covers the whole family, not just the draft tag.
+Deno.test("reader accepts a plain 0.6 on-disk version tag", async () => {
+  const multiscales = await buildMultiscales();
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+  setOmeVersion(store, "0.6");
+
+  const imported = await fromOmeZarr(store, { version: "0.6", validate: true });
+  assertEquals(imported.metadata.version, "0.6");
+  assertEquals(imported.metadata.coordinateSystems![0].name, "intrinsic");
+});
+
+// A future draft tag in the 0.6 family (e.g. "0.6.dev5") is also read as v0.6.
+Deno.test("reader accepts a future 0.6 draft tag", async () => {
+  const multiscales = await buildMultiscales();
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+  setOmeVersion(store, "0.6.dev5");
+
+  const imported = await fromOmeZarr(store);
+  assertEquals(imported.metadata.version, "0.6");
+});
+
+// The browser reader follows the same family rule for the draft tag.
+Deno.test("browser reader accepts the 0.6.dev4 on-disk tag", async () => {
+  const multiscales = await buildMultiscales();
+  const store: MemoryStore = new Map();
+  await toOmeZarrBrowser(store, multiscales, { version: "0.6" });
+
+  const ome = readOmeAttributes(store) as { version: string };
+  assertEquals(ome.version, "0.6.dev4");
+
+  const imported = await fromOmeZarrBrowser(store, { version: "0.6" });
+  assertEquals(imported.metadata.version, "0.6");
+  assertEquals(imported.images.length, multiscales.images.length);
+});
+
+// "0.6.dev4" is a recognized, supported version string.
+Deno.test("0.6.dev4 is a supported version", () => {
+  assertEquals(isSupportedVersion("0.6.dev4"), true);
+  assertEquals(isV06Version("0.6.dev4"), true);
+  assertEquals(isV06Version("0.6"), true);
+  assertEquals(isV06Version("0.5"), false);
 });

--- a/ts/test/v06_coordinate_transformations_test.ts
+++ b/ts/test/v06_coordinate_transformations_test.ts
@@ -1,0 +1,636 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * OME-Zarr v0.6 (RFC 5) coordinate-systems and coordinate-transformations tests.
+ *
+ * Mirrors the Python `py/test/test_coordinate_transformations.py` and the v0.6
+ * cases added to `test_convert_ome_zarr_version.py`, adapted to the TypeScript
+ * API. Self-contained: builds a small multiscale image in memory rather than
+ * relying on downloaded fixtures.
+ */
+
+import { assertEquals, assertExists, assertRejects } from "@std/assert";
+import {
+  AnatomicalOrientationValues,
+  createAffine,
+  createAxis,
+  createCoordinateSystem,
+  createIdentity,
+  createRotation,
+  createScale,
+  createTransformSequence,
+  createTranslation,
+  fromOmeZarr,
+  type MemoryStore,
+  NgffImage,
+  type NgffMultiscales,
+  toOmeZarr,
+  type V06Transform,
+} from "../src/mod.ts";
+import {
+  toMultiscales,
+  toNgffImage,
+} from "../src/process/to_multiscales-node.ts";
+import { fromOmeZarr as fromOmeZarrBrowser } from "../src/io/from_ngff_zarr-browser.ts";
+import { toOmeZarr as toOmeZarrBrowser } from "../src/io/to_ngff_zarr-browser.ts";
+import { prepareRfc9Metadata } from "../src/io/to_ngff_zarr_ozx_common.ts";
+
+async function buildMultiscales(): Promise<NgffMultiscales> {
+  const shape = [32, 32, 32];
+  const data = new Uint8Array(shape[0] * shape[1] * shape[2]);
+  for (let i = 0; i < data.length; i++) {
+    data[i] = i % 256;
+  }
+  const image = await toNgffImage(data, { dims: ["z", "y", "x"], shape });
+  return await toMultiscales(image, { scaleFactors: [2], chunks: 16 });
+}
+
+Deno.test("toMultiscales exposes the intrinsic coordinate system", async () => {
+  const multiscales = await buildMultiscales();
+  assertExists(multiscales.metadata.coordinateSystems);
+  const names = multiscales.metadata.coordinateSystems!.map((cs) => cs.name);
+  assertEquals(names.includes("intrinsic"), true);
+});
+
+// Locate the root group's zarr.json in a MemoryStore and return its parsed
+// `ome` attributes, independent of how zarrita keys the root node.
+function readOmeAttributes(store: MemoryStore): Record<string, unknown> {
+  for (const [key, bytes] of store.entries()) {
+    if (!key.endsWith("zarr.json")) continue;
+    const node = JSON.parse(new TextDecoder().decode(bytes));
+    if (
+      node.node_type === "group" && node.attributes &&
+      typeof node.attributes === "object" && "ome" in node.attributes
+    ) {
+      return node.attributes.ome as Record<string, unknown>;
+    }
+  }
+  throw new Error("No root group with an 'ome' attribute found in the store");
+}
+
+// Rewrite the root group's `ome.multiscales[0]` entry in place, so reader
+// behavior can be exercised against on-disk shapes the writer never emits
+// (bare per-dataset transforms, unknown transform types, corrupt metadata).
+// Only the root metadata is changed; the previously written arrays remain.
+function mutateRootEntry(
+  store: MemoryStore,
+  mutate: (entry: Record<string, unknown>) => void,
+): void {
+  for (const [key, bytes] of store.entries()) {
+    if (!key.endsWith("zarr.json")) continue;
+    const node = JSON.parse(new TextDecoder().decode(bytes));
+    if (
+      node.node_type === "group" && node.attributes &&
+      typeof node.attributes === "object" && "ome" in node.attributes
+    ) {
+      const ome = node.attributes.ome as {
+        multiscales: Array<Record<string, unknown>>;
+      };
+      mutate(ome.multiscales[0]);
+      store.set(key, new TextEncoder().encode(JSON.stringify(node)));
+      return;
+    }
+  }
+  throw new Error("No root group with an 'ome' attribute found in the store");
+}
+
+Deno.test("v0.6 write produces coordinate systems and sequence transforms", async () => {
+  const multiscales = await buildMultiscales();
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+
+  const ome = readOmeAttributes(store) as {
+    version: string;
+    multiscales: Array<Record<string, unknown>>;
+  };
+  assertEquals(ome.version, "0.6");
+
+  const entry = ome.multiscales[0];
+  // v0.6 carries axes inside coordinate systems, not at the entry level.
+  assertEquals("axes" in entry, false);
+
+  const coordinateSystems = entry.coordinateSystems as Array<{
+    name: string;
+    axes: Array<{ name: string }>;
+  }>;
+  assertEquals(coordinateSystems[0].name, "intrinsic");
+  assertEquals(coordinateSystems[0].axes.map((a) => a.name), ["z", "y", "x"]);
+
+  const datasets = entry.datasets as Array<{
+    coordinateTransformations: Array<Record<string, unknown>>;
+  }>;
+  const sequence = datasets[0].coordinateTransformations[0] as {
+    type: string;
+    name: string;
+    input: { path: string };
+    output: { name: string };
+    transformations: Array<{ type: string }>;
+  };
+  assertEquals(sequence.type, "sequence");
+  assertEquals(sequence.name, "scale0_to_intrinsic");
+  assertEquals(sequence.input.path, "scale0");
+  assertEquals(sequence.output.name, "intrinsic");
+  assertEquals(sequence.transformations[0].type, "scale");
+  assertEquals(sequence.transformations[1].type, "translation");
+});
+
+Deno.test("v0.6 round-trip preserves multiscale structure", async () => {
+  const multiscales = await buildMultiscales();
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+
+  const imported = await fromOmeZarr(store, { validate: true, version: "0.6" });
+  assertEquals(imported.metadata.version, "0.6");
+  assertEquals(imported.images.length, multiscales.images.length);
+  assertEquals(imported.images[0].dims, ["z", "y", "x"]);
+  assertEquals(imported.images[0].scale, multiscales.images[0].scale);
+  assertEquals(imported.images[1].scale, multiscales.images[1].scale);
+  assertEquals(
+    imported.images[0].translation,
+    multiscales.images[0].translation,
+  );
+
+  assertExists(imported.metadata.coordinateSystems);
+  assertEquals(imported.metadata.coordinateSystems![0].name, "intrinsic");
+});
+
+// Mirrors test_coordinate_transformations.py::test_transform_serialization:
+// every transform type survives a v0.6 write/read round-trip, including its
+// input/output coordinate-system references.
+function transformsToRoundTrip(): V06Transform[] {
+  return [
+    createIdentity(),
+    createScale([2.0, 2.0, 2.0]),
+    createTranslation([10.0, 20.0, 30.0]),
+    createRotation([
+      [0.0, -1.0, 0.0],
+      [1.0, 0.0, 0.0],
+      [0.0, 0.0, 1.0],
+    ]),
+    createAffine([
+      [1.0, 0.0, 0.0, 5.0],
+      [0.0, 1.0, 0.0, 10.0],
+      [0.0, 0.0, 1.0, 15.0],
+    ]),
+    createTransformSequence([
+      createScale([2.0, 2.0, 2.0]),
+      createTranslation([10.0, 20.0, 30.0]),
+    ]),
+  ];
+}
+
+for (const transform of transformsToRoundTrip()) {
+  Deno.test(
+    `v0.6 round-trips a top-level ${transform.type} transform`,
+    async () => {
+      const multiscales = await buildMultiscales();
+
+      const outputCs = createCoordinateSystem("output", [
+        createAxis("z", "space"),
+        createAxis("y", "space"),
+        createAxis("x", "space"),
+      ]);
+      const intrinsic = multiscales.metadata.coordinateSystems![0];
+      transform.input = { name: intrinsic.name };
+      transform.output = { name: outputCs.name };
+      transform.name = `additional_${transform.type}`;
+
+      multiscales.metadata.coordinateSystems!.push(outputCs);
+      multiscales.metadata.coordinateTransformations = [transform];
+
+      const store: MemoryStore = new Map();
+      await toOmeZarr(store, multiscales, { version: "0.6" });
+
+      const imported = await fromOmeZarr(store);
+      const importedTransforms = imported.metadata.coordinateTransformations;
+      assertExists(importedTransforms);
+      assertEquals(importedTransforms!.length, 1);
+      assertEquals(imported.metadata.coordinateSystems!.length, 2);
+
+      const roundTripped = importedTransforms![0];
+      assertEquals(roundTripped.type, transform.type);
+      assertEquals(roundTripped.input, { name: intrinsic.name });
+      assertEquals(roundTripped.output, { name: outputCs.name });
+    },
+  );
+}
+
+Deno.test("rotation and affine payloads survive the round-trip", async () => {
+  const multiscales = await buildMultiscales();
+  const rotation = createRotation([
+    [0.0, -1.0, 0.0],
+    [1.0, 0.0, 0.0],
+    [0.0, 0.0, 1.0],
+  ]);
+  const affine = createAffine([
+    [1.0, 0.0, 0.0, 5.0],
+    [0.0, 1.0, 0.0, 10.0],
+    [0.0, 0.0, 1.0, 15.0],
+  ]);
+  const intrinsic = multiscales.metadata.coordinateSystems![0];
+  for (const t of [rotation, affine]) {
+    t.input = { name: intrinsic.name };
+    t.output = { name: intrinsic.name };
+  }
+  multiscales.metadata.coordinateTransformations = [rotation, affine];
+
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+  const imported = await fromOmeZarr(store);
+
+  const transforms = imported.metadata.coordinateTransformations!;
+  assertEquals(transforms.length, 2);
+  const importedRotation = transforms[0];
+  const importedAffine = transforms[1];
+  if (importedRotation.type !== "rotation") {
+    throw new Error("expected a rotation transform");
+  }
+  if (importedAffine.type !== "affine") {
+    throw new Error("expected an affine transform");
+  }
+  assertEquals(importedRotation.rotation, rotation.rotation);
+  assertEquals(importedAffine.affine, affine.affine);
+});
+
+// Mirrors test_convert_ome_zarr_version.py::test_conversion, adapted to a
+// self-contained in-memory multiscale image.
+Deno.test("convert across v0.4, v0.5, and v0.6", async () => {
+  const multiscales = await buildMultiscales();
+  for (const version of ["0.4", "0.5", "0.6"] as const) {
+    const store: MemoryStore = new Map();
+    await toOmeZarr(store, multiscales, { version });
+    const back = await fromOmeZarr(store, { validate: true, version });
+    assertEquals(back.metadata.version, version);
+    assertEquals(back.images.length, multiscales.images.length);
+    assertEquals(back.images[0].dims, ["z", "y", "x"]);
+  }
+});
+
+Deno.test("convert v0.6 -> v0.5 -> v0.4 chain preserves scale", async () => {
+  const multiscales = await buildMultiscales();
+
+  const s6: MemoryStore = new Map();
+  await toOmeZarr(s6, multiscales, { version: "0.6" });
+  const m6 = await fromOmeZarr(s6, { version: "0.6" });
+
+  const s5: MemoryStore = new Map();
+  await toOmeZarr(s5, m6, { version: "0.5" });
+  const m5 = await fromOmeZarr(s5, { version: "0.5" });
+  assertEquals(m5.metadata.version, "0.5");
+
+  const s4: MemoryStore = new Map();
+  await toOmeZarr(s4, m5, { version: "0.4" });
+  const m4 = await fromOmeZarr(s4, { version: "0.4" });
+  assertEquals(m4.metadata.version, "0.4");
+
+  assertEquals(m4.images.length, multiscales.images.length);
+  assertEquals(m4.images[0].scale, multiscales.images[0].scale);
+  assertEquals(m4.images[1].scale, multiscales.images[1].scale);
+});
+
+Deno.test("v0.6 round-trip via browser modules", async () => {
+  const multiscales = await buildMultiscales();
+  const store: MemoryStore = new Map();
+  await toOmeZarrBrowser(store, multiscales, { version: "0.6" });
+
+  const imported = await fromOmeZarrBrowser(store, { version: "0.6" });
+  assertEquals(imported.metadata.version, "0.6");
+  assertEquals(imported.images.length, multiscales.images.length);
+  assertEquals(imported.images[0].dims, ["z", "y", "x"]);
+  assertEquals(imported.images[0].scale, multiscales.images[0].scale);
+  assertExists(imported.metadata.coordinateSystems);
+  assertEquals(imported.metadata.coordinateSystems![0].name, "intrinsic");
+});
+
+// Downgrading v0.6 -> v0.5 keeps the simple scale/translation subset of
+// top-level transforms but drops richer ones (rotation/affine/sequence), which
+// v0.4/v0.5 cannot represent. Exercises legacyTopLevelTransforms.
+Deno.test("downgrade keeps a top-level scale but drops a rotation", async () => {
+  const intrinsicName = "intrinsic";
+
+  const withScale = await buildMultiscales();
+  withScale.metadata.coordinateTransformations = [{
+    type: "scale",
+    scale: [2.0, 2.0, 2.0],
+    input: { name: intrinsicName },
+    output: { name: intrinsicName },
+  }];
+  const scaleStore: MemoryStore = new Map();
+  await toOmeZarr(scaleStore, withScale, { version: "0.5" });
+  const scaleBack = await fromOmeZarr(scaleStore, { version: "0.5" });
+  const keptTransforms = scaleBack.metadata.coordinateTransformations!;
+  assertEquals(keptTransforms.length, 1);
+  assertEquals(keptTransforms[0].type, "scale");
+
+  const withRotation = await buildMultiscales();
+  withRotation.metadata.coordinateTransformations = [createRotation([
+    [0.0, -1.0, 0.0],
+    [1.0, 0.0, 0.0],
+    [0.0, 0.0, 1.0],
+  ])];
+  withRotation.metadata.coordinateTransformations[0].input = {
+    name: intrinsicName,
+  };
+  withRotation.metadata.coordinateTransformations[0].output = {
+    name: intrinsicName,
+  };
+  const rotStore: MemoryStore = new Map();
+  await toOmeZarr(rotStore, withRotation, { version: "0.5" });
+  // The rotation is dropped, so the v0.5 entry carries no top-level transforms.
+  const ome = readOmeAttributes(rotStore) as {
+    multiscales: Array<Record<string, unknown>>;
+  };
+  assertEquals("coordinateTransformations" in ome.multiscales[0], false);
+  const rotBack = await fromOmeZarr(rotStore, { version: "0.5" });
+  assertEquals(rotBack.metadata.coordinateTransformations, undefined);
+});
+
+// Writing v0.6 from metadata that lacks coordinateSystems (e.g. built via
+// createMetadata) synthesizes the implicit "intrinsic" system from the axes.
+Deno.test("v0.6 write synthesizes intrinsic system when absent", async () => {
+  const multiscales = await buildMultiscales();
+  delete (multiscales.metadata as { coordinateSystems?: unknown })
+    .coordinateSystems;
+
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+
+  const imported = await fromOmeZarr(store, { version: "0.6" });
+  assertExists(imported.metadata.coordinateSystems);
+  assertEquals(imported.metadata.coordinateSystems![0].name, "intrinsic");
+  assertEquals(
+    imported.metadata.coordinateSystems![0].axes.map((a) => a.name),
+    ["z", "y", "x"],
+  );
+});
+
+// rotation/affine may carry an external `path` to binary parameters; it must
+// survive the v0.6 round-trip.
+Deno.test("v0.6 preserves the path field on rotation and affine", async () => {
+  const multiscales = await buildMultiscales();
+  const intrinsicName = multiscales.metadata.coordinateSystems![0].name;
+  const rotation: V06Transform = {
+    type: "rotation",
+    rotation: [[0.0, -1.0], [1.0, 0.0]],
+    path: "transforms/rotation",
+    input: { name: intrinsicName },
+    output: { name: intrinsicName },
+  };
+  const affine: V06Transform = {
+    type: "affine",
+    affine: [[1.0, 0.0], [0.0, 1.0]],
+    path: "transforms/affine",
+    input: { name: intrinsicName },
+    output: { name: intrinsicName },
+  };
+  multiscales.metadata.coordinateTransformations = [rotation, affine];
+
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+  const imported = await fromOmeZarr(store);
+
+  const transforms = imported.metadata.coordinateTransformations!;
+  if (transforms[0].type !== "rotation" || transforms[1].type !== "affine") {
+    throw new Error("expected a rotation then an affine transform");
+  }
+  assertEquals(transforms[0].path, "transforms/rotation");
+  assertEquals(transforms[1].path, "transforms/affine");
+});
+
+// An input/output `name` is retained only when it names a known coordinate
+// system; an unknown name is dropped while a `path` reference is always kept.
+// Mirrors the Python _parse_transforms identifier resolution.
+Deno.test("v0.6 read drops unknown coordinate-system names, keeps paths", async () => {
+  const multiscales = await buildMultiscales();
+  multiscales.metadata.coordinateTransformations = [{
+    type: "scale",
+    scale: [2.0, 2.0, 2.0],
+    input: { name: "does-not-exist" },
+    output: { path: "scale0" },
+  }];
+
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+  const imported = await fromOmeZarr(store);
+
+  const transform = imported.metadata.coordinateTransformations![0];
+  // Unknown input name -> no identifier survives; path output -> kept.
+  assertEquals(transform.input, undefined);
+  assertEquals(transform.output, { path: "scale0" });
+});
+
+// A dataset whose transforms are a bare [scale, translation] (not wrapped in a
+// sequence, as another writer might emit) must still yield the per-axis scale
+// and translation. Exercises the non-sequence branch of extractScaleTranslation.
+Deno.test("v0.6 read handles bare per-dataset scale and translation", async () => {
+  const multiscales = await buildMultiscales();
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+
+  mutateRootEntry(store, (entry) => {
+    const datasets = entry.datasets as Array<Record<string, unknown>>;
+    datasets.forEach((ds, index) => {
+      const factor = 2 ** index;
+      ds.coordinateTransformations = [
+        { type: "scale", scale: [factor, factor, factor] },
+        { type: "translation", translation: [index, index, index] },
+      ];
+    });
+  });
+
+  const imported = await fromOmeZarr(store);
+  assertEquals(imported.images[0].scale, { z: 1, y: 1, x: 1 });
+  assertEquals(imported.images[0].translation, { z: 0, y: 0, x: 0 });
+  assertEquals(imported.images[1].scale, { z: 2, y: 2, x: 2 });
+  assertEquals(imported.images[1].translation, { z: 1, y: 1, x: 1 });
+});
+
+Deno.test("v0.6 read rejects metadata missing coordinateSystems", async () => {
+  const multiscales = await buildMultiscales();
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+  mutateRootEntry(store, (entry) => {
+    delete entry.coordinateSystems;
+  });
+  await assertRejects(
+    () => fromOmeZarr(store),
+    Error,
+    "coordinateSystems",
+  );
+});
+
+Deno.test("v0.6 read rejects empty datasets", async () => {
+  const multiscales = await buildMultiscales();
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+  mutateRootEntry(store, (entry) => {
+    entry.datasets = [];
+  });
+  await assertRejects(
+    () => fromOmeZarr(store),
+    Error,
+    "datasets",
+  );
+});
+
+Deno.test("v0.6 read rejects a malformed scale transform", async () => {
+  const multiscales = await buildMultiscales();
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+  mutateRootEntry(store, (entry) => {
+    // `scale` must be an array of numbers; a string is rejected rather than
+    // passed through an unchecked cast.
+    entry.coordinateTransformations = [{
+      type: "scale",
+      scale: "not-an-array",
+      input: { name: "intrinsic" },
+      output: { name: "intrinsic" },
+    }];
+  });
+  await assertRejects(
+    () => fromOmeZarr(store),
+    Error,
+    "must be an array of numbers",
+  );
+});
+
+Deno.test("v0.6 read rejects an unknown transform type", async () => {
+  const multiscales = await buildMultiscales();
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+  mutateRootEntry(store, (entry) => {
+    entry.coordinateTransformations = [{
+      type: "notARealTransform",
+      input: { name: "intrinsic" },
+      output: { name: "intrinsic" },
+    }];
+  });
+  await assertRejects(
+    () => fromOmeZarr(store),
+    Error,
+    "Unsupported transform type",
+  );
+});
+
+// Anatomical orientation (RFC 4) and axis units carried on the intrinsic
+// coordinate system survive a v0.6 round-trip.
+Deno.test("v0.6 round-trips axis units and anatomical orientation", async () => {
+  const shape = [16, 16, 16];
+  const data = new Uint8Array(shape[0] * shape[1] * shape[2]);
+  const base = await toNgffImage(data, { dims: ["z", "y", "x"], shape });
+  const image = new NgffImage({
+    data: base.data,
+    dims: base.dims,
+    scale: base.scale,
+    translation: base.translation,
+    name: base.name,
+    axesUnits: { z: "micrometer", y: "micrometer", x: "micrometer" },
+    axesOrientations: {
+      z: {
+        type: "anatomical",
+        value: AnatomicalOrientationValues.InferiorToSuperior,
+      },
+      y: {
+        type: "anatomical",
+        value: AnatomicalOrientationValues.AnteriorToPosterior,
+      },
+      x: { type: "anatomical", value: AnatomicalOrientationValues.RightToLeft },
+    },
+    computedCallbacks: undefined,
+  });
+  const multiscales = await toMultiscales(image, {
+    scaleFactors: [2],
+    chunks: 8,
+  });
+
+  const store: MemoryStore = new Map();
+  // RFC-4 anatomical orientation is written automatically when present on the
+  // image; there is no enabled-RFCs opt-in.
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+  const imported = await fromOmeZarr(store, { version: "0.6", validate: true });
+
+  assertEquals(imported.images[0].axesUnits, {
+    z: "micrometer",
+    y: "micrometer",
+    x: "micrometer",
+  });
+  assertEquals(
+    imported.images[0].axesOrientations?.x,
+    { type: "anatomical", value: AnatomicalOrientationValues.RightToLeft },
+  );
+  const intrinsicAxes = imported.metadata.coordinateSystems![0].axes;
+  assertEquals(intrinsicAxes[2].unit, "micrometer");
+});
+
+// The requested-version mismatch is a validation concern: it is enforced only
+// under `validate`, consistent with the node reader and the v0.4/v0.5 path.
+Deno.test("browser reader gates v0.6 version mismatch behind validate", async () => {
+  const multiscales = await buildMultiscales();
+  const store: MemoryStore = new Map();
+  await toOmeZarrBrowser(store, multiscales, { version: "0.6" });
+
+  // Without validation, a mismatched requested version does not throw.
+  const lenient = await fromOmeZarrBrowser(store, { version: "0.4" });
+  assertEquals(lenient.metadata.version, "0.6");
+
+  // With validation, the mismatch is reported.
+  await assertRejects(
+    () => fromOmeZarrBrowser(store, { version: "0.4", validate: true }),
+    Error,
+    "Expected OME-Zarr version 0.4",
+  );
+});
+
+// Under validate=true the v0.6 reader runs the same structural pass as v0.4/v0.5
+// over the normalized metadata, so a dataset scale whose length disagrees with
+// the axis count is rejected.
+Deno.test("v0.6 read validates per-dataset scale length under validate", async () => {
+  const multiscales = await buildMultiscales();
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version: "0.6" });
+  mutateRootEntry(store, (entry) => {
+    const datasets = entry.datasets as Array<Record<string, unknown>>;
+    const seq = (datasets[0].coordinateTransformations as Array<
+      Record<string, unknown>
+    >)[0];
+    const transforms = seq.transformations as Array<Record<string, unknown>>;
+    // Drop a component so the scale vector no longer matches the 3 axes.
+    transforms[0].scale = [2.0, 2.0];
+  });
+
+  // Lenient read tolerates it; strict validation rejects it.
+  const lenient = await fromOmeZarr(store);
+  assertEquals(lenient.images.length, multiscales.images.length);
+  await assertRejects(
+    () => fromOmeZarr(store, { validate: true }),
+    Error,
+  );
+});
+
+// RFC-9 (.ozx) output is always v0.5, which cannot represent v0.6-only
+// transforms; prepareRfc9Metadata must reduce them to the scale/translation
+// subset so they never leak into the store.
+Deno.test("RFC-9 metadata drops a v0.6-only rotation but keeps a scale", async () => {
+  const withRotation = await buildMultiscales();
+  withRotation.metadata.coordinateTransformations = [createRotation([
+    [0.0, -1.0, 0.0],
+    [1.0, 0.0, 0.0],
+    [0.0, 0.0, 1.0],
+  ])];
+  const rotEntry = prepareRfc9Metadata(withRotation);
+  // No representable top-level transform remains, so the field is omitted.
+  assertEquals("coordinateTransformations" in rotEntry, false);
+
+  const withScale = await buildMultiscales();
+  withScale.metadata.coordinateTransformations = [createScale([2, 2, 2])];
+  const scaleEntry = prepareRfc9Metadata(withScale);
+  const kept = scaleEntry.coordinateTransformations as Array<
+    Record<string, unknown>
+  >;
+  assertEquals(kept.length, 1);
+  assertEquals(kept[0].type, "scale");
+  // The v0.6-only input/output/name fields are stripped from the kept transform.
+  assertEquals("input" in kept[0], false);
+  assertEquals("output" in kept[0], false);
+});


### PR DESCRIPTION
## Summary

Ports [#255](https://github.com/fideus-labs/ngff-zarr/pull/255) (RFC-5 coordinate
systems and transformations) — already merged for the Python package — to the
TypeScript package `@fideus-labs/ngff-zarr`. This adds **OME-Zarr v0.6**
reading, writing, and version conversion, bringing TS to parity with the Python
implementation.

## Why

The Python side gained v0.6 / RFC-5 in #255. The TypeScript package mirrors the
Python API and data model, so it needs the matching v0.6 support to read and
write the same stores. This PR is the TS counterpart of that work.

## What changed

- **New version**: `NgffVersion.V06 = "0.6"`, added to `SUPPORTED_VERSIONS`, and
  `LATEST` bumped to `0.6`. The **default write version stays `0.5`** — v0.6 is
  opt-in via `{ version: "0.6" }`, so existing callers are unaffected.
- **Read / write / convert**: v0.6 branches added to `toOmeZarr` / `fromOmeZarr`
  in both the Node and browser entry points. Round-trips and 0.4 ↔ 0.5 ↔ 0.6
  conversion work in memory and on disk.
- **Types & factories**: `CoordinateSystem`, `CoordinateSystemIdentifier`,
  `Rotation`, `Affine`, `TransformSequence`, `V06Transform`, a
  `coordinateSystems` field on the metadata, the
  `INTRINSIC_COORDINATE_SYSTEM_NAME` constant, and `createRotation` /
  `createAffine` / `createTransformSequence` / `createCoordinateSystem`
  factories.
- **RFC-4 parity fix**: `hasRfc4OrientationMetadata` now treats an empty or
  absent `orientation` (`{}`, `null`, `""`) as *no* orientation metadata,
  mirroring the `if axis['orientation']:` guard added to the Python side in the
  same PR.
- **Docs**: root `README.md` now lists v0.4, v0.5, **and v0.6** support for the
  TS package.

## Implementation details

**Design decision — v0.6 as a serialization layer, not a parallel model.** The
Python port uses dedicated `v04` / `v05` / `v06` metadata classes with
conversion methods, treating v0.6 as the canonical in-memory form. The TS
codebase instead has a single, version-agnostic `MetadataInterface` (axes +
per-dataset scale/translation + a `version` string). To stay consistent with
that, v0.6 is handled as a **(de)serialization boundary** in the new
`ts/src/utils/v06_metadata.ts` rather than a new canonical class. This is
lower-risk for the existing 0.4/0.5 paths while reproducing the exact on-disk
format and external behavior. `NgffVersion.LATEST` is now `0.6`.

**On-disk format** (matches `py/ngff_zarr/v06/zarr_metadata.py`): v0.6 carries
`coordinateSystems` instead of a top-level `axes` list, and each dataset maps
its array index space into the implicit `"intrinsic"` system via a `sequence`
of scale + translation with `input` / `output` coordinate references:

```jsonc
"ome": { "version": "0.6", "multiscales": [{
  "name": "image",
  "coordinateSystems": [{ "name": "intrinsic", "axes": [ /* … */ ] }],
  "datasets": [{ "path": "scale0", "coordinateTransformations": [{
    "type": "sequence", "name": "scale0_to_intrinsic",
    "input":  { "path": "scale0" },
    "output": { "name": "intrinsic" },
    "transformations": [{ "type": "scale", /* … */ },
                        { "type": "translation", /* … */ }] }] }] }] }
```

**Downgrade behavior**: writing a v0.6-origin value back at 0.4/0.5 keeps the
representable scale/translation subset and drops richer top-level transforms
(rotation / affine / sequence) that those versions cannot express.

**Input hardening** (from a CodeRabbit pass on the diff): the reader validates
untrusted on-disk transform payloads — `scale` / `translation` must be numeric
arrays, `rotation` / `affine` 2-D numeric arrays — instead of using unchecked
casts; unknown coordinate-system `name` references are dropped while `path`
references are kept; and empty `input: {}` / `output: {}` identifiers are never
emitted.

## Testing & quality

- New `ts/test/v06_coordinate_transformations_test.ts` (mirrors
  `test_coordinate_transformations.py` and the v0.6 conversion cases): write/read
  round-trips, on-disk format, every transform type round-tripping its
  input/output references, 0.4 ↔ 0.5 ↔ 0.6 conversion, the browser path, reader
  rejection paths, identifier gating, and units/orientation round-tripping.
- Extended `ts/test/rfc4_validation_test.ts` for the empty/absent-orientation
  guard.
- Full Deno suite green (**429 passed / 0 failed**); `deno check`, `deno lint`,
  and `deno fmt --check` all clean. Coverage of `v06_metadata.ts` ≈ 97 % branch.
- CodeRabbit re-review after applying fixes: **0 findings**.

## Notes / caveats (faithful to the Python PR)

- v0.6 **read validation** runs the same structural pass as v0.4/v0.5 over the
  normalized metadata (axes + per-dataset scale/translation) when `validate` is
  enabled. Full RFC-5 *wire-schema* validation (coordinate-system graphs,
  arbitrary transform chains) remains deferred, mirroring the Python PR's
  `validate=False` and its `# TODO: Restore validation for v0.6`.
- The pre-existing `ts/src/schemas/coordinate_systems.ts` Zod schema encodes an
  **older RFC-5 draft shape** (string `input`/`output`, 1-D rotation) and is not
  wired into I/O; this PR parses manually (like Python) and leaves that schema
  and its tests untouched. Reconciling it to the `{ path, name }` object form is
  a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OME-Zarr v0.6 support for reading and writing, including RFC-5 coordinate systems and version-specific coordinate-transformation handling.
  * Writer embeds v0.6 multiscales using the correct wrapping, synthesizes an implicit “intrinsic” coordinate system when needed, and supports v0.6→v0.5 downgrades by keeping only compatible transforms.
* **Bug Fixes**
  * Improved RFC-4 orientation metadata detection to ignore empty orientation values.
* **Documentation**
  * Updated README to advertise OME-Zarr v0.6 (RFC-5 coordinate systems/transformations).
* **Tests**
  * Added extensive v0.6 coordinate-systems/transformation coverage, browser parity checks, and RFC-9 (.ozx) export normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
