### PR TITLE
fix(py): re-open LIF source at compute time to survive closed file handle

### DIFF
--- a/py/ngff_zarr/lif_to_ngff_image.py
+++ b/py/ngff_zarr/lif_to_ngff_image.py
@@ -10,6 +10,7 @@ into OME-Zarr format.
 Requires the `liffile` package: pip install liffile
 """
 
+import os
 import re
 from collections.abc import Sequence
 from functools import reduce
@@ -54,6 +55,62 @@ SPATIAL_DIMS = {"x", "y", "z"}
 def _get_lif_image_data_delayed(lif_image: Any) -> np.ndarray:
     """Load LIF image data (for use with dask.delayed)."""
     return lif_image.asarray()
+
+
+def _read_lif_image_array(lif_path: str, index: int) -> np.ndarray:
+    """Re-open the LIF file and read a single image's array.
+
+    Re-opening per read keeps the dask graph self-contained: the ``LifFile``
+    handle that produced the graph is typically closed (and the graph may be
+    serialized to other worker processes) by the time chunks are computed, so
+    holding a reference to a ``LifImage`` from that handle raises
+    ``ValueError: seek of closed file``.
+    """
+    from liffile import LifFile
+
+    with LifFile(lif_path) as lif:
+        return lif.images[index].asarray()
+
+
+def _lif_reopen_locator(lif_image: Any) -> tuple[str, int] | None:
+    """Derive a ``(filepath, index)`` that re-opens the source LIF and
+    reselects ``lif_image``.
+
+    Returns ``None`` when the source file path cannot be determined (e.g. the
+    image is a test mock or was created without a backing file), in which case
+    the caller falls back to referencing the ``LifImage`` directly.
+    """
+    parent = getattr(lif_image, "parent", None)
+    filepath = getattr(parent, "filepath", None)
+    if not isinstance(filepath, (str, os.PathLike)):
+        return None
+    try:
+        images = list(parent.images)
+    except TypeError:
+        return None
+    uuid = getattr(lif_image, "uuid", None)
+    for i, img in enumerate(images):
+        if img is lif_image:
+            return (os.fspath(filepath), i)
+    if uuid is not None:
+        for i, img in enumerate(images):
+            if getattr(img, "uuid", None) == uuid:
+                return (os.fspath(filepath), i)
+    return None
+
+
+def _delayed_lif_data(lif_image: Any, shape: Sequence[int], dtype: Any) -> da.Array:
+    """Build a lazy dask array for ``lif_image`` that survives the source
+    ``LifFile`` being closed by re-opening the file at compute time when
+    possible.
+    """
+    locator = _lif_reopen_locator(lif_image)
+    if locator is not None:
+        lif_path, index = locator
+        delayed_data = dask.delayed(_read_lif_image_array)(lif_path, index)
+    else:
+        delayed_data = dask.delayed(_get_lif_image_data_delayed)(lif_image)
+    return da.from_delayed(delayed_data, shape=tuple(shape), dtype=dtype)
 
 
 def _extract_scale_translation(
@@ -327,10 +384,10 @@ def lif_to_ngff_image(
             if dim not in translation:
                 translation[dim] = 0.0
 
-    # Create lazy dask array from the LIF image
-    # Use delayed to avoid loading data until needed
-    delayed_data = dask.delayed(_get_lif_image_data_delayed)(lif_image)
-    data = da.from_delayed(delayed_data, shape=lif_shape, dtype=dtype)
+    # Create lazy dask array from the LIF image. Re-open the source file at
+    # compute time so the array remains valid after the producing LifFile
+    # handle is closed.
+    data = _delayed_lif_data(lif_image, lif_shape, dtype)
 
     # Reshape if needed for flattened channels
     if data.shape != ngff_shape:
@@ -546,9 +603,10 @@ def lif_to_hcs_plate(
     lif_dims = lif_image.dims
     lif_shape = lif_image.shape
 
-    # Create a delayed load for the full data
-    delayed_data = dask.delayed(_get_lif_image_data_delayed)(lif_image)
-    full_data = da.from_delayed(delayed_data, shape=lif_shape, dtype=lif_image.dtype)
+    # Create a delayed load for the full data. Re-open the source file at
+    # compute time so the array remains valid after the producing LifFile
+    # handle is closed.
+    full_data = _delayed_lif_data(lif_image, lif_shape, lif_image.dtype)
 
     # Build slicing for each mosaic position
     for pos_idx in range(n_positions):

--- a/py/test/test_lif_to_ngff_image.py
+++ b/py/test/test_lif_to_ngff_image.py
@@ -426,3 +426,127 @@ class TestLifFileToNgffImages:
         assert "SHG_area_1" in names
         assert "SHG_area_2" in names
         assert "Overview" not in names
+
+
+class TestDelayedReopen:
+    """Regression tests for lazy reads surviving a closed source LifFile.
+
+    The lazy dask array must not depend on the LifFile handle that produced
+    it remaining open: that handle is closed (and the graph may be serialized
+    to worker processes) before chunks are computed, which previously raised
+    ``ValueError: seek of closed file`` during multiscale generation / write.
+    """
+
+    def test_reopen_locator_resolves_path_and_index(self):
+        from ngff_zarr.lif_to_ngff_image import _lif_reopen_locator
+
+        parent = Mock()
+        parent.filepath = "/data/sample.lif"
+        img_a = Mock()
+        img_b = Mock()
+        parent.images = [img_a, img_b]
+        img_b.parent = parent
+
+        assert _lif_reopen_locator(img_b) == ("/data/sample.lif", 1)
+
+    def test_reopen_locator_none_without_real_filepath(self):
+        from ngff_zarr.lif_to_ngff_image import _lif_reopen_locator
+
+        # A plain Mock has an auto-attribute (non-str) filepath -> no locator,
+        # so the caller falls back to referencing the image directly.
+        assert _lif_reopen_locator(Mock()) is None
+
+    def test_reopen_locator_falls_back_to_uuid_when_identity_differs(self):
+        """When re-listing parent.images yields fresh objects (so ``is``
+        identity fails), the stable uuid is used to find the index."""
+        from ngff_zarr.lif_to_ngff_image import _lif_reopen_locator
+
+        parent = Mock()
+        parent.filepath = "/data/sample.lif"
+        # A distinct object with the same uuid stands in for the same series
+        # re-read from a freshly opened handle.
+        other_first = Mock()
+        other_first.uuid = "uuid-0"
+        other_match = Mock()
+        other_match.uuid = "uuid-1"
+        parent.images = [other_first, other_match]
+
+        lif_image = Mock()
+        lif_image.parent = parent
+        lif_image.uuid = "uuid-1"
+
+        assert _lif_reopen_locator(lif_image) == ("/data/sample.lif", 1)
+
+    def test_reopen_locator_none_when_no_identity_or_uuid_match(self):
+        """Identity and uuid both fail to match any image -> no locator."""
+        from ngff_zarr.lif_to_ngff_image import _lif_reopen_locator
+
+        parent = Mock()
+        parent.filepath = "/data/sample.lif"
+        sibling = Mock()
+        sibling.uuid = "uuid-other"
+        parent.images = [sibling]
+
+        lif_image = Mock()
+        lif_image.parent = parent
+        lif_image.uuid = None
+
+        assert _lif_reopen_locator(lif_image) is None
+
+    def test_reopen_locator_none_when_images_not_iterable(self):
+        """A real filepath but a non-iterable parent.images -> no locator
+        (falls back to a direct read rather than raising)."""
+        from ngff_zarr.lif_to_ngff_image import _lif_reopen_locator
+
+        parent = Mock()
+        parent.filepath = "/data/sample.lif"
+        # parent.images is an auto-Mock attribute, which is not iterable.
+        lif_image = Mock()
+        lif_image.parent = parent
+
+        assert _lif_reopen_locator(lif_image) is None
+
+    @patch("liffile.LifFile")
+    def test_delayed_data_reopens_after_close(self, mock_liffile_class):
+        """Computing the array re-opens the file instead of using the stale,
+        now-closed source image."""
+        expected = np.arange(10 * 4 * 4, dtype=np.uint8).reshape(10, 4, 4)
+
+        reopened_img = Mock()
+        reopened_img.asarray.return_value = expected
+        reopened_lif = MagicMock()
+        reopened_lif.images = [reopened_img]
+        mock_liffile_class.return_value.__enter__ = Mock(return_value=reopened_lif)
+        mock_liffile_class.return_value.__exit__ = Mock(return_value=False)
+
+        parent = Mock()
+        parent.filepath = "/data/sample.lif"
+        src_img = Mock()
+        src_img.parent = parent
+        parent.images = [src_img]
+        # Simulate the closed-handle failure if the stale image is touched.
+        src_img.asarray.side_effect = ValueError("seek of closed file")
+
+        from ngff_zarr.lif_to_ngff_image import _delayed_lif_data
+
+        arr = _delayed_lif_data(src_img, (10, 4, 4), np.uint8)
+        result = np.asarray(arr.compute())
+
+        assert np.array_equal(result, expected)
+        src_img.asarray.assert_not_called()
+        mock_liffile_class.assert_called_once_with("/data/sample.lif")
+
+    def test_delayed_data_falls_back_to_direct_read(self):
+        """Without a resolvable source path (e.g. mocks), the array still
+        computes via the image's own asarray()."""
+        src_img = Mock()
+        src_img.parent = None
+        src_img.asarray.return_value = np.ones((2, 3, 3), dtype=np.uint8)
+
+        from ngff_zarr.lif_to_ngff_image import _delayed_lif_data
+
+        arr = _delayed_lif_data(src_img, (2, 3, 3), np.uint8)
+        result = np.asarray(arr.compute())
+
+        assert result.shape == (2, 3, 3)
+        src_img.asarray.assert_called()


