### PR TITLE
docs: document OME-Zarr v0.6 (RFC-5) support across docs and READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ The main Python package provides:
 - Conversion of most bioimaging file formats
 - Multiple downscaling methods
 - Supports Python>=3.10
-- Reads OME-Zarr v0.1 to v0.5 into simple Python data classes with Dask arrays
+- Reads OME-Zarr v0.1 to v0.6 into simple Python data classes with Dask arrays
 - Optional OME-Zarr data model validation during reading
-- Writes OME-Zarr v0.4 to v0.5
+- Writes OME-Zarr v0.4 to v0.6
+- v0.6 adds RFC-5 coordinate systems and transformations
 - [Sharded Zarr] stores
 - Optional writing via zarr-python 2, zarr-python 3, [tensorstore] or zarrita (TypeScript)
 - [Anatomical orientation metadata](./docs/rfc4.md) (RFC-4)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,9 +25,10 @@ A lean and kind
 - Conversion of most bioimaging file formats
 - Multiple downscaling methods
 - Supports Python>=3.10
-- Reads OME-Zarr v0.1 to v0.5 into simple Python data classes with Dask arrays
+- Reads OME-Zarr v0.1 to v0.6 into simple Python data classes with Dask arrays
 - Optional OME-Zarr data model validation during reading
-- Writes OME-Zarr v0.4 to v0.5
+- Writes OME-Zarr v0.4 to v0.6
+- v0.6 adds RFC-5 coordinate systems and transformations
 - [Sharded Zarr] stores
 - Optional writing via zarr-python 2, zarr-python 3, [tensorstore] or zarrita (TypeScript)
 - [Anatomical orientation metadata](./rfc4.md) (RFC-4)

--- a/docs/python.md
+++ b/docs/python.md
@@ -170,7 +170,7 @@ To read an OME-Zarr file, use [`from_ngff_zarr`], which returns the
 >>> multiscales = nz.from_ngff_zarr('cthead1.ome.zarr')
 ```
 
-OME-Zarr version 0.1 to 0.5 is supported.
+OME-Zarr version 0.1 to 0.6 is supported. Version 0.6 adds RFC-5 coordinate systems and transformations.
 
 ## OME-Zarr Zip (.ozx) files
 

--- a/docs/spec_features.md
+++ b/docs/spec_features.md
@@ -16,6 +16,8 @@ supported by `ngff-zarr`.
 - **Metadata**: Rich metadata support, including spatial metadata.
 - **Anatomical Orientation**: Support for anatomical orientation metadata
   (RFC-4).
+- **Coordinate Systems and Transformations**: Support for RFC-5 coordinate
+  systems and transformations in OME-Zarr v0.6.
 - **High Content Screening (HCS)**: Complete support for plate and well data
   structures.
 - **Sharded Zarr**: Support for sharded Zarr stores, allowing for scalable data
@@ -28,10 +30,11 @@ supported by `ngff-zarr`.
 
 ## OME-Zarr Versions
 
-- **OME-Zarr v0.1 to v0.5**: Reads OME-Zarr versions 0.1 to 0.5 into simple
+- **OME-Zarr v0.1 to v0.6**: Reads OME-Zarr versions 0.1 to 0.6 into simple
   Python data classes with Dask arrays.
-- **OME-Zarr v0.4 to v0.5**: Writes OME-Zarr versions 0.4 to 0.5, including
-  support for RFC 4.
+- **OME-Zarr v0.4 to v0.6**: Writes OME-Zarr versions 0.4 to 0.6, including
+  RFC-4 anatomical orientation. v0.6 additionally adds RFC-5 coordinate systems
+  and transformations.
 
 ## High Content Screening (HCS)
 
@@ -59,6 +62,7 @@ implementation details.
   allowing for scalable data management.
 - **RFC-4**: [Anatomical orientation support](./rfc4.md), allowing images to
   include metadata about their anatomical orientation.
+- **RFC-5**: Coordinate systems and transformations for OME-Zarr v0.6.
 - **RFC-9**: [OME-Zarr Zip (.ozx) format support](https://ngff.openmicroscopy.org/rfc/9/index.html),
   enabling single-file distribution of OME-Zarr datasets.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -9,7 +9,7 @@ NGFF-Zarr provides a TypeScript implementation for working with OME-Zarr data st
 - 🦕 **Deno-first**: Built for Deno with first-class TypeScript support
 - 📦 **Universal compatibility**: Works in Deno, Node.js, and browsers
 - 🔍 **Type-safe**: Full TypeScript support with Zod schema validation
-- 🗂️ **OME-Zarr support**: Read and write OME-Zarr v0.4 and v0.5
+- 🗂️ **OME-Zarr support**: Read and write OME-Zarr v0.4, v0.5, and v0.6 (v0.6 adds RFC-5 coordinate systems and transformations)
 - 🧪 **Well-tested**: Comprehensive test suite with browser validation
 - 🏗️ **Mirrors Python API**: Familiar interfaces for Python users
 - 📖 **Lazy loading**: Efficient handling of large datasets
@@ -99,9 +99,9 @@ const multiscales = await fromNgffZarr("image.ome.zarr", {
 });
 
 // Specify expected version
-const multiscalesV5 = await fromNgffZarr("image.ome.zarr", {
+const multiscalesV6 = await fromNgffZarr("image.ome.zarr", {
   validate: true,
-  version: "0.5",
+  version: "0.6",
 });
 ```
 
