### PR TITLE
feat: allow reading dev4 versions

### DIFF
--- a/py/ngff_zarr/_supported_versions.py
+++ b/py/ngff_zarr/_supported_versions.py
@@ -29,7 +29,8 @@ class NgffVersion(StrEnum):
     V04 = "0.4"
     V05 = "0.5"
     V06 = "0.6"
-    LATEST = "0.6"
+    V06dev4 = "0.6.dev4"
+    LATEST = "0.6.dev4"
 
 
 # Supported NGFF specification versions
@@ -39,4 +40,6 @@ SUPPORTED_VERSIONS = (
     NgffVersion.V03,
     NgffVersion.V04,
     NgffVersion.V05,
+    NgffVersion.V06,
+    NgffVersion.V06dev4
 )

--- a/py/ngff_zarr/from_ngff_zarr.py
+++ b/py/ngff_zarr/from_ngff_zarr.py
@@ -346,7 +346,7 @@ def from_ome_zarr(
             "within the plate (e.g., 'plate.zarr/A/1/0' for well A1, field 0)."
         )
 
-    if "0.6" in version:
+    if version.startswith("0.6"):
         from .v06.zarr_metadata import Metadata
         # TODO: Restore validation for v0.6
         metadata_obj, images = Metadata._from_zarr_attrs(

--- a/py/ngff_zarr/from_ngff_zarr.py
+++ b/py/ngff_zarr/from_ngff_zarr.py
@@ -346,7 +346,7 @@ def from_ome_zarr(
             "within the plate (e.g., 'plate.zarr/A/1/0' for well A1, field 0)."
         )
 
-    if version == "0.6":
+    if "0.6" in version:
         from .v06.zarr_metadata import Metadata
         # TODO: Restore validation for v0.6
         metadata_obj, images = Metadata._from_zarr_attrs(

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -501,6 +501,8 @@ def _create_zarr_root(
 
     if version != "0.4":
         # RFC 2, Zarr 3 - omero goes inside ome namespace
+        if version == "0.6":
+            version = "0.6.dev4"
         ome_dict = {"version": version, "multiscales": [metadata_dict]}
         if "omero" in metadata_dict:
             ome_dict["omero"] = metadata_dict.pop("omero")


### PR DESCRIPTION
@thewtex minor tweak in the wake of #98: Most datasets available on the web for testing write the version `0.6.dev4`, which is currently not supported to read, because the reader just checks the version against `version==0.6`. We can remove this later, for the time being this makes it easier to test things with other development versions.

Vice versa, I added a conditional check we'll also have to remove later, that will replace the written version `"0.6"` with `"0.6.dev4"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for NGFF version **0.6.dev4** and made it the latest available version.
* **Bug Fixes**
  * Improved NGFF/OME-Zarr version detection so metadata parsing correctly handles **0.6** version variants.
  * When exporting NGFF **0.6**, the written root metadata is now normalized to **0.6.dev4** for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->