### PR DESCRIPTION
## Summary

Converting a LIF file to OME-Zarr through the CLI
(`ngff-zarr -i sample.lif --input-backend liffile -o out.ome.zarr`) failed
with:

```
OSError: Failed to write data to the zarr array at path 'scale0/...'.
Original error: ValueError: seek of closed file
```

The same root cause also produced a `Could not compute OMERO metadata: seek of
closed file` warning during metadata-only probes.

## Root cause

`lif_file_to_ngff_images()` opens a `LifFile` inside a `with` block and builds
lazy dask arrays whose reader closes over `LifImage` objects belonging to that
handle. The handle is **closed when the function returns**, so when the
multiscale write (or OMERO quantile computation) later computes those chunks,
the read hits an already-closed file. The dask graph also may be serialized to
other worker processes, where an open handle could never travel anyway.

## What changed

`py/ngff_zarr/lif_to_ngff_image.py` — make the lazy reader self-contained by
re-opening the source file at compute time instead of holding a reference to a
`LifImage` from a soon-to-be-closed handle:

- **`_read_lif_image_array(lif_path, index)`** — re-opens the LIF via
  `LifFile(lif_path)` and reads a single image by index at compute time.
- **`_lif_reopen_locator(lif_image)`** — derives a stable `(filepath, index)`
  from `lif_image.parent.filepath`, matching the image first by object identity
  and falling back to its `uuid`. Returns `None` when no real source path is
  resolvable (e.g. test mocks or handleless images).