@@ -303,7 +303,7 @@ interface Metadata {
   datasets: Dataset[];          // Scale level paths and transforms
   coordinateTransformations?: CoordinateTransformation[];
   name?: string;
-  version?: "0.4" | "0.5";
+  version?: "0.4" | "0.5" | "0.6";
   type?: string;                // Downsampling method type
   metadata?: Record<string, unknown>;
 }
@@ -332,7 +332,7 @@ async function fromNgffZarr(
   store: string | MemoryStore | FetchStore,
   options?: {
     validate?: boolean;
-    version?: "0.4" | "0.5";
+    version?: "0.4" | "0.5" | "0.6";
   }
 ): Promise<NgffMultiscales>
 ```
@@ -352,7 +352,7 @@ const ms = await fromNgffZarr("data.ome.zarr");
 // With validation
 const validatedMs = await fromNgffZarr("data.ome.zarr", {
   validate: true,
-  version: "0.5",
+  version: "0.6",
 });
 
 // From URL
@@ -368,7 +368,7 @@ async function toNgffZarr(
   store: string,
   multiscales: NgffMultiscales,
   options?: {
-    version?: "0.4" | "0.5";
+    version?: "0.4" | "0.5" | "0.6";
     chunksPerShard?: number | number[] | Record<string, number>;
   }
 ): Promise<void>
@@ -386,7 +386,7 @@ async function toNgffZarr(
 await toNgffZarr("output.ome.zarr", multiscales);
 
 // With version specification
-await toNgffZarr("output.ome.zarr", multiscales, { version: "0.5" });
+await toNgffZarr("output.ome.zarr", multiscales, { version: "0.6" });
 
 // With sharding (v0.5)
 await toNgffZarr("output.ome.zarr", multiscales, {

--- a/ts/README.md
+++ b/ts/README.md
@@ -14,7 +14,7 @@ compatible with Deno, Node.js, and the browser.
 - 🦕 **Deno-first**: Built for Deno with first-class TypeScript support
 - 📦 **npm compatible**: Automatically builds npm packages using @deno/dnt
 - 🔍 **Type-safe**: Full TypeScript support with Zod schema validation
-- 🗂️ **OME-Zarr support**: Read and write OME-Zarr files using zarrita
+- 🗂️ **OME-Zarr support**: Read and write OME-Zarr v0.4, v0.5, and v0.6 using zarrita
 - 🧪 **Well-tested**: Comprehensive test suite using @std/assert
 - 🏗️ **Mirrors Python API**: TypeScript classes and types mirror the Python
   dataclasses


### PR DESCRIPTION
## Summary

Updates the project documentation to reflect that the codebase now supports
**OME-Zarr v0.6**, including **RFC-5 coordinate systems and transformations**.
The implementation already shipped this support (see
`py/ngff_zarr/v06/`, `ts/src/io/to_ngff_zarr.ts`, and the `0.6`/`0.6.dev4`
entries in `SUPPORTED_VERSIONS`), but the user-facing docs and READMEs still
advertised v0.5 as the ceiling. This PR brings the docs in line with the code.

Documentation-only — no source, API, or behavior changes.

## What changed

- **`README.md` / `docs/index.md`** — Feature list now states reads of
  OME-Zarr **v0.1–v0.6** and writes of **v0.4–v0.6**, with a new line noting
  that v0.6 adds RFC-5 coordinate systems and transformations.
- **`docs/python.md`** — Read-support sentence bumped to v0.1–v0.6 and notes
  the RFC-5 addition in v0.6.
- **`docs/spec_features.md`** — Adds a "Coordinate Systems and Transformations"
  feature entry and an RFC-5 entry under "RFCs Supported"; updates the
  read/write version ranges to v0.6.
- **`docs/typescript.md`** — Updates the feature blurb, the `version` option in
  `fromNgffZarr`/`toNgffZarr`, the `Metadata.version` union type, and the inline
  examples to include `"0.6"`.
- **`ts/README.md`** — Feature blurb now explicitly lists v0.4, v0.5, and v0.6.

## Why

The v0.6 / RFC-5 read and write paths landed in earlier commits
(`859519b94 feat(ts): add OME-Zarr v0.6 (RFC-5) coordinate transformations
support`, plus the Python `v06` module), but the documentation had not caught
up. Users reading the docs would not know v0.6 is available or that RFC-5
coordinate systems and transformations are supported. These edits document
existing, tested behavior.

## Implementation details / accuracy notes

- Each version claim was verified against the source rather than assumed:
  - Python reads v0.1–v0.6 (`NgffVersion` / `SUPPORTED_VERSIONS` in
    `py/ngff_zarr/_supported_versions.py`) and writes v0.4–v0.6
    (`_validate_ngff_parameters` accepts `V04`/`V05`/`V06` in
    `py/ngff_zarr/to_ngff_zarr.py`).
  - TypeScript accepts `"0.4" | "0.5" | "0.6"` for the `version` option and
    `Metadata.version`, and the v0.6 write path emits RFC-5 coordinate systems
    and transformations (`ts/src/io/to_ngff_zarr.ts`).
  - On disk, a requested `"0.6"` is tagged with the draft spec version
    `"0.6.dev4"` in both implementations; the public `version` option remains
    `"0.6"`, so the docs intentionally refer to `"0.6"`.
- **RFC-4 / RFC-5 are additive, not mutually exclusive.** The initial wording in
  `docs/spec_features.md` implied v0.6 replaced the RFC-4 orientation model with
  RFC-5. The v0.6 metadata writer still validates RFC-4 anatomical orientation
  (`py/ngff_zarr/v06/zarr_metadata.py`), so the text was corrected to: writes
  v0.4–v0.6 *including RFC-4 anatomical orientation*, and *v0.6 additionally
  adds RFC-5 coordinate systems and transformations*.

## Testing

- No tests added. The changes are documentation-only and introduce no new code
  behavior. The `>>>` snippets in `docs/python.md` are illustrative, not
  executed (pytest is configured with `testpaths = ["tests"]` and no doctest
  options).
- The v0.6 / RFC-5 behavior the docs describe is already covered by existing
  tests: `py/test/test_coordinate_transformations.py`,
  `py/test/test_convert_ome_zarr_version.py`,
  `ts/test/v06_coordinate_transformations_test.ts`, and
  `ts/test/schemas/rfc4_rfc5_schemas_test.ts`.
- `coderabbit review --agent` reports 0 findings on the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated feature lists across the README and docs to broaden OME-Zarr version support for reading (v0.1–v0.6) and writing (v0.4–v0.6).
  * Added explicit documentation for OME-Zarr v0.6, including RFC-5 coordinate systems and transformations.
  * Refreshed TypeScript “Quick Start” and API reference examples/typing references to include v0.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->