### PR TITLE
build(ts): auto-format CHANGELOG.md during version bump to keep CI green

### DIFF
--- a/ts/.cz.toml
+++ b/ts/.cz.toml
@@ -13,6 +13,12 @@ bump_message = "chore(ts): bump @fideus-labs/ngff-zarr to version $new_version"
 annotated_tag = true
 gpg_sign = true
 major_version_zero = true
+# Format the generated CHANGELOG.md with `deno fmt` before it is staged and
+# committed. cz writes the changelog, then runs pre_bump_hooks, then stages and
+# commits the changelog + version files, so formatting here lands inside the
+# bump commit and keeps CI's `deno fmt --check` green (avoids a follow-up
+# "fix: format ts CHANGELOG" commit).
+pre_bump_hooks = ["deno fmt CHANGELOG.md"]
 
 [tool.commitizen.customize]
 path = "../.commitizen"


### PR DESCRIPTION
## Summary

Adds a Commitizen `pre_bump_hooks` entry to `ts/.cz.toml` so the TypeScript
package's `CHANGELOG.md` is formatted with `deno fmt` **inside** the version-bump
commit, instead of in a separate follow-up commit.

```toml
pre_bump_hooks = ["deno fmt CHANGELOG.md"]
```

## Why

`cd ts && pixi run bump` regenerates `CHANGELOG.md` from a Jinja template. The
generated markdown (e.g. multi-line breaking-change bullets) does not match
`deno fmt`'s prose formatting, so the bump commit lands a changelog that fails
CI's `deno fmt --check` gate (`.github/workflows/typescript.yml`). The fix was
previously applied by hand as a separate commit each release — e.g.
`93ee09f` *"fix: format ts CHANGELOG"*, immediately after the `0.21.0` bump.
This hook removes that recurring manual step and keeps every bump commit
CI-green on its own.

## How it works

Commitizen's bump sequence (verified against the pinned `commitizen 4.13.0`) is:

1. Write `CHANGELOG.md` from the template
2. Run `pre_bump_hooks`  ← **`deno fmt CHANGELOG.md` runs here**
3. `git add` the changelog + version files
4. Commit (and tag)

Because the hook runs **after** the changelog is generated but **before** it is
staged, the formatted file is what gets committed.

## Implementation details

- One-line config change plus an explanatory comment; no source or runtime code
  is affected.
- `deno` is already required by every `ts` task and is on `PATH` during
  `pixi run bump`, so the hook has no new dependency.
- `CHANGELOG.md` is within `deno fmt`'s scope (only `dist/` is excluded in
  `ts/deno.json`).

## Verification

Reproduced the full bump end-to-end against `commitizen 4.13.0` in a scratch
repo using a changelog template that is intentionally `deno fmt`-dirty:

- **Without** the hook → the committed `CHANGELOG.md` **fails** `deno fmt --check`
  (reproduces the problem that required the manual follow-up commit).
- **With** the hook → the committed `CHANGELOG.md` **passes** `deno fmt --check`
  and the working tree is left clean.

CodeRabbit review of the change: **0 findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to automatically format the generated changelog before version bumps are committed.
  * This helps keep the changelog consistently formatted and avoids formatting check failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->