- **`_delayed_lif_data(lif_image, shape, dtype)`** — uses the re-open path when
  a locator is available and otherwise falls back to the prior direct
  `LifImage` reference, preserving existing behavior for non-file-backed images.

Both delayed-read sites now route through `_delayed_lif_data`:
- `lif_to_ngff_image()` (standard series conversion)
- `lif_to_hcs_plate()` (mosaic / HCS conversion)

This covers every caller, including `cli_input_to_ngff_image`, and restores
OMERO metadata computation.

## Tests

Added a `TestDelayedReopen` class to `py/test/test_lif_to_ngff_image.py`
covering all branches of the new helpers:

- locator resolves `(path, index)` via object identity
- uuid fallback when re-listed images are fresh objects (identity differs)
- `None` when neither identity nor uuid matches
- `None` when `parent.images` is not iterable (guarded `TypeError`)
- `None` when no real source filepath is available
- `_delayed_lif_data` re-opens the file on compute (and does **not** touch the
  stale image, which is wired to raise `seek of closed file`)
- `_delayed_lif_data` falls back to a direct read when no path is resolvable

Full file: 25 tests passing; `ruff check`/`ruff format` clean.

## Verification

End-to-end on a 1.6 GB single-series stack
(`TestNeuronwithSpinesZoomed.lif`, series `zstack1 63x+zoom`,
`(C=3, Z=64, Y=2048, X=2048)` uint16):

- Conversion succeeds — OME-Zarr v0.5, 5 scales written.
- OMERO metadata computed for 3 channels (warning gone).
- Read-back confirms correct dims/shape/anisotropic spacing, and a corner block
  matches the source LIF exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced lazy image data loading in LIF→NGFF image conversion and high-content screening plate processing by implementing a safer file-reopening mechanism for reliably deferred dask array computation.

* **Tests**
  * Added comprehensive test suite for lazy image reading behavior after file closure, validating automatic path resolution, stable identifier matching, and direct computation fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->