### PR TITLE
ci(mcp): re-enable Windows testing in MCP CI matrix

### DIFF
--- a/.github/workflows/mcp-ci.yml
+++ b/.github/workflows/mcp-ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:


### PR DESCRIPTION
## Summary

Re-adds `windows-latest` to the OS matrix of the MCP server CI workflow
(`.github/workflows/mcp-ci.yml`), restoring Windows test coverage for the
`ngff-zarr-mcp` package.

```diff
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
```

## Why

Windows was dropped from the MCP CI matrix in #175 while other MCP fixes were
landed. Issue #176 tracks bringing it back so the MCP server is once again
tested on all three major platforms (Linux, macOS, Windows) across Python
3.10–3.13.

Closes #176.

## Implementation notes

- **Matrix-only change.** The disable in #175 was purely the CI OS list — there
  were no `skipif`/platform guards added to the MCP tests, and `win-64` is
  already a declared platform in `mcp/pyproject.toml`'s pixi workspace, so no
  test or packaging changes were needed.
- **Verified locally on Windows** (win-64, Python 3.13.13, pixi 0.69.0) by
  running the exact CI steps against the `dev` environment before flipping the
  matrix:

  | CI step | Command | Result |
  |---------|---------|--------|
  | Lint | `pixi run -e dev lint` (ruff) | ✅ All checks passed |
  | Type check | `pixi run -e dev typecheck` (mypy) | ✅ No issues in 10 source files |
  | Tests | `pixi run -e dev test` (pytest) | ✅ 15 passed |

- No change to the `python-version` list; Windows runs the same 3.10–3.13
  span as the other operating systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated checks to run on Windows as well as macOS and Linux, improving cross-platform coverage and confidence in releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->