### PR TITLE
feat: non-destructive OME-Zarr spec-version upgrade (Python + TS + CLI)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -173,6 +173,43 @@ Provide the full path: 'plate.ome.zarr/A/1/0', 'plate.ome.zarr/A/2/0', ...
 
 For more details on HCS support, see [HCS Support](./hcs.md).
 
+### Upgrade an OME-Zarr store to a new version
+
+The `ngff-zarr upgrade` subcommand changes the OME-Zarr specification version
+recorded in an existing store. It has two modes.
+
+Omitting `-o`/`--output` performs an **in-place, metadata-only** upgrade: only
+the store's group metadata is rewritten and every array chunk on disk is left
+untouched.
+
+```shell
+ngff-zarr upgrade path/to/image.zarr --to 0.6
+```
+
+Passing `-o`/`--output` writes an **upgraded copy** to a new store through the
+standard write pipeline, leaving the source store intact. This is the mode to
+use for a transition across the Zarr v2/v3 boundary that the in-place mode
+cannot do safely (for example a 0.5/0.6 downgrade back to 0.4).
+
+```shell
+ngff-zarr upgrade src.zarr -o dst.zarr --to 0.5
+```
+
+The target version is selected with `--to` (alias `--version`), one of `0.4`,
+`0.5`, or `0.6` (default `0.6`). Add `--validate` to validate the source
+metadata against the NGFF schema while reading. For the write-to-new-store mode,
+`--overwrite` (the default) replaces any pre-existing data at the output store,
+while `--no-overwrite` refuses to; both flags are ignored for an in-place
+upgrade, which never overwrites array data.
+
+```shell
+# Validate the source, and refuse to overwrite an existing destination store.
+ngff-zarr upgrade src.zarr -o dst.zarr --to 0.6 --validate --no-overwrite
+```
+
+The command prints the detected source version, the target version, and which
+mode it ran. `ngff-zarr upgrade --help` lists every option.
+
 ### More options
 
 ```shell

--- a/docs/python.md
+++ b/docs/python.md
@@ -477,6 +477,76 @@ multiscales = from_ngff_zarr('cthead1.ome.zarr')
 to_ngff_zarr('cthead1_zarr2.ome.zarr', multiscales, version='0.4')
 ```
 
+## Upgrade OME-Zarr versions
+
+The conversion above re-reads and re-writes the entire pyramid. When you only
+need to change the *recorded specification version* of an existing store,
+[`upgrade_ome_zarr`] does it directly in one of two modes.
+
+**In-place, metadata-only.** When no `output` is given (or `output` resolves to
+the same store as `input`) and the source and target share the same underlying
+Zarr format -- for example 0.5 to 0.6, both Zarr v3 -- only the root group's
+`zarr.json` metadata is rewritten. **Every array chunk on disk is left
+byte-for-byte untouched**, avoiding the data loss of a naive "read, erase,
+re-write" upgrade. In-place upgrades that cross the Zarr v2/v3 boundary in the
+*upgrade* direction (0.4 to 0.5 or 0.4 to 0.6) are also metadata-only: each
+array's Zarr v3 `zarr.json` is given a `v2` chunk-key encoding so the existing
+chunk binaries resolve unchanged. The obsolete Zarr v2 sidecars (`.zarray`,
+`.zgroup`, `.zattrs`) are then removed, so the upgraded store is a valid Zarr v3
+/ OME-Zarr 0.5 (or 0.6) store *only* -- it is not simultaneously a valid Zarr v2
+/ OME-Zarr 0.4 store; only the chunk data binaries are reused, resolved through
+the `v2` chunk-key encoding. The reverse -- an in-place *downgrade* across that
+boundary (0.5/0.6 to 0.4) -- cannot preserve chunk keys and raises a
+`ValueError`; pass an `output` store instead.
+
+**Write-to-new-store.** When an `output` store distinct from `input` is given,
+the source is read lazily and re-written to `output` at the requested version
+through the standard write pipeline. Every supported transition (0.4, 0.5, 0.6,
+in either direction) works in this mode, and the source store is never erased.
+
+Upgrade a 0.5 store to 0.6 in place, keeping every array chunk:
+
+```python
+import numpy as np
+import ngff_zarr as nz
+
+# Synthesize a tiny store written at OME-Zarr 0.5 (Zarr v3).
+image = nz.to_ngff_image(np.zeros((4, 32, 32), dtype=np.uint8),
+                         dims=['z', 'y', 'x'])
+multiscales = nz.to_multiscales(image, scale_factors=[2])
+nz.to_ome_zarr('image.ome.zarr', multiscales, version='0.5')
+
+# Rewrite only the root metadata to 0.6; array chunks are left untouched.
+nz.upgrade_ome_zarr('image.ome.zarr', version='0.6')
+```
+
+Write an upgraded 0.6 copy from a 0.4 source, leaving the source intact:
+
+```python
+import numpy as np
+import ngff_zarr as nz
+
+# Synthesize a tiny store written at OME-Zarr 0.4 (Zarr v2).
+image = nz.to_ngff_image(np.zeros((4, 32, 32), dtype=np.uint8),
+                         dims=['z', 'y', 'x'])
+multiscales = nz.to_multiscales(image, scale_factors=[2])
+nz.to_ome_zarr('image_v04.ome.zarr', multiscales, version='0.4')
+
+# Write a new 0.6 store; 'image_v04.ome.zarr' is read lazily and never erased.
+nz.upgrade_ome_zarr('image_v04.ome.zarr', 'image_v06.ome.zarr', version='0.6')
+```
+
+Pass `validate=True` to validate the source metadata against the NGFF schema
+while reading, and `overwrite=False` (write-to-new-store only) to refuse to
+overwrite pre-existing data at `output`. A runnable version of both examples,
+which also proves the in-place upgrade leaves the array chunks byte-for-byte
+identical, is in
+[`py/examples/upgrade_ome_zarr_example.py`](https://github.com/fideus-labs/ngff-zarr/blob/main/py/examples/upgrade_ome_zarr_example.py).
+
+Note that `upgrade_ome_zarr` upgrades a single image. To upgrade an HCS plate or
+a bioformats2raw container, point at each contained image by its own path (for
+example `plate.ome.zarr/A/1/0`).
+
 [dataclass]: https://docs.python.org/3/library/dataclasses.html
 [dataclasses]: https://docs.python.org/3/library/dataclasses.html
 [Dask arrays]: https://docs.dask.org/en/stable/array.html
@@ -488,6 +558,7 @@ to_ngff_zarr('cthead1_zarr2.ome.zarr', multiscales, version='0.4')
 [`to_ngff_image`]: ./apidocs/ngff_zarr/ngff_zarr.to_ngff_image.md
 [`to_multiscales`]: ./apidocs/ngff_zarr/ngff_zarr.to_multiscales.md
 [`from_ngff_zarr`]: ./apidocs/ngff_zarr/ngff_zarr.from_ngff_zarr.md
+[`upgrade_ome_zarr`]: ./apidocs/ngff_zarr/ngff_zarr.upgrade_ome_zarr.md
 [`from_hcs_zarr`]: ./apidocs/ngff_zarr/ngff_zarr.hcs.md
 [Sharded Zarr]: https://zarr.dev/zeps/accepted/ZEP0002.html
 [tensorstore]: https://google.github.io/tensorstore/

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -752,6 +752,88 @@ const multiscalesV5 = await fromNgffZarr("data_v05.ome.zarr");
 await toNgffZarr("data_v04.ome.zarr", multiscalesV5, { version: "0.4" });
 ```
 
+### Upgrading OME-Zarr Store Versions
+
+The conversion above re-reads and re-writes the entire pyramid. To change only
+the *recorded specification version* of an existing store, `upgradeOmeZarr()`
+mirrors the Python `upgrade_ome_zarr` and offers the same two modes:
+
+```typescript
+function upgradeOmeZarr(
+  input: string | MemoryStore | FetchStore | Readable,
+  options?: {
+    output?: string | MemoryStore; // FetchStore is read-only, not a destination
+    version?: "0.4" | "0.5" | "0.6"; // default "0.6"
+    validate?: boolean;
+    overwrite?: boolean; // write-to-new-store only; default true
+  },
+): Promise<void>;
+```
+
+**In-place, metadata-only.** When `output` is omitted (or resolves to the same
+store as `input`) and the source and target share the same underlying Zarr
+format -- 0.5 to 0.6, both Zarr v3 -- only the root group's `zarr.json` is
+rewritten and every array chunk in the store is left byte-for-byte untouched,
+avoiding the data loss of a naive "read, erase, re-write" upgrade. An in-place
+upgrade that would cross the Zarr v2/v3 boundary
+(OME-Zarr 0.4 to 0.5/0.6) throws with guidance to pass `output` instead.
+
+```typescript
+import {
+  createAxis,
+  createDataset,
+  createMetadata,
+  createMultiscales,
+  createNgffImage,
+  toOmeZarr,
+  upgradeOmeZarr,
+  type MemoryStore,
+} from "@fideus-labs/ngff-zarr";
+
+// Build a small image and write it to a MemoryStore at version 0.5 (Zarr v3).
+const data = new Uint8Array(4 * 32 * 32);
+const image = await createNgffImage(
+  data.buffer,
+  [4, 32, 32],
+  "uint8",
+  ["z", "y", "x"],
+  { z: 1.0, y: 1.0, x: 1.0 },
+  { z: 0.0, y: 0.0, x: 0.0 },
+);
+const axes = [
+  createAxis("z", "space", "micrometer"),
+  createAxis("y", "space", "micrometer"),
+  createAxis("x", "space", "micrometer"),
+];
+const datasets = [createDataset("0", [1.0, 1.0, 1.0], [0.0, 0.0, 0.0])];
+const multiscales = createMultiscales([image], createMetadata(axes, datasets));
+
+const store: MemoryStore = new Map();
+await toOmeZarr(store, multiscales, { version: "0.5" });
+
+// Upgrade 0.5 -> 0.6 in place: only the root group's metadata is rewritten,
+// leaving every array chunk in the store untouched.
+await upgradeOmeZarr(store, { version: "0.6" });
+```
+
+**Write-to-new-store.** When `output` is a store distinct from `input`, the
+source is read lazily and re-written to `output` at the requested version
+through the standard write pipeline. Every supported transition (0.4, 0.5, 0.6,
+in either direction) works in this mode, and the source store is never mutated.
+
+```typescript
+import { upgradeOmeZarr, type MemoryStore } from "@fideus-labs/ngff-zarr";
+
+// `source` is an existing 0.4 store (e.g. a MemoryStore or FetchStore).
+const target: MemoryStore = new Map();
+await upgradeOmeZarr(source, { output: target, version: "0.6" });
+```
+
+In-place upgrade of a local **path** store is Node/Deno-only -- the browser build
+ships no filesystem store -- while `MemoryStore` inputs work in every
+environment, consistent with the other I/O functions. In the browser, use a
+`MemoryStore` for an in-place upgrade, or pass `output`.
+
 ### High Content Screening (HCS)
 
 Work with plate and well data:

--- a/py/examples/upgrade_ome_zarr_example.py
+++ b/py/examples/upgrade_ome_zarr_example.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Runnable, network-free end-to-end example of :func:`upgrade_ome_zarr`.
+
+Demonstrates both upgrade modes on a single synthesized multiscale image:
+
+1. **Write-to-new-store** across the Zarr v2 <-> v3 boundary: a store written at
+   OME-Zarr 0.4 (Zarr v2) is upgraded to 0.6 (Zarr v3) at a *new* location,
+   leaving the 0.4 source untouched.
+2. **In-place metadata-only** within Zarr v3: a fresh copy written at 0.5 is
+   upgraded to 0.6 in place -- only the root group's ``zarr.json`` is rewritten,
+   and every array chunk file on disk is left byte-for-byte identical. This is
+   the fix for issue #219 (https://github.com/fideus-labs/ngff-zarr/issues/219),
+   where an earlier erase-then-reload approach destroyed the array data it was
+   meant to preserve.
+
+For each mode the script prints the before/after on-disk spec versions and
+confirms the upgraded store reads back with its array data intact (pixel values
+equal to the source). It requires no network access and no user input.
+
+Run from the ``py/`` directory:
+
+    pixi run -e test python examples/upgrade_ome_zarr_example.py
+
+The process exits non-zero if any version does not update as expected, if the
+in-place upgrade touches a chunk file, or if the reloaded pixels differ from the
+source, so the script doubles as a self-checking smoke test.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import zarr
+from ngff_zarr import (
+    from_ome_zarr,
+    to_multiscales,
+    to_ngff_image,
+    to_ome_zarr,
+    upgrade_ome_zarr,
+)
+
+# The root group metadata file for a Zarr v3 store. An in-place same-format
+# upgrade rewrites only this file; per-array metadata and chunks are untouched.
+ROOT_METADATA = "zarr.json"
+
+
+def read_ome_version(store_path: str) -> str:
+    """Return the on-disk OME-Zarr spec version recorded at ``store_path``.
+
+    Handles both a Zarr v3 store (0.5/0.6, version under the ``ome`` key) and a
+    Zarr v2 store (0.4, version under the top-level ``multiscales``), mirroring
+    the reader's own v2 fallback so a 0.4 store opened without an explicit
+    format still resolves.
+    """
+    attrs = zarr.open_group(store_path, mode="r").attrs.asdict()
+    if not attrs:
+        attrs = zarr.open_group(store_path, mode="r", zarr_format=2).attrs.asdict()
+    if "ome" in attrs:
+        return attrs["ome"]["version"]
+    return attrs["multiscales"][0]["version"]
+
+
+def chunk_digests(root: Path) -> dict[str, str]:
+    """Map every array/chunk data file under ``root`` to its SHA-256 digest.
+
+    Excludes the ``zarr.json`` / ``.zarray`` / ``.zattrs`` / ``.zgroup``
+    metadata sidecars so the result is exactly the array chunk payload -- the
+    bytes an in-place upgrade must never touch.
+    """
+    metadata_names = {ROOT_METADATA, ".zarray", ".zattrs", ".zgroup", ".zmetadata"}
+    digests: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file() and path.name not in metadata_names:
+            rel = path.relative_to(root).as_posix()
+            digests[rel] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return digests
+
+
+def synthesize_multiscales():
+    """Build a small deterministic 2-level ``c, z, y, x`` multiscale image."""
+    rng = np.random.default_rng(0)
+    data = rng.integers(0, 255, size=(1, 4, 32, 32), dtype=np.uint8)
+    image = to_ngff_image(data, dims=("c", "z", "y", "x"))
+    return to_multiscales(image, scale_factors=[2]), data
+
+
+def demo_write_to_new_store(tmp: Path) -> None:
+    """0.4 -> 0.6 write-to-new-store: the 0.4 source is left intact."""
+    print("== Mode 1: write-to-new-store (0.4 -> 0.6, Zarr v2 -> v3) ==")
+    multiscales, source_data = synthesize_multiscales()
+
+    src = str(tmp / "image_v04.ome.zarr")
+    dst = str(tmp / "image_v06.ome.zarr")
+
+    to_ome_zarr(src, multiscales, version="0.4")
+    src_before = read_ome_version(src)
+    print(f"  source version (before) : {src_before!r}")
+    assert src_before == "0.4", src_before
+
+    # Upgrade into a brand-new store; the source is read lazily, never erased.
+    upgrade_ome_zarr(src, dst, version="0.6")
+
+    src_after = read_ome_version(src)
+    dst_after = read_ome_version(dst)
+    print(f"  source version (after)  : {src_after!r}  (unchanged)")
+    print(f"  new store version       : {dst_after!r}")
+    assert src_after == "0.4", src_after
+    assert dst_after == "0.6.dev4", dst_after
+
+    # Confirm the upgraded store reads back with pixel data intact.
+    reloaded = from_ome_zarr(dst, version="0.6")
+    full_res = np.asarray(reloaded.images[0].data)
+    print(f"  reloaded full-res shape : {full_res.shape}")
+    assert np.array_equal(full_res, source_data), "pixel data changed on upgrade"
+    print("  OK: 0.4 source preserved, 0.6 copy reads back with data intact\n")
+
+
+def demo_in_place(tmp: Path) -> None:
+    """0.5 -> 0.6 in place: metadata-only, array chunks left byte-identical."""
+    print("== Mode 2: in-place metadata-only (0.5 -> 0.6, Zarr v3) ==")
+    multiscales, source_data = synthesize_multiscales()
+
+    store = str(tmp / "image_v05.ome.zarr")
+    store_root = Path(store)
+
+    to_ome_zarr(store, multiscales, version="0.5")
+    before_version = read_ome_version(store)
+    before_chunks = chunk_digests(store_root)
+    print(f"  version (before)        : {before_version!r}")
+    print(f"  array/chunk data files  : {len(before_chunks)}")
+    assert before_version == "0.5", before_version
+
+    # In-place upgrade: rewrites only the root zarr.json.
+    upgrade_ome_zarr(store, version="0.6")
+
+    after_version = read_ome_version(store)
+    after_chunks = chunk_digests(store_root)
+    print(f"  version (after)         : {after_version!r}")
+    assert after_version == "0.6.dev4", after_version
+
+    # Prove every array chunk file is byte-for-byte identical.
+    assert after_chunks == before_chunks, "array chunk data changed on in-place upgrade"
+    print(f"  {len(after_chunks)} array/chunk data files byte-for-byte identical")
+
+    # Confirm the upgraded store reads back with pixel data intact.
+    reloaded = from_ome_zarr(store, version="0.6")
+    full_res = np.asarray(reloaded.images[0].data)
+    print(f"  reloaded full-res shape : {full_res.shape}")
+    assert np.array_equal(full_res, source_data), "pixel data changed on upgrade"
+    print("  OK: metadata upgraded 0.5 -> 0.6, chunks untouched, data intact\n")
+
+
+def main() -> int:
+    tmp = Path(tempfile.mkdtemp(prefix="ngff_upgrade_example_"))
+    try:
+        demo_write_to_new_store(tmp)
+        demo_in_place(tmp)
+        print("SUCCESS: both upgrade modes completed with array data intact")
+        return 0
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/py/ngff_zarr/__init__.py
+++ b/py/ngff_zarr/__init__.py
@@ -73,6 +73,7 @@ from .tiff_to_ngff_image import (
 from .to_multiscales import to_multiscales
 from .to_ngff_image import to_ngff_image
 from .to_ngff_zarr import ScaleStrategy, to_ngff_zarr, to_ome_zarr
+from .upgrade_ome_zarr import upgrade_ome_zarr
 from .v04.zarr_metadata import (
     AxesType,
     Axis,
@@ -126,6 +127,7 @@ __all__ = [
     "ScaleStrategy",
     "from_ome_zarr",
     "from_ngff_zarr",
+    "upgrade_ome_zarr",
     "detect_cli_io_backend",
     "ConversionBackend",
     "cli_input_to_ngff_image",

--- a/py/ngff_zarr/cli.py
+++ b/py/ngff_zarr/cli.py
@@ -468,8 +468,9 @@ def _ngff_image_to_multiscales(
     )
 
 
-def main():
+def _convert_main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
+        prog="ngff-zarr",
         description="Convert datasets to and from the OME-Zarr Next Generation File Format.",
         formatter_class=RichHelpFormatter,
     )
@@ -643,7 +644,7 @@ def main():
         default=None,
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     _REMOTE_SCHEMES = ("s3://", "gs://", "az://", "azure://", "http://", "https://")
 
@@ -1191,6 +1192,127 @@ def main():
                 multiscales,
                 chunks_per_shard=chunks_per_shard,
             )
+
+
+def _upgrade_main(argv: list[str] | None = None) -> None:
+    """Handle the ``ngff-zarr upgrade`` subcommand.
+
+    Upgrades an OME-Zarr store to a different specification version. With no
+    ``--output`` the upgrade is in-place and metadata-only -- every array chunk
+    on disk is left untouched. With an ``--output`` an upgraded copy is written
+    to a new store through the standard write pipeline, leaving the source
+    intact.
+    """
+    parser = argparse.ArgumentParser(
+        prog="ngff-zarr upgrade",
+        description=(
+            "Upgrade an OME-Zarr store to a different specification version. "
+            "Omit --output for an in-place, metadata-only upgrade (array chunks "
+            "are left untouched); pass --output to write an upgraded copy to a "
+            "new store, leaving the source intact."
+        ),
+        formatter_class=RichHelpFormatter,
+    )
+    parser.add_argument(
+        "input",
+        help="Path or URL to the source OME-Zarr store.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Destination store. If omitted, the store is upgraded in place "
+        "(metadata-only; array chunks are left untouched).",
+    )
+    parser.add_argument(
+        "--to",
+        "--version",
+        dest="version",
+        choices=["0.4", "0.5", "0.6"],
+        default="0.6",
+        help="Target OME-Zarr version (default: 0.6).",
+    )
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate the source metadata against the NGFF schema on read.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        dest="overwrite",
+        action="store_true",
+        help="When writing to a new --output store, overwrite existing data (default).",
+    )
+    parser.add_argument(
+        "--no-overwrite",
+        dest="overwrite",
+        action="store_false",
+        help="When writing to a new --output store, do not overwrite existing data.",
+    )
+    parser.set_defaults(overwrite=True)
+
+    args = parser.parse_args(argv)
+
+    from .upgrade_ome_zarr import (
+        _read_source_version,
+        _stores_are_same,
+        upgrade_ome_zarr,
+    )
+
+    console = _build_console()
+
+    # Detect the on-disk source version for an informative summary. A detection
+    # failure here is non-fatal: upgrade_ome_zarr re-reads the store below and
+    # will surface a precise error, rendered friendlily, if the input is bad.
+    try:
+        source_version = _read_source_version(args.input, None)
+    except Exception:
+        source_version = None
+
+    in_place = _stores_are_same(args.input, args.output)
+    mode = "in-place metadata-only upgrade" if in_place else "write to a new store"
+
+    if source_version is not None:
+        console.print(f"[cyan]Detected source OME-Zarr version:[/] {source_version}")
+    console.print(f"[cyan]Target OME-Zarr version:[/] {args.version}")
+    console.print(f"[cyan]Mode:[/] {mode}")
+    if not in_place:
+        console.print(f"[cyan]Output store:[/] {args.output}")
+
+    try:
+        upgrade_ome_zarr(
+            args.input,
+            args.output,
+            version=args.version,
+            validate=args.validate,
+            overwrite=args.overwrite,
+        )
+    except (ValueError, NotImplementedError) as exc:
+        console.print(f"[red]✗ Upgrade failed:[/] {exc}")
+        sys.exit(1)
+
+    if in_place:
+        console.print(
+            f"[green]✓ Upgraded [/]{args.input}[green] in place to "
+            f"OME-Zarr {args.version} (array chunks left untouched).[/]"
+        )
+    else:
+        console.print(
+            f"[green]✓ Wrote upgraded OME-Zarr {args.version} store to [/]{args.output}"
+        )
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the ``ngff-zarr`` command.
+
+    Dispatches to the ``upgrade`` subcommand when the first token is
+    ``"upgrade"``; otherwise runs the flat conversion command unchanged so
+    existing invocations behave exactly as before.
+    """
+    if argv is None:
+        argv = sys.argv[1:]
+    if argv and argv[0] == "upgrade":
+        return _upgrade_main(argv[1:])
+    return _convert_main(argv)
 
 
 if __name__ == "__main__":

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -22,10 +22,8 @@ from dask import __version__ as dask_version
 from itkwasm import array_like_to_numpy_array
 from packaging.version import Version
 
-from ._zarr_kwargs import zarr_kwargs
 from ._supported_versions import NgffVersion
-
-
+from ._zarr_kwargs import zarr_kwargs
 from ._zarr_open_array import open_array
 from ._zarr_types import StoreLike
 from .config import config
@@ -417,7 +415,7 @@ def _validate_ngff_parameters(
     """Validate the parameters for the NGFF Zarr generation."""
     if isinstance(version, str):
         version = NgffVersion(version)
-    
+
     if version not in [NgffVersion.V04, NgffVersion.V05, NgffVersion.V06]:
         raise ValueError(f"Unsupported version: {version}")
 
@@ -460,6 +458,33 @@ def _prepare_metadata(
     return metadata, dimension_names, dimension_names_kwargs
 
 
+def _write_root_ome_attrs(root: zarr.Group, metadata_dict: dict, version: str) -> None:
+    """Serialize the OME-Zarr root-group attributes for ``metadata_dict``.
+
+    Sets ``ome``/``multiscales`` (and hoists ``omero`` to its version-specific
+    location) on an already-open ``zarr.Group``, exactly as the writer does --
+    including mapping the API version ``"0.6"`` to the ``"0.6.dev4"`` string
+    persisted on disk. Shared by :func:`_create_zarr_root` and
+    :func:`ngff_zarr.upgrade_ome_zarr` so both emit byte-identical root
+    metadata. ``metadata_dict`` is mutated in place: its ``omero`` entry is
+    popped so it lives only in its hoisted location, matching historical
+    behavior.
+    """
+    if version != "0.4":
+        # RFC 2, Zarr 3 - omero goes inside ome namespace
+        if version == "0.6":
+            version = "0.6.dev4"
+        ome_dict = {"version": version, "multiscales": [metadata_dict]}
+        if "omero" in metadata_dict:
+            ome_dict["omero"] = metadata_dict.pop("omero")
+        root.attrs["ome"] = ome_dict
+    else:
+        # v0.4 - omero is at root level
+        if "omero" in metadata_dict:
+            root.attrs["omero"] = metadata_dict.pop("omero")
+        root.attrs["multiscales"] = [metadata_dict]
+
+
 def _create_zarr_root(
     store: StoreLike,
     chunk_store: StoreLike | None,
@@ -491,19 +516,7 @@ def _create_zarr_root(
             **format_kwargs,
         )
 
-    if version != "0.4":
-        # RFC 2, Zarr 3 - omero goes inside ome namespace
-        if version == "0.6":
-            version = "0.6.dev4"
-        ome_dict = {"version": version, "multiscales": [metadata_dict]}
-        if "omero" in metadata_dict:
-            ome_dict["omero"] = metadata_dict.pop("omero")
-        root.attrs["ome"] = ome_dict
-    else:
-        # v0.4 - omero is at root level
-        if "omero" in metadata_dict:
-            root.attrs["omero"] = metadata_dict.pop("omero")
-        root.attrs["multiscales"] = [metadata_dict]
+    _write_root_ome_attrs(root, metadata_dict, version)
 
     return root
 

--- a/py/ngff_zarr/upgrade_ome_zarr.py
+++ b/py/ngff_zarr/upgrade_ome_zarr.py
@@ -1,0 +1,567 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Upgrade an OME-Zarr store from one specification version to another.
+
+`upgrade_ome_zarr` changes the OME-Zarr specification version recorded in a
+store. It offers two modes:
+
+**In-place metadata-only rewrite.** When no `output` is given (or `output`
+resolves to the same store as `input`) and the source and target share the same
+underlying Zarr format -- for example 0.5 -> 0.6, both Zarr v3 -- only the root
+group's metadata (`zarr.json`) is rewritten. Every array chunk on disk is left
+byte-for-byte untouched. This is the fix for issue #219, where the previous
+"read, erase, re-write" approach destroyed the array data it was meant to
+preserve.
+
+In-place upgrades that cross the Zarr v2<->v3 boundary in the *upgrade*
+direction (OME-Zarr 0.4->0.5 or 0.4->0.6) are also metadata-only: each array's
+Zarr v3 ``zarr.json`` is given a ``v2`` chunk-key encoding matching the source
+separator so the existing chunk binaries resolve unchanged (see
+:func:`_rewrite_v2_group_to_v3`). The reverse, an in-place *downgrade* across
+the boundary (0.5/0.6->0.4), cannot preserve chunk keys and is rejected with a
+clear ``ValueError``; pass an ``output`` store instead.
+
+**Write-to-new-store conversion.** When an `output` store distinct from `input`
+is given, the source is read lazily and re-written to `output` at the requested
+version through the standard, tested write pipeline. Every supported transition
+(0.4<->0.5<->0.6) works in this mode. Array data streams from the source; the
+source store is never erased.
+
+Examples
+--------
+Upgrade a 0.5 store to 0.6 in place, keeping all array chunks:
+
+    upgrade_ome_zarr("image.ome.zarr", version="0.6")
+
+Write an upgraded copy to a new store:
+
+    upgrade_ome_zarr("image_v04.ome.zarr", "image_v05.ome.zarr", version="0.5")
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
+
+import packaging.version
+import zarr
+import zarr.errors
+import zarr.storage
+
+from ._supported_versions import NgffVersion
+from ._zarr_types import StoreLike
+from .from_ngff_zarr import (
+    REMOTE_URL_SCHEMES,
+    _is_remote_store,
+    from_ome_zarr,
+    zarr_version_major,
+)
+from .to_ngff_zarr import (
+    _numcodecs_to_zarr_v3_codec,
+    _pop_metadata_optionals,
+    _write_root_ome_attrs,
+    to_ome_zarr,
+)
+
+if TYPE_CHECKING:
+    from .multiscales import NgffMultiscales
+
+
+def _normalize_target_version(version: str | NgffVersion) -> str:
+    """Return the API version string (``"0.4"``/``"0.5"``/``"0.6"``).
+
+    Both the API alias ``"0.6"`` and the on-disk development string
+    ``"0.6.dev4"`` normalize to ``"0.6"`` so the value can be handed to
+    ``Metadata.to_version`` (which only knows the three released versions).
+    """
+    nv = NgffVersion(version)
+    if nv in (NgffVersion.V06, NgffVersion.V06dev4):
+        return "0.6"
+    return nv.value
+
+
+def _zarr_format_for_version(version: str) -> int:
+    """OME-Zarr < 0.5 lives in Zarr v2; 0.5 and later live in Zarr v3."""
+    if packaging.version.parse(version) < packaging.version.parse("0.5"):
+        return 2
+    return 3
+
+
+def _store_fspath(store: StoreLike) -> Path | None:
+    """Best-effort local filesystem path for ``store``, else ``None``.
+
+    Used only to detect input/output aliasing. Remote and in-memory stores
+    return ``None`` and are therefore treated as distinct unless they are the
+    very same object.
+    """
+    if isinstance(store, (str, Path)):
+        if _is_remote_store(str(store)):
+            return None
+        return Path(store).resolve()
+    if _is_remote_store(store):
+        return None
+    for attr in ("root", "path"):
+        val = getattr(store, attr, None)
+        if isinstance(val, (str, Path)):
+            return Path(val).resolve()
+    dir_path = getattr(store, "dir_path", None)
+    if callable(dir_path):
+        try:
+            return Path(dir_path()).resolve()
+        except Exception:
+            return None
+    return None
+
+
+def _stores_are_same(input: StoreLike, output: StoreLike | None) -> bool:
+    """Whether ``output`` designates the same store as ``input``.
+
+    ``output is None`` always means "same store" (an in-place request). Two
+    string/URL forms are compared directly; local paths are compared by their
+    resolved filesystem path so ``foo`` and ``./foo/`` match.
+    """
+    if output is None or input is output:
+        return True
+    if isinstance(input, (str, Path)) and isinstance(output, (str, Path)):
+        in_s, out_s = str(input), str(output)
+        if _is_remote_store(in_s) or _is_remote_store(out_s):
+            return in_s.rstrip("/") == out_s.rstrip("/")
+    in_path = _store_fspath(input)
+    out_path = _store_fspath(output)
+    return in_path is not None and in_path == out_path
+
+
+def _resolve_write_store(store: StoreLike, storage_options: dict | None) -> StoreLike:
+    """Wrap a remote URL output in an ``FsspecStore`` when needed.
+
+    ``to_ome_zarr`` has no ``storage_options`` parameter, so a remote output URL
+    combined with ``storage_options`` is resolved to a store object here, exactly
+    as ``from_ome_zarr`` resolves remote inputs. Local and in-memory stores pass
+    through unchanged.
+    """
+    if (
+        isinstance(store, str)
+        and storage_options is not None
+        and store.startswith(REMOTE_URL_SCHEMES)
+        and zarr_version_major >= 3
+        and hasattr(zarr.storage, "FsspecStore")
+    ):
+        return zarr.storage.FsspecStore.from_url(store, storage_options=storage_options)
+    return store
+
+
+def _read_root_attrs(store: StoreLike, storage_options: dict | None) -> dict:
+    """Read the root-group attributes of ``store`` without loading arrays.
+
+    Mirrors the auto-detection (and Zarr v2 fallback) that ``from_ome_zarr``
+    performs internally: a Zarr v2 (OME-Zarr 0.4) store opened without an
+    explicit format on zarr-python 3 yields an empty root, so it is retried as
+    Zarr v2. Used for both source-version detection and HCS/container rejection.
+    """
+    open_store = store
+    if (
+        isinstance(store, str)
+        and storage_options is not None
+        and store.startswith(REMOTE_URL_SCHEMES)
+        and zarr_version_major >= 3
+        and hasattr(zarr.storage, "FsspecStore")
+    ):
+        open_store = zarr.storage.FsspecStore.from_url(
+            store, storage_options=storage_options
+        )
+
+    def _attrs(**kwargs) -> dict:
+        try:
+            return zarr.open_group(open_store, mode="r", **kwargs).attrs.asdict()
+        except zarr.errors.GroupNotFoundError:
+            # No group in the requested Zarr format -- e.g. a Zarr v2 (OME-Zarr
+            # 0.4) store opened without an explicit format on zarr-python 3.
+            # Signal "not found in this format" so the caller can retry as Zarr
+            # v2; genuine failures (missing, corrupt, or permission-restricted
+            # stores) propagate instead of being masked as an empty-attrs
+            # version-detection error.
+            return {}
+
+    root_attrs = _attrs()
+    if not root_attrs and zarr_version_major >= 3:
+        root_attrs = _attrs(zarr_format=2)
+
+    return root_attrs
+
+
+def _read_source_version(store: StoreLike, storage_options: dict | None) -> str:
+    """Detect the on-disk OME-Zarr version string of ``store``.
+
+    ``from_ome_zarr`` always normalizes the metadata it returns to v0.6, so the
+    original version cannot be recovered from the returned object. It is read
+    here straight from the root attributes.
+    """
+    from .parse_metadata import _detect_version
+
+    return _detect_version(_read_root_attrs(store, storage_options)).value
+
+
+def _validate_target_version(target_version: str, requested: str | NgffVersion) -> None:
+    """Reject a target ``version`` that ``upgrade_ome_zarr`` cannot produce.
+
+    ``NgffVersion`` also admits the pre-0.4 drafts (0.1--0.3) that live in
+    ``SUPPORTED_VERSIONS`` for read compatibility, but the metadata
+    ``to_version`` chains only convert among 0.4/0.5/0.6. Fail early with an
+    actionable message rather than deep in a conversion.
+    """
+    if target_version not in ("0.4", "0.5", "0.6"):
+        raise ValueError(
+            f"Unsupported target version {requested!r}. upgrade_ome_zarr() can "
+            "upgrade to OME-Zarr 0.4, 0.5, or 0.6."
+        )
+
+
+def _reject_plate_or_container(root_attrs: dict) -> None:
+    """Reject an HCS plate root or bioformats2raw container root.
+
+    ``upgrade_ome_zarr`` upgrades a single image. Whole-plate / whole-container
+    upgrades are out of scope for this effort: each contained image is upgraded
+    by pointing at its own path. This reuses the same detection predicates
+    ``from_ome_zarr`` relies on so the two agree on what a plate/container is.
+    """
+    from .parse_metadata import _is_bioformats2raw, _is_hcs_plate
+
+    if _is_hcs_plate(root_attrs):
+        raise ValueError(
+            "The input is an HCS (High Content Screening) plate root. "
+            "upgrade_ome_zarr() upgrades one image at a time; upgrade each "
+            "well/field image by its own path (e.g. 'plate.ome.zarr/A/1/0'). "
+            "Whole-plate upgrades are out of scope."
+        )
+    if _is_bioformats2raw(root_attrs):
+        raise ValueError(
+            "The input is a bioformats2raw container root. "
+            "upgrade_ome_zarr() upgrades one image at a time; upgrade each "
+            "contained image by its own path (e.g. 'container.ome.zarr/0'). "
+            "Whole-container upgrades are out of scope."
+        )
+
+
+def _upgrade_in_place(
+    store: StoreLike,
+    multiscales: NgffMultiscales,
+    target_version: str,
+    target_zarr_format: int,
+) -> None:
+    """Rewrite only the root-group metadata of ``store`` to ``target_version``.
+
+    Opens the existing root group for read/write (``mode="a"``) so the array
+    chunks are never rewritten -- the crux of the issue #219 fix. Calling
+    ``to_ome_zarr(..., overwrite=True)`` on the source instead would erase those
+    arrays.
+    """
+    root = zarr.open_group(store, mode="a", zarr_format=target_zarr_format)
+
+    # Convert the already-read metadata to the target version, preserving the
+    # existing ``type``/``metadata``/``omero`` fields. ``_prepare_metadata`` is
+    # deliberately avoided: it resets ``type``/``metadata`` to ``None`` for any
+    # store whose method type is not a recognized ``Methods`` value.
+    new_metadata = multiscales.metadata.to_version(target_version)
+    metadata_dict = asdict(new_metadata)
+    metadata_dict = _pop_metadata_optionals(metadata_dict)
+    metadata_dict["@type"] = "ngff:Image"
+
+    _write_root_ome_attrs(root, metadata_dict, target_version)
+
+
+def _parent_group_paths(array_paths: list[str]) -> list[str]:
+    """Return every intermediate group path implied by ``array_paths``.
+
+    For a dataset laid out at ``scale0/image`` the intermediate group
+    ``scale0`` must gain a Zarr v3 ``zarr.json`` (and keep its ``.zattrs`` such
+    as ``_ARRAY_DIMENSIONS``). Flat arrays (``"0"``) imply no intermediate
+    group. Returned sorted so parents precede children.
+    """
+    groups: set[str] = set()
+    for path in array_paths:
+        parts = PurePosixPath(path).parts
+        for i in range(1, len(parts)):
+            groups.add("/".join(parts[:i]))
+    return sorted(groups)
+
+
+def _delete_v2_sidecars(store: StoreLike) -> None:
+    """Delete the Zarr v2 metadata sidecars from ``store``, sparing chunks.
+
+    Removes every ``.zgroup``/``.zattrs``/``.zarray``/``.zmetadata`` key so the
+    store is cleanly Zarr v3. Chunk data files never begin with a dot, so they
+    are never matched. Filesystem-backed stores are pruned by ``unlink``;
+    other stores (e.g. ``MemoryStore``) go through the async store API, the
+    same pattern used by ``rfc9_zip``.
+    """
+    sidecar_names = {".zgroup", ".zattrs", ".zarray", ".zmetadata"}
+
+    fspath = _store_fspath(store)
+    if fspath is not None and fspath.is_dir():
+        for path in fspath.rglob("*"):
+            if path.is_file() and path.name in sidecar_names:
+                path.unlink()
+        return
+
+    # A string/Path that is not an existing directory: nothing to prune.
+    if isinstance(store, (str, Path)):
+        return
+
+    import asyncio
+
+    async def _prune() -> None:
+        keys = [key async for key in store.list()]
+        for key in keys:
+            if key.rsplit("/", 1)[-1] in sidecar_names:
+                await store.delete(key)
+
+    try:
+        asyncio.run(_prune())
+    except RuntimeError as exc:
+        if "running event loop" not in str(exc):
+            raise
+        raise RuntimeError(
+            "In-place cross-format upgrade of an in-memory store is not "
+            "supported from within a running event loop (e.g. a Jupyter "
+            "notebook). Pass an `output` store to use the write-to-new-store "
+            "path instead."
+        ) from exc
+
+
+def _rewrite_v2_group_to_v3(
+    store: StoreLike,
+    new_metadata,
+    target_version: str,
+) -> None:
+    """Rewrite a Zarr v2 (OME-Zarr 0.4) group to Zarr v3 in place, keeping chunks.
+
+    Each array's chunk binaries are left exactly where they are: the new Zarr v3
+    ``zarr.json`` is given a ``v2`` ``chunk_key_encoding`` whose separator equals
+    the source array's ``dimension_separator``, so the pre-existing chunk keys
+    (e.g. ``0/0/0/0`` or ``0.0.0.0``) resolve unchanged. Only metadata is written
+    or removed; no chunk file is ever moved, rewritten, or deleted. This is the
+    cross-format analogue of the in-place issue #219 fix.
+
+    An array whose Zarr v2 encoding cannot be faithfully represented in Zarr v3
+    (Fortran memory order, filters, or a compressor with no v3 codec equivalent)
+    raises ``ValueError`` naming the array, rather than silently corrupting data;
+    the caller is directed to write-to-new-store instead.
+    """
+    import warnings
+
+    dim_names = list(new_metadata.dimension_names)
+    array_paths = [dataset.path for dataset in new_metadata.datasets]
+
+    # --- Read phase: capture all Zarr v2 metadata before writing anything. ---
+    array_specs: list[dict] = []
+    for path in array_paths:
+        source = zarr.open_array(store, path=path, mode="r", zarr_format=2)
+        meta = source.metadata
+
+        order = getattr(meta, "order", "C")
+        if order == "F":
+            raise ValueError(
+                f"Array '{path}' uses Fortran ('F') memory order, which an "
+                "in-place Zarr v2->v3 metadata rewrite cannot preserve without "
+                "rewriting chunks. Pass an `output` store to write a new upgraded "
+                "copy instead."
+            )
+
+        filters = getattr(meta, "filters", None)
+        if filters:
+            raise ValueError(
+                f"Array '{path}' declares Zarr v2 filters ({filters!r}) that have "
+                "no faithful Zarr v3 codec equivalent for an in-place rewrite. "
+                "Pass an `output` store to write a new upgraded copy instead."
+            )
+
+        compressor = getattr(meta, "compressor", None)
+        if compressor is None:
+            # No compression: emit only the (implicit) bytes codec. Passing
+            # ``compressors=None`` avoids create_array's default zstd, which
+            # would misread the raw chunk bytes.
+            compressors = None
+        else:
+            v3_codec = _numcodecs_to_zarr_v3_codec(compressor)
+            if v3_codec is None:
+                raise ValueError(
+                    f"Array '{path}' uses compressor {compressor!r}, which has no "
+                    "faithful Zarr v3 codec equivalent. Pass an `output` store to "
+                    "write a new upgraded copy instead."
+                )
+            compressors = [v3_codec]
+
+        separator = getattr(meta, "dimension_separator", None) or "."
+        array_specs.append(
+            {
+                "path": path,
+                "shape": source.shape,
+                "chunks": source.chunks,
+                "dtype": source.dtype,
+                "fill_value": meta.fill_value,
+                "separator": separator,
+                "compressors": compressors,
+                "attrs": dict(source.attrs),
+            }
+        )
+
+    group_paths = _parent_group_paths(array_paths)
+    group_attrs: dict[str, dict] = {}
+    for group_path in group_paths:
+        try:
+            source_group = zarr.open_group(
+                store, path=group_path, mode="r", zarr_format=2
+            )
+            group_attrs[group_path] = dict(source_group.attrs)
+        except Exception:
+            group_attrs[group_path] = {}
+
+    # --- Write phase: materialize the Zarr v3 hierarchy. Chunks are untouched. ---
+    root = zarr.open_group(store, mode="a", zarr_format=3)
+
+    for group_path in group_paths:
+        group = zarr.open_group(store, path=group_path, mode="a", zarr_format=3)
+        for key, value in group_attrs[group_path].items():
+            group.attrs[key] = value
+
+    for spec in array_specs:
+        array = root.create_array(
+            name=spec["path"],
+            shape=spec["shape"],
+            chunks=spec["chunks"],
+            dtype=spec["dtype"],
+            fill_value=spec["fill_value"],
+            compressors=spec["compressors"],
+            chunk_key_encoding={
+                "name": "v2",
+                "configuration": {"separator": spec["separator"]},
+            },
+            dimension_names=dim_names,
+            overwrite=False,
+        )
+        for key, value in spec["attrs"].items():
+            array.attrs[key] = value
+
+    # Root OME attributes, exactly as to_ome_zarr / _upgrade_in_place emit them.
+    metadata_dict = asdict(new_metadata)
+    metadata_dict = _pop_metadata_optionals(metadata_dict)
+    metadata_dict["@type"] = "ngff:Image"
+    _write_root_ome_attrs(root, metadata_dict, target_version)
+
+    # Drop the now-obsolete Zarr v2 sidecars; chunk files are left in place.
+    _delete_v2_sidecars(store)
+
+    # Consolidate so the upgraded store matches a freshly written Zarr v3 store.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        zarr.consolidate_metadata(store, zarr_format=3)
+
+
+def upgrade_ome_zarr(
+    input: StoreLike,
+    output: StoreLike | None = None,
+    *,
+    version: str | NgffVersion = "0.6",
+    validate: bool = False,
+    storage_options: dict | None = None,
+    overwrite: bool = True,
+) -> None:
+    """Upgrade an OME-Zarr store to a different specification version.
+
+    :param input: Source store or path to read.
+    :type  input: StoreLike
+
+    :param output: Destination store or path. If ``None`` (or the same store as
+        ``input``), the upgrade is performed in place: only metadata is rewritten
+        and every array chunk on disk is left byte-for-byte untouched (this
+        includes the cross-format 0.4->0.5/0.6 case, which rewrites the array and
+        group metadata to Zarr v3 while preserving chunks). An in-place downgrade
+        across the Zarr v2<->v3 boundary (0.5/0.6->0.4) cannot preserve chunk keys
+        and raises ``ValueError``. If a distinct store, an upgraded copy is
+        written there via the standard write pipeline.
+    :type  output: StoreLike, optional
+
+    :param version: Target OME-Zarr specification version. Accepts a string such
+        as ``"0.6"`` or an ``NgffVersion`` member.
+    :type  version: str or NgffVersion, optional
+
+    :param validate: If ``True``, validate the source metadata against the NGFF
+        schema while reading.
+    :type  validate: bool, optional
+
+    :param storage_options: Storage options for remote ``input``/``output`` URLs
+        (zarr-python 3+).
+    :type  storage_options: dict, optional
+
+    :param overwrite: For the write-to-new-store mode, whether to overwrite any
+        pre-existing data at ``output``. Ignored for in-place upgrades, which
+        never overwrite array data.
+    :type  overwrite: bool, optional
+
+    :return: ``None``. The upgraded metadata is written to ``output`` (or, for an
+        in-place upgrade, back to ``input``).
+    """
+    from .parse_metadata import _detect_version
+
+    target_version = _normalize_target_version(version)
+    _validate_target_version(target_version, version)
+    target_zarr_format = _zarr_format_for_version(target_version)
+
+    root_attrs = _read_root_attrs(input, storage_options)
+    # Whole-plate / whole-container upgrades are out of scope; reject early with
+    # guidance toward the per-image path form.
+    _reject_plate_or_container(root_attrs)
+
+    source_version = _detect_version(root_attrs).value
+    source_zarr_format = _zarr_format_for_version(source_version)
+    same_store = _stores_are_same(input, output)
+
+    # No-op: the source spec version already equals the requested target.
+    # Normalize both to the API version so an on-disk "0.6.dev4" matches a
+    # requested "0.6".
+    if _normalize_target_version(source_version) == target_version and same_store:
+        # In-place no-op: leave the store bit-for-bit unchanged (no read, no
+        # write). When an ``output`` is given for a same-version request we fall
+        # through instead, so the user still gets their requested new store.
+        return
+
+    # Read the source once, using the detected version so the correct parser and
+    # Zarr format are selected. The returned metadata is normalized to v0.6.
+    multiscales = from_ome_zarr(
+        input,
+        validate=validate,
+        version=source_version,
+        storage_options=storage_options,
+    )
+
+    if same_store:
+        if source_zarr_format == target_zarr_format:
+            # Same underlying Zarr format (0.5<->0.6): rewrite only root metadata.
+            _upgrade_in_place(input, multiscales, target_version, target_zarr_format)
+        elif source_zarr_format == 2 and target_zarr_format == 3:
+            # Cross-format upgrade (0.4 -> 0.5/0.6): rewrite array + group
+            # metadata to Zarr v3 while preserving every chunk file on disk.
+            new_metadata = multiscales.metadata.to_version(target_version)
+            _rewrite_v2_group_to_v3(input, new_metadata, target_version)
+        else:
+            # Cross-format downgrade (0.5/0.6 -> 0.4) in place: Zarr v3 default
+            # chunk keys differ from Zarr v2, so chunks cannot be preserved.
+            raise ValueError(
+                "In-place downgrade across the Zarr v2<->v3 boundary "
+                f"(OME-Zarr {source_version} -> {target_version}) cannot preserve "
+                "chunk files: Zarr v3 chunk keys differ from Zarr v2. Pass an "
+                "`output` store to write a new downgraded copy safely."
+            )
+        return
+
+    # Write-to-new-store: reuse the tested read/write pipeline. ``to_ome_zarr``
+    # re-derives the target-version metadata and streams the source arrays
+    # lazily, so all supported transitions work and the source is never erased.
+    output_store = _resolve_write_store(output, storage_options)
+    to_ome_zarr(
+        output_store,
+        multiscales,
+        version=target_version,
+        overwrite=overwrite,
+    )

--- a/py/test/test_cli_upgrade.py
+++ b/py/test/test_cli_upgrade.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Tests for the ``ngff-zarr upgrade`` CLI subcommand (Phase 3).
+
+The subcommand is exercised end-to-end through the same subprocess mechanism
+the other ``test_cli_*.py`` modules use, so the non-breaking ``main()``
+dispatch, argument parsing, and Rich feedback are all covered as a user would
+hit them. Every store is synthesized in memory/on tmp_path -- no pooch
+downloads and no network access.
+"""
+
+import os
+import subprocess
+import sys
+
+import numpy as np
+import packaging.version
+import pytest
+import zarr
+from ngff_zarr import to_multiscales, to_ngff_image, to_ome_zarr
+
+zarr_version = packaging.version.parse(zarr.__version__)
+
+# OME-Zarr >= 0.5 requires the Zarr v3 support added in zarr-python 3.0.0b1.
+pytestmark = pytest.mark.skipif(
+    zarr_version < packaging.version.parse("3.0.0b1"),
+    reason="zarr version < 3.0.0b1",
+)
+
+# The on-disk ``ome.version`` string each API version is written as.
+DISK_VERSION = {"0.4": "0.4", "0.5": "0.5", "0.6": "0.6.dev4"}
+
+# Metadata sidecars across Zarr v2 and v3, excluded when isolating chunk data.
+_METADATA_NAMES = {"zarr.json", ".zarray", ".zattrs", ".zgroup", ".zmetadata"}
+
+
+def _run_ngff_zarr(*args):
+    """Run the ngff-zarr CLI as a subprocess and return the result."""
+    cmd = [
+        sys.executable,
+        "-c",
+        "from ngff_zarr.cli import main; main()",
+    ] + list(args)
+    env = {**os.environ, "PYTHONIOENCODING": "utf-8"}
+    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+
+def _synth_multiscales():
+    """Build a small in-memory 2-level multiscales plus its source pixels."""
+    rng = np.random.default_rng(0)
+    data = rng.integers(0, 255, size=(1, 4, 32, 32), dtype=np.uint8)
+    image = to_ngff_image(data, dims=("c", "z", "y", "x"))
+    return to_multiscales(image, scale_factors=[2]), data
+
+
+def _write_source(store, version_str):
+    """Write a fresh synthesized multiscales to ``store`` at ``version_str``."""
+    multiscales, data = _synth_multiscales()
+    to_ome_zarr(store, multiscales, version=version_str)
+    return data
+
+
+def _chunk_files(root):
+    """Map each chunk *data* file to ``(size, mtime_ns, bytes)``.
+
+    Metadata sidecars are excluded so the result holds only chunk data whose
+    immutability we assert across an in-place upgrade.
+    """
+    files = {}
+    for path in root.rglob("*"):
+        if path.is_file() and path.name not in _METADATA_NAMES:
+            stat = path.stat()
+            files[path.relative_to(root).as_posix()] = (
+                stat.st_size,
+                stat.st_mtime_ns,
+                path.read_bytes(),
+            )
+    return files
+
+
+def _all_files_digest(root):
+    """Map every file under ``root`` to its size + bytes (order-independent)."""
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def test_in_place_upgrade_0_5_to_0_6(tmp_path):
+    """In-place 0.5 -> 0.6 rewrites metadata only; chunk files are untouched."""
+    store = tmp_path / "image.ome.zarr"
+    _write_source(str(store), "0.5")
+    chunks_before = _chunk_files(store)
+    assert chunks_before, "expected chunk data files in the source store"
+
+    result = _run_ngff_zarr("upgrade", str(store), "--to", "0.6")
+    assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+    # The on-disk spec version was bumped to the 0.6 development string.
+    root = zarr.open_group(str(store), mode="r", zarr_format=3)
+    assert root.attrs["ome"]["version"] == DISK_VERSION["0.6"]
+
+    # Every array chunk file is byte-identical and unmodified.
+    chunks_after = _chunk_files(store)
+    assert set(chunks_after) == set(chunks_before)
+    for rel, sig in chunks_before.items():
+        assert chunks_after[rel] == sig, f"array chunk file changed: {rel}"
+
+    # The Rich summary names the mode and reassures about the chunks. Collapse
+    # whitespace first: Rich soft-wraps the summary to the (non-TTY) console
+    # width, which can split the message mid-phrase when the input path is long
+    # (e.g. on the Windows CI runner), so assert against width-independent text.
+    summary = " ".join(result.stdout.split())
+    assert "in-place" in summary
+    assert "chunks left untouched" in summary
+
+
+def test_write_to_new_store_0_4_to_0_5(tmp_path):
+    """0.4 -> 0.5 written to a new store; the source is left unchanged."""
+    from ngff_zarr import from_ome_zarr
+
+    src = tmp_path / "source.ome.zarr"
+    dst = tmp_path / "target.ome.zarr"
+    data = _write_source(str(src), "0.4")
+    source_before = _all_files_digest(src)
+
+    result = _run_ngff_zarr("upgrade", str(src), "-o", str(dst), "--to", "0.5")
+    assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+    # The destination reads back validated at 0.5 with equal pixels.
+    dst_root = zarr.open_group(str(dst), mode="r", zarr_format=3)
+    assert dst_root.attrs["ome"]["version"] == DISK_VERSION["0.5"]
+    reloaded = from_ome_zarr(str(dst), version="0.5", validate=True)
+    np.testing.assert_array_equal(reloaded.images[0].data.compute(), data)
+
+    # The source store is completely unchanged.
+    assert _all_files_digest(src) == source_before
+
+
+def test_in_place_cross_format_downgrade_exits_nonzero(tmp_path):
+    """0.6 -> 0.4 in place is rejected with guidance and a non-zero exit code."""
+    store = tmp_path / "image.ome.zarr"
+    _write_source(str(store), "0.6")
+    chunks_before = _chunk_files(store)
+
+    result = _run_ngff_zarr("upgrade", str(store), "--to", "0.4")
+    assert result.returncode != 0
+
+    # A concise, actionable message (not a traceback) directs the user to
+    # write to a new output store.
+    combined = result.stdout + result.stderr
+    assert "output" in combined
+    assert "Traceback" not in combined
+
+    # The rejected downgrade left the store untouched.
+    assert _chunk_files(store) == chunks_before
+
+
+def test_invalid_target_version_rejected(tmp_path):
+    """An unsupported --to value is rejected by argparse choices (exit != 0)."""
+    store = tmp_path / "image.ome.zarr"
+    _write_source(str(store), "0.5")
+
+    result = _run_ngff_zarr("upgrade", str(store), "--to", "9.9")
+    assert result.returncode != 0
+    assert "9.9" in (result.stdout + result.stderr)
+
+
+def test_upgrade_help_mentions_both_modes():
+    """``ngff-zarr upgrade --help`` runs and describes both upgrade modes."""
+    result = _run_ngff_zarr("upgrade", "--help")
+    assert result.returncode == 0
+
+    # Collapse wrapping so phrases split across lines still match.
+    help_text = " ".join(result.stdout.split())
+    assert "in-place" in help_text
+    assert "new store" in help_text
+    assert "--output" in help_text
+
+
+def test_non_upgrade_invocation_routes_to_flat_parser():
+    """A non-``upgrade`` first token still hits the flat conversion parser.
+
+    Network-free: we only need to prove the dispatch fell through to the flat
+    parser, which is demonstrated by its own required-argument enforcement.
+    """
+    # ``-o`` without ``-i`` reaches the flat parser, which rejects it because
+    # ``-i/--input`` is required -- exactly as before the subcommand dispatch.
+    result = _run_ngff_zarr("-o", "unused.ome.zarr")
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "-i" in combined or "--input" in combined
+    assert "Traceback" not in combined
+
+
+def test_no_args_produces_sensible_output():
+    """``ngff-zarr`` with no args yields the flat parser's usage, not a crash."""
+    result = _run_ngff_zarr()
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "usage" in combined.lower() or "--input" in combined
+    assert "Traceback" not in combined

--- a/py/test/test_upgrade_ome_zarr.py
+++ b/py/test/test_upgrade_ome_zarr.py
@@ -1,0 +1,489 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+"""Tests for :func:`ngff_zarr.upgrade_ome_zarr` (Phases 1 & 2).
+
+Every fixture is synthesized in memory -- no pooch downloads and no network
+access -- so these tests exercise the core upgrade behavior in isolation.
+
+Phase 1 covered same-Zarr-format in-place upgrades (0.5<->0.6) and
+write-to-new-store for everything. Phase 2 adds the cross-format in-place
+upgrade over the Zarr v2<->v3 boundary (0.4->0.5, 0.4->0.6) -- a metadata-only
+rewrite that leaves every chunk file byte-for-byte in place -- plus a full
+(source, target) x (mode) matrix, no-op short-circuiting, metadata
+preservation, and input hardening (unsupported versions, aliasing, HCS roots).
+"""
+
+import hashlib
+from pathlib import Path
+
+import numpy as np
+import pytest
+import zarr
+import zarr.storage
+from ngff_zarr import (
+    from_ome_zarr,
+    to_multiscales,
+    to_ngff_image,
+    to_ome_zarr,
+    upgrade_ome_zarr,
+)
+from ngff_zarr.v04.zarr_metadata import Omero, OmeroChannel, OmeroWindow
+from packaging import version
+
+zarr_version = version.parse(zarr.__version__)
+
+# Skip when zarr predates the v3 support required for OME-Zarr >= 0.5.
+pytestmark = pytest.mark.skipif(
+    zarr_version < version.parse("3.0.0b1"), reason="zarr version < 3.0.0b1"
+)
+
+# The on-disk ``ome.version`` string a given API version is written as.
+DISK_VERSION = {"0.4": "0.4", "0.5": "0.5", "0.6": "0.6.dev4"}
+
+# Every metadata sidecar name across Zarr v2 and v3, so ``_chunk_files`` can
+# isolate the true chunk *data* whose immutability we assert across an upgrade.
+_METADATA_NAMES = {"zarr.json", ".zarray", ".zattrs", ".zgroup", ".zmetadata"}
+
+
+def _synth_multiscales():
+    """Build a small in-memory 2-level multiscales plus its source pixels."""
+    rng = np.random.default_rng(0)
+    data = rng.integers(0, 255, size=(1, 4, 32, 32), dtype=np.uint8)
+    image = to_ngff_image(data, dims=("c", "z", "y", "x"))
+    return to_multiscales(image, scale_factors=[2]), data
+
+
+def _chunk_files(root: Path) -> dict:
+    """Map each chunk *data* file to ``(size, mtime_ns, bytes)``.
+
+    Metadata files (Zarr v2 ``.z*`` sidecars and Zarr v3 ``zarr.json``) are
+    excluded so the result holds only chunk data whose immutability we assert.
+    """
+    files = {}
+    for path in root.rglob("*"):
+        if path.is_file() and path.name not in _METADATA_NAMES:
+            stat = path.stat()
+            files[path.relative_to(root).as_posix()] = (
+                stat.st_size,
+                stat.st_mtime_ns,
+                path.read_bytes(),
+            )
+    return files
+
+
+def _all_files_digest(root: Path) -> dict:
+    """Map every file under ``root`` to its sha256 digest (order-independent)."""
+    return {
+        path.relative_to(root).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def _write_source(store, version_str: str):
+    """Write a fresh synthesized multiscales to ``store`` at ``version_str``."""
+    multiscales, data = _synth_multiscales()
+    to_ome_zarr(store, multiscales, version=version_str)
+    return data
+
+
+def _leftover_v2_sidecars(root: Path) -> list:
+    return [
+        p.relative_to(root).as_posix()
+        for p in root.rglob("*")
+        if p.name in {".zarray", ".zattrs", ".zgroup", ".zmetadata"}
+    ]
+
+
+def _disk_ome_version(store_path, api_version: str) -> str:
+    """Read the on-disk spec version, honoring where each format records it.
+
+    v0.4 (Zarr v2) keeps it in ``multiscales[0].version`` at the root; v0.5+
+    (Zarr v3) keeps it in the ``ome`` namespace.
+    """
+    if api_version == "0.4":
+        root = zarr.open_group(str(store_path), mode="r", zarr_format=2)
+        return root.attrs["multiscales"][0]["version"]
+    root = zarr.open_group(str(store_path), mode="r", zarr_format=3)
+    return root.attrs["ome"]["version"]
+
+
+# --------------------------------------------------------------------------- #
+# Phase 1 behavior (retained)
+# --------------------------------------------------------------------------- #
+
+
+def test_in_place_0_5_to_0_6(tmp_path):
+    multiscales, data = _synth_multiscales()
+    store_path = str(tmp_path / "image.ome.zarr")
+    to_ome_zarr(store_path, multiscales, version="0.5")
+
+    root_before = zarr.open_group(store_path, mode="r")
+    assert root_before.attrs["ome"]["version"] == "0.5"
+    chunks_before = _chunk_files(tmp_path)
+    assert chunks_before, "expected chunk data files in the source store"
+
+    upgrade_ome_zarr(store_path, version="0.6")
+
+    root_after = zarr.open_group(store_path, mode="r")
+    assert root_after.attrs["ome"]["version"] == "0.6.dev4"
+
+    # Array chunk files are byte-identical and unmodified (path, size, mtime,
+    # and content) -- only the root group metadata was rewritten.
+    chunks_after = _chunk_files(tmp_path)
+    assert set(chunks_after) == set(chunks_before)
+    for rel, sig in chunks_before.items():
+        assert chunks_after[rel] == sig, f"array chunk file changed: {rel}"
+
+    reloaded = from_ome_zarr(store_path, version="0.6", validate=True)
+    ms0 = root_after.attrs["ome"]["multiscales"][0]
+    assert "coordinateSystems" in ms0
+    np.testing.assert_array_equal(reloaded.images[0].data.compute(), data)
+
+
+# --------------------------------------------------------------------------- #
+# Phase 2: in-place same-format (0.5 <-> 0.6) -- chunks byte-identical
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "source_version, target_version",
+    [("0.5", "0.6"), ("0.6", "0.5")],
+)
+def test_in_place_same_format_preserves_chunks(
+    tmp_path, source_version, target_version
+):
+    store_path = str(tmp_path / "image.ome.zarr")
+    data = _write_source(store_path, source_version)
+    chunks_before = _chunk_files(tmp_path)
+    assert chunks_before
+
+    upgrade_ome_zarr(store_path, version=target_version)
+
+    chunks_after = _chunk_files(tmp_path)
+    assert set(chunks_after) == set(chunks_before)
+    for rel, sig in chunks_before.items():
+        assert chunks_after[rel] == sig, f"chunk changed: {rel}"
+
+    root_after = zarr.open_group(store_path, mode="r")
+    assert root_after.attrs["ome"]["version"] == DISK_VERSION[target_version]
+    reloaded = from_ome_zarr(store_path, version=target_version, validate=True)
+    np.testing.assert_array_equal(reloaded.images[0].data.compute(), data)
+
+
+# --------------------------------------------------------------------------- #
+# Phase 2: in-place cross-format upgrade (0.4 -> 0.5, 0.4 -> 0.6)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("target_version", ["0.5", "0.6"])
+def test_in_place_cross_format_upgrade_preserves_chunks(tmp_path, target_version):
+    store_path = str(tmp_path / "image_v04.ome.zarr")
+    data = _write_source(store_path, "0.4")
+
+    chunks_before = _chunk_files(tmp_path)
+    assert chunks_before, "expected chunk data files in the v0.4 source store"
+
+    upgrade_ome_zarr(store_path, version=target_version)
+
+    # Chunk data files are byte-identical (path, size, mtime, content): the
+    # rewrite only rewrote metadata and never touched a chunk binary.
+    chunks_after = _chunk_files(tmp_path)
+    assert set(chunks_after) == set(chunks_before)
+    for rel, sig in chunks_before.items():
+        assert chunks_after[rel] == sig, f"chunk changed: {rel}"
+
+    # The store is cleanly Zarr v3: no v2 sidecars remain, and it opens as v3.
+    assert _leftover_v2_sidecars(tmp_path) == []
+    root = zarr.open_group(store_path, mode="r", zarr_format=3)
+    assert root.attrs["ome"]["version"] == DISK_VERSION[target_version]
+
+    # It reads back validated at the requested version with equal pixels.
+    reloaded = from_ome_zarr(store_path, version=target_version, validate=True)
+    np.testing.assert_array_equal(reloaded.images[0].data.compute(), data)
+
+
+def test_in_place_cross_format_upgrade_dot_separator(tmp_path):
+    """A v0.4 store using the Zarr v2 '.' chunk separator upgrades in place."""
+    store_path = str(tmp_path / "dot.ome.zarr")
+    group = zarr.open_group(store_path, mode="w", zarr_format=2)
+    payload = np.arange(1 * 2 * 8 * 8, dtype="uint16").reshape(1, 2, 8, 8)
+    arr = group.create_array(
+        name="0",
+        shape=payload.shape,
+        chunks=(1, 1, 8, 8),
+        dtype="uint16",
+        chunk_key_encoding={"name": "v2", "separator": "."},
+    )
+    arr[:] = payload
+    group.attrs["multiscales"] = [
+        {
+            "version": "0.4",
+            "name": "image",
+            "axes": [
+                {"name": "c", "type": "channel"},
+                {"name": "z", "type": "space"},
+                {"name": "y", "type": "space"},
+                {"name": "x", "type": "space"},
+            ],
+            "datasets": [
+                {
+                    "path": "0",
+                    "coordinateTransformations": [
+                        {"type": "scale", "scale": [1.0, 1.0, 1.0, 1.0]}
+                    ],
+                }
+            ],
+        }
+    ]
+
+    chunks_before = _chunk_files(tmp_path)
+    # Confirm the '.'-separated chunk keys were actually written.
+    assert any("." in Path(rel).name for rel in chunks_before), chunks_before
+
+    upgrade_ome_zarr(store_path, version="0.5")
+
+    chunks_after = _chunk_files(tmp_path)
+    assert set(chunks_after) == set(chunks_before)
+    for rel, sig in chunks_before.items():
+        assert chunks_after[rel] == sig, f"chunk changed: {rel}"
+    assert _leftover_v2_sidecars(tmp_path) == []
+
+    reloaded = from_ome_zarr(store_path, version="0.5", validate=True)
+    np.testing.assert_array_equal(reloaded.images[0].data.compute(), payload)
+
+
+# --------------------------------------------------------------------------- #
+# Phase 2: in-place cross-format downgrade (0.5 -> 0.4, 0.6 -> 0.4) is rejected
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("source_version", ["0.5", "0.6"])
+def test_in_place_cross_format_downgrade_raises(tmp_path, source_version):
+    store_path = str(tmp_path / "image.ome.zarr")
+    _write_source(store_path, source_version)
+    chunks_before = _chunk_files(tmp_path)
+
+    with pytest.raises(ValueError, match="output"):
+        upgrade_ome_zarr(store_path, version="0.4")
+
+    # The failed downgrade left the store untouched.
+    assert _chunk_files(tmp_path) == chunks_before
+
+
+# --------------------------------------------------------------------------- #
+# Phase 2: in-place same-version no-op leaves the store bit-for-bit unchanged
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("version_str", ["0.4", "0.5", "0.6"])
+def test_in_place_noop_is_bit_for_bit(tmp_path, version_str):
+    store_path = str(tmp_path / "image.ome.zarr")
+    _write_source(store_path, version_str)
+    digest_before = _all_files_digest(tmp_path)
+
+    upgrade_ome_zarr(store_path, version=version_str)
+
+    assert _all_files_digest(tmp_path) == digest_before
+
+
+# --------------------------------------------------------------------------- #
+# Phase 2: write-to-new-store for the full ordered version matrix
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("source_version", ["0.4", "0.5", "0.6"])
+@pytest.mark.parametrize("target_version", ["0.4", "0.5", "0.6"])
+def test_write_to_new_store_matrix(tmp_path, source_version, target_version):
+    source_path = tmp_path / "source.ome.zarr"
+    target_path = tmp_path / "target.ome.zarr"
+    data = _write_source(str(source_path), source_version)
+
+    source_before = _all_files_digest(source_path)
+
+    upgrade_ome_zarr(str(source_path), str(target_path), version=target_version)
+
+    # The source store is left completely unchanged.
+    assert _all_files_digest(source_path) == source_before
+
+    # The new store reads back validated at the requested version, pixels equal.
+    assert (
+        _disk_ome_version(target_path, target_version) == DISK_VERSION[target_version]
+    )
+    reloaded = from_ome_zarr(str(target_path), version=target_version, validate=True)
+    np.testing.assert_array_equal(reloaded.images[0].data.compute(), data)
+
+
+def test_write_to_new_store_memory():
+    """Write-to-new-store also works store-to-store in memory (no filesystem)."""
+    multiscales, data = _synth_multiscales()
+    source = zarr.storage.MemoryStore()
+    to_ome_zarr(source, multiscales, version="0.4")
+
+    target = zarr.storage.MemoryStore()
+    upgrade_ome_zarr(source, target, version="0.6")
+
+    root_target = zarr.open_group(target, mode="r")
+    assert root_target.attrs["ome"]["version"] == "0.6.dev4"
+    reloaded = from_ome_zarr(target, version="0.6", validate=True)
+    np.testing.assert_array_equal(reloaded.images[0].data.compute(), data)
+
+    # Source still readable at its own version: never erased.
+    source_reloaded = from_ome_zarr(source, version="0.4", validate=True)
+    np.testing.assert_array_equal(source_reloaded.images[0].data.compute(), data)
+
+
+# --------------------------------------------------------------------------- #
+# Phase 2: non-geometry metadata (OMERO, name) survives an upgrade
+# --------------------------------------------------------------------------- #
+
+
+def _with_omero_and_name(multiscales):
+    multiscales.metadata.name = "my special image"
+    multiscales.metadata.omero = Omero(
+        channels=[
+            OmeroChannel(
+                color="00FF00",
+                window=OmeroWindow(min=0, max=255, start=5, end=250),
+                label="green",
+            )
+        ]
+    )
+    return multiscales
+
+
+@pytest.mark.parametrize(
+    "source_version, target_version, mode",
+    [
+        ("0.4", "0.6", "in_place"),
+        ("0.5", "0.6", "in_place"),
+        ("0.4", "0.6", "new_store"),
+    ],
+)
+def test_omero_and_name_round_trip(tmp_path, source_version, target_version, mode):
+    multiscales, _ = _synth_multiscales()
+    _with_omero_and_name(multiscales)
+    source_path = str(tmp_path / "source.ome.zarr")
+    to_ome_zarr(source_path, multiscales, version=source_version)
+
+    if mode == "in_place":
+        upgrade_ome_zarr(source_path, version=target_version)
+        read_path = source_path
+    else:
+        read_path = str(tmp_path / "target.ome.zarr")
+        upgrade_ome_zarr(source_path, read_path, version=target_version)
+
+    root = zarr.open_group(read_path, mode="r")
+    ome = root.attrs["ome"]
+    ms0 = ome["multiscales"][0]
+    assert ms0["name"] == "my special image"
+    # For v0.5+ omero is hoisted next to multiscales inside the ome namespace.
+    omero = ome.get("omero", ms0.get("omero"))
+    assert omero is not None, "omero metadata was dropped by the upgrade"
+    channel = omero["channels"][0]
+    assert channel["label"] == "green"
+    assert channel["color"] == "00FF00"
+
+
+def test_method_metadata_and_orientation_survive_cross_format(tmp_path):
+    """type/method ``metadata`` and RFC-4 orientation survive 0.4 -> 0.5."""
+    rng = np.random.default_rng(2)
+    data = rng.integers(0, 255, size=(1, 4, 32, 32), dtype=np.uint8)
+    image = to_ngff_image(data, dims=("c", "z", "y", "x"))
+    multiscales = to_multiscales(image, scale_factors=[2], orientation="LPS")
+    store_path = str(tmp_path / "image_v04.ome.zarr")
+    to_ome_zarr(store_path, multiscales, version="0.4")
+
+    upgrade_ome_zarr(store_path, version="0.5")
+
+    root = zarr.open_group(store_path, mode="r", zarr_format=3)
+    ms0 = root.attrs["ome"]["multiscales"][0]
+    # Downsampling method type + metadata carried through.
+    assert ms0.get("type") == "itkwasm_gaussian"
+    assert ms0.get("metadata") is not None
+    # RFC-4 anatomical orientation carried onto the axes.
+    assert any("orientation" in axis for axis in ms0["axes"])
+
+
+# --------------------------------------------------------------------------- #
+# Phase 2: focused edge cases
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("bad_version", ["0.3", "0.2", "0.1"])
+def test_unsupported_target_version_raises(tmp_path, bad_version):
+    store_path = str(tmp_path / "image.ome.zarr")
+    _write_source(store_path, "0.5")
+    with pytest.raises(ValueError, match="[Uu]nsupported target version"):
+        upgrade_ome_zarr(store_path, version=bad_version)
+
+
+def test_output_equal_to_input_routes_in_place(tmp_path):
+    """Passing output == input must use the safe in-place path, not erase data."""
+    store_path = str(tmp_path / "image.ome.zarr")
+    data = _write_source(store_path, "0.5")
+    chunks_before = _chunk_files(tmp_path)
+
+    upgrade_ome_zarr(store_path, store_path, version="0.6")
+
+    root_after = zarr.open_group(store_path, mode="r")
+    assert root_after.attrs["ome"]["version"] == "0.6.dev4"
+    chunks_after = _chunk_files(tmp_path)
+    assert set(chunks_after) == set(chunks_before)
+    for rel, sig in chunks_before.items():
+        assert chunks_after[rel] == sig, f"chunk changed: {rel}"
+    reloaded = from_ome_zarr(store_path, version="0.6", validate=True)
+    np.testing.assert_array_equal(reloaded.images[0].data.compute(), data)
+
+
+def test_output_equal_to_input_cross_format(tmp_path):
+    """Aliasing across the v2<->v3 boundary also routes to the in-place rewrite."""
+    store_path = str(tmp_path / "image_v04.ome.zarr")
+    data = _write_source(store_path, "0.4")
+    chunks_before = _chunk_files(tmp_path)
+
+    upgrade_ome_zarr(store_path, store_path, version="0.5")
+
+    chunks_after = _chunk_files(tmp_path)
+    assert set(chunks_after) == set(chunks_before)
+    for rel, sig in chunks_before.items():
+        assert chunks_after[rel] == sig, f"chunk changed: {rel}"
+    assert _leftover_v2_sidecars(tmp_path) == []
+    reloaded = from_ome_zarr(store_path, version="0.5", validate=True)
+    np.testing.assert_array_equal(reloaded.images[0].data.compute(), data)
+
+
+def test_missing_store_surfaces_io_error(tmp_path):
+    """A nonexistent store raises the real I/O error, not a version-detect error.
+
+    Regression guard: the root-attribute reader only swallows the Zarr
+    format-mismatch case (so a v0.4/v2 store can be retried as Zarr v2); a
+    genuine missing/unreadable store must propagate instead of degrading into a
+    generic empty-attributes version-detection failure.
+    """
+    missing = str(tmp_path / "does_not_exist.ome.zarr")
+    with pytest.raises(FileNotFoundError):
+        upgrade_ome_zarr(missing, version="0.6")
+
+
+def test_hcs_plate_root_raises_guidance(tmp_path):
+    """An HCS plate root is rejected with guidance toward the per-image path."""
+    plate_path = str(tmp_path / "plate.ome.zarr")
+    group = zarr.open_group(plate_path, mode="w", zarr_format=2)
+    group.attrs["plate"] = {
+        "columns": [{"name": "1"}],
+        "rows": [{"name": "A"}],
+        "wells": [{"path": "A/1", "rowIndex": 0, "columnIndex": 0}],
+        "version": "0.4",
+    }
+    with pytest.raises(ValueError, match="[Pp]late"):
+        upgrade_ome_zarr(plate_path, version="0.5")
+
+
+def test_bioformats2raw_container_root_raises_guidance(tmp_path):
+    """A bioformats2raw container root is rejected with per-image guidance."""
+    container_path = str(tmp_path / "container.ome.zarr")
+    group = zarr.open_group(container_path, mode="w", zarr_format=2)
+    group.attrs["bioformats2raw.layout"] = 3
+    with pytest.raises(ValueError, match="bioformats2raw"):
+        upgrade_ome_zarr(container_path, version="0.5")

--- a/ts/src/browser-mod.ts
+++ b/ts/src/browser-mod.ts
@@ -48,6 +48,14 @@ export {
   toOmeZarrOzx,
   type ToOmeZarrOzxOptions,
 } from "./io/to_ngff_zarr-browser.ts";
+// upgradeOmeZarr: spec-version upgrade (in-place metadata rewrite or
+// write-to-new-store). In the browser only MemoryStore inputs/outputs are
+// supported; in-place upgrade of a local *path* store is Node/Deno-only.
+export {
+  type UpgradeInput,
+  upgradeOmeZarr,
+  type UpgradeOmeZarrOptions,
+} from "./io/upgrade_ome_zarr-browser.ts";
 // Browser-compatible processing modules
 export * from "./process/to_multiscales-browser.ts";
 export * from "./schemas/methods.ts";

--- a/ts/src/io/to_ngff_zarr-browser.ts
+++ b/ts/src/io/to_ngff_zarr-browser.ts
@@ -10,16 +10,11 @@ import type { ZarrCodec } from "../utils/codecs.ts";
 import { defaultCodecs } from "../utils/codecs.ts";
 import { createWriteQueue, zarrGet, zarrSet } from "../utils/worker_pool.ts";
 import type { MemoryStore } from "./from_ngff_zarr-browser.ts";
-import { V06_ONDISK_VERSION } from "../types/supported_versions.ts";
 import { memoryStoreToZip } from "./rfc9_zip.ts";
 import {
-  processAxes,
+  buildRootAttributes,
   writeNgffMultiscalesToMemoryStore,
 } from "./to_ngff_zarr_ozx_common.ts";
-import {
-  buildV06MultiscalesEntry,
-  legacyTopLevelTransforms,
-} from "../utils/v06_metadata.ts";
 
 export { isOzxPath } from "./rfc9_zip.ts";
 
@@ -94,70 +89,10 @@ export async function toOmeZarr(
     // Create root location and group with zarrita v0.5.2 API
     const root = zarr.root(_resolvedStore);
 
-    // Process axes (orientation included when present)
-    const processedAxes = processAxes(multiscales.metadata.axes);
-
-    // Create the root group with OME-Zarr metadata.
-    // - v0.6 (RFC 5): coordinate systems + per-dataset sequence transforms,
-    //   wrapped under the "ome" property.
-    // - v0.5: axes carried directly, wrapped under "ome".
-    // - v0.4: axes carried directly, placed at the root.
-    let attributes: Record<string, unknown>;
-    if (_version === "0.6") {
-      const v06Entry = buildV06MultiscalesEntry(
-        multiscales.metadata,
-        processedAxes,
-      );
-      attributes = {
-        ome: {
-          // The v0.6 spec is still a draft; tag the store with the development
-          // version `0.6.dev4` even though the requested version is `"0.6"`.
-          version: V06_ONDISK_VERSION,
-          multiscales: [v06Entry],
-          ...(multiscales.metadata.omero && {
-            omero: multiscales.metadata.omero,
-          }),
-        },
-      };
-    } else {
-      // v0.4/v0.5 only support the simple scale/translation subset of top-level
-      // transformations; drop richer v0.6 transforms when downgrading.
-      const legacyTransforms = legacyTopLevelTransforms(
-        multiscales.metadata.coordinateTransformations,
-      );
-      const multiscalesMetadata = {
-        version: _version,
-        name: multiscales.metadata.name,
-        axes: processedAxes,
-        datasets: multiscales.metadata.datasets,
-        ...(legacyTransforms && {
-          coordinateTransformations: legacyTransforms,
-        }),
-        ...(multiscales.metadata.type && {
-          type: multiscales.metadata.type,
-        }),
-        ...(multiscales.metadata.metadata && {
-          metadata: multiscales.metadata.metadata,
-        }),
-      };
-
-      attributes = _version === "0.5"
-        ? {
-          ome: {
-            version: _version,
-            multiscales: [multiscalesMetadata],
-            ...(multiscales.metadata.omero && {
-              omero: multiscales.metadata.omero,
-            }),
-          },
-        }
-        : {
-          multiscales: [multiscalesMetadata],
-          ...(multiscales.metadata.omero && {
-            omero: multiscales.metadata.omero,
-          }),
-        };
-    }
+    // Build the version-specific root-group metadata (v0.6 RFC-5 coordinate
+    // systems, v0.5 `ome`-wrapped axes, or bare v0.4 multiscales). Shared with
+    // the Node writer and the in-place `upgradeOmeZarr` rewrite.
+    const attributes = buildRootAttributes(multiscales.metadata, _version);
 
     const rootGroup = await zarr.create(root, { attributes });
 

--- a/ts/src/io/to_ngff_zarr.ts
+++ b/ts/src/io/to_ngff_zarr.ts
@@ -8,16 +8,11 @@ import type { ZarrCodec } from "../utils/codecs.ts";
 import { defaultCodecs } from "../utils/codecs.ts";
 import { createWriteQueue, zarrGet, zarrSet } from "../utils/worker_pool.ts";
 import type { MemoryStore } from "./from_ngff_zarr.ts";
-import { V06_ONDISK_VERSION } from "../types/supported_versions.ts";
 import { isOzxPath, memoryStoreToZip } from "./rfc9_zip.ts";
 import {
-  processAxes,
+  buildRootAttributes,
   writeNgffMultiscalesToMemoryStore,
 } from "./to_ngff_zarr_ozx_common.ts";
-import {
-  buildV06MultiscalesEntry,
-  legacyTopLevelTransforms,
-} from "../utils/v06_metadata.ts";
 
 export interface ToOmeZarrOptions {
   overwrite?: boolean;
@@ -157,70 +152,10 @@ export async function toOmeZarr(
     // Create root location and group with zarrita v0.5.2 API
     const root = zarr.root(_resolvedStore as MemoryStore);
 
-    // Process axes (orientation included when present)
-    const processedAxes = processAxes(multiscales.metadata.axes);
-
-    // Create the root group with OME-Zarr metadata.
-    // - v0.6 (RFC 5): coordinate systems + per-dataset sequence transforms,
-    //   wrapped under the "ome" property.
-    // - v0.5: axes carried directly, wrapped under "ome".
-    // - v0.4: axes carried directly, placed at the root.
-    let attributes: Record<string, unknown>;
-    if (_version === "0.6") {
-      const v06Entry = buildV06MultiscalesEntry(
-        multiscales.metadata,
-        processedAxes,
-      );
-      attributes = {
-        ome: {
-          // The v0.6 spec is still a draft; tag the store with the development
-          // version `0.6.dev4` even though the requested version is `"0.6"`.
-          version: V06_ONDISK_VERSION,
-          multiscales: [v06Entry],
-          ...(multiscales.metadata.omero && {
-            omero: multiscales.metadata.omero,
-          }),
-        },
-      };
-    } else {
-      // v0.4/v0.5 only support the simple scale/translation subset of top-level
-      // transformations; drop richer v0.6 transforms when downgrading.
-      const legacyTransforms = legacyTopLevelTransforms(
-        multiscales.metadata.coordinateTransformations,
-      );
-      const multiscalesMetadata = {
-        version: _version,
-        name: multiscales.metadata.name,
-        axes: processedAxes,
-        datasets: multiscales.metadata.datasets,
-        ...(legacyTransforms && {
-          coordinateTransformations: legacyTransforms,
-        }),
-        ...(multiscales.metadata.type && {
-          type: multiscales.metadata.type,
-        }),
-        ...(multiscales.metadata.metadata && {
-          metadata: multiscales.metadata.metadata,
-        }),
-      };
-
-      attributes = _version === "0.5"
-        ? {
-          ome: {
-            version: _version,
-            multiscales: [multiscalesMetadata],
-            ...(multiscales.metadata.omero && {
-              omero: multiscales.metadata.omero,
-            }),
-          },
-        }
-        : {
-          multiscales: [multiscalesMetadata],
-          ...(multiscales.metadata.omero && {
-            omero: multiscales.metadata.omero,
-          }),
-        };
-    }
+    // Build the version-specific root-group metadata (v0.6 RFC-5 coordinate
+    // systems, v0.5 `ome`-wrapped axes, or bare v0.4 multiscales). Shared with
+    // the browser writer and the in-place `upgradeOmeZarr` rewrite.
+    const attributes = buildRootAttributes(multiscales.metadata, _version);
 
     const rootGroup = await zarr.create(root, { attributes });
 

--- a/ts/src/io/to_ngff_zarr_ozx_common.ts
+++ b/ts/src/io/to_ngff_zarr_ozx_common.ts
@@ -1,16 +1,22 @@
 // SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
 // SPDX-License-Identifier: MIT
 /**
- * Shared internal utilities for RFC-9 (.ozx) writing
- * Used by both Node and browser implementations to avoid code duplication
+ * Shared internal utilities for OME-Zarr writing (regular Zarr stores and
+ * RFC-9 .ozx). Used by the Node and browser writers — and the in-place
+ * `upgradeOmeZarr` metadata rewrite — to avoid duplicating the root-attribute
+ * and axis-processing logic.
  */
 
 import * as zarr from "zarrita";
 
 import type { NgffMultiscales } from "../types/multiscales.ts";
 import type { NgffImage } from "../types/ngff_image.ts";
-import type { Axis } from "../types/zarr_metadata.ts";
-import { legacyTopLevelTransforms } from "../utils/v06_metadata.ts";
+import type { Axis, MetadataInterface } from "../types/zarr_metadata.ts";
+import {
+  buildV06MultiscalesEntry,
+  legacyTopLevelTransforms,
+} from "../utils/v06_metadata.ts";
+import { V06_ONDISK_VERSION } from "../types/supported_versions.ts";
 import type { MemoryStore } from "./rfc9_zip.ts";
 
 /**
@@ -42,6 +48,70 @@ export function processAxes(
 
     return result;
   });
+}
+
+/**
+ * Build the root-group attributes for an OME-Zarr store at a given spec version
+ * from the version-agnostic in-memory metadata. This is the single source of
+ * truth for the on-disk root shape shared by the Node and browser writers
+ * ({@link toOmeZarr}) and the in-place metadata rewrite in `upgradeOmeZarr`:
+ *
+ * - **0.6 (RFC 5):** coordinate systems + per-dataset `sequence` transforms,
+ *   wrapped under the `ome` namespace and tagged {@link V06_ONDISK_VERSION}.
+ * - **0.5:** axes carried directly on the multiscale entry, wrapped under `ome`.
+ * - **0.4:** axes carried directly on the multiscale entry at the root (no
+ *   `ome` wrapper).
+ *
+ * Richer v0.6-only top-level transforms are reduced to the simple
+ * scale/translation subset for 0.4/0.5 via {@link legacyTopLevelTransforms}.
+ */
+export function buildRootAttributes(
+  metadata: MetadataInterface,
+  version: "0.4" | "0.5" | "0.6",
+): Record<string, unknown> {
+  // Process axes (orientation included when present).
+  const processedAxes = processAxes(metadata.axes);
+
+  if (version === "0.6") {
+    const v06Entry = buildV06MultiscalesEntry(metadata, processedAxes);
+    return {
+      ome: {
+        // The v0.6 spec is still a draft; tag the store with the development
+        // version `0.6.dev4` even though the requested version is `"0.6"`.
+        version: V06_ONDISK_VERSION,
+        multiscales: [v06Entry],
+        ...(metadata.omero && { omero: metadata.omero }),
+      },
+    };
+  }
+
+  // v0.4/v0.5 only support the simple scale/translation subset of top-level
+  // transformations; drop richer v0.6 transforms when downgrading.
+  const legacyTransforms = legacyTopLevelTransforms(
+    metadata.coordinateTransformations,
+  );
+  const multiscalesMetadata = {
+    version,
+    name: metadata.name,
+    axes: processedAxes,
+    datasets: metadata.datasets,
+    ...(legacyTransforms && { coordinateTransformations: legacyTransforms }),
+    ...(metadata.type && { type: metadata.type }),
+    ...(metadata.metadata && { metadata: metadata.metadata }),
+  };
+
+  return version === "0.5"
+    ? {
+      ome: {
+        version,
+        multiscales: [multiscalesMetadata],
+        ...(metadata.omero && { omero: metadata.omero }),
+      },
+    }
+    : {
+      multiscales: [multiscalesMetadata],
+      ...(metadata.omero && { omero: metadata.omero }),
+    };
 }
 
 /**

--- a/ts/src/io/upgrade_ome_zarr-browser.ts
+++ b/ts/src/io/upgrade_ome_zarr-browser.ts
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+// Browser-compatible version of upgrade_ome_zarr that doesn't import
+// @zarrita/storage (which pulls in Node.js-specific modules like node:fs).
+import { fromOmeZarr, type MemoryStore } from "./from_ngff_zarr-browser.ts";
+import { toOmeZarr } from "./to_ngff_zarr-browser.ts";
+import {
+  type UpgradeInput,
+  upgradeOmeZarrImpl,
+  type UpgradeOmeZarrOptions,
+} from "./upgrade_ome_zarr_common.ts";
+
+export type { UpgradeInput, UpgradeOmeZarrOptions };
+
+/**
+ * Resolve an in-place upgrade `input` to a writable store, browser edition.
+ *
+ * Only `Map` (MemoryStore) is writable in the browser. Local file paths require
+ * a filesystem store the browser build intentionally omits, and FetchStore /
+ * HTTP(S) URLs are read-only; all are rejected with guidance to pass `output`.
+ */
+function resolveWritableStore(input: UpgradeInput): Promise<MemoryStore> {
+  if (input instanceof Map) {
+    return Promise.resolve(input);
+  }
+  const message = typeof input === "string" &&
+      !(input.startsWith("http://") || input.startsWith("https://"))
+    ? "Local file paths are not supported in browser environments. Use a " +
+      "MemoryStore for an in-place upgrade, or pass `output`."
+    : "In-place upgrade requires a writable MemoryStore, but a read-only " +
+      "store was given. Pass `output` to write the upgraded store to a new " +
+      "location.";
+  return Promise.reject(new Error(message));
+}
+
+/**
+ * Browser-compatible version of {@link upgradeOmeZarr}.
+ *
+ * Offers the same two modes as the Node version:
+ *
+ * **In-place metadata-only rewrite** (same Zarr format, 0.5 <-> 0.6): only the
+ * root group's `zarr.json` is rewritten and every array chunk is left
+ * byte-for-byte untouched (the fix for issue #219). An in-place upgrade across
+ * the Zarr v2 <-> v3 boundary (0.4 <-> 0.5/0.6) throws with guidance to pass
+ * `output`.
+ *
+ * **Write-to-new-store conversion** (distinct `output`): the source is read
+ * lazily and re-written at the requested version through the standard pipeline;
+ * every supported transition works and the source store is never mutated.
+ *
+ * In the browser only `MemoryStore` inputs/outputs are supported — local file
+ * paths require Node/Deno. For an in-place upgrade the `input` must therefore be
+ * a `MemoryStore`; otherwise pass a `MemoryStore` `output`.
+ *
+ * @see https://github.com/fideus-labs/ngff-zarr/issues/219
+ */
+export function upgradeOmeZarr(
+  input: UpgradeInput,
+  options: UpgradeOmeZarrOptions = {},
+): Promise<void> {
+  return upgradeOmeZarrImpl(input, options, {
+    fromOmeZarr,
+    toOmeZarr,
+    resolveWritableStore,
+  });
+}

--- a/ts/src/io/upgrade_ome_zarr.ts
+++ b/ts/src/io/upgrade_ome_zarr.ts
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+import * as zarr from "zarrita";
+
+import { fromOmeZarr, type MemoryStore } from "./from_ngff_zarr.ts";
+import { toOmeZarr } from "./to_ngff_zarr.ts";
+import {
+  type UpgradeInput,
+  upgradeOmeZarrImpl,
+  type UpgradeOmeZarrOptions,
+} from "./upgrade_ome_zarr_common.ts";
+
+export type { UpgradeInput, UpgradeOmeZarrOptions };
+
+/**
+ * Resolve an in-place upgrade `input` to a writable store.
+ *
+ * `Map` (MemoryStore) and local file paths (via `@zarrita/storage`'s
+ * `FileSystemStore`) are writable. Read-only inputs — `FetchStore`, HTTP(S)
+ * URLs, or a bare `Readable` — are rejected with guidance to pass `output`,
+ * since an in-place upgrade must be able to rewrite the store's root metadata.
+ */
+async function resolveWritableStore(
+  input: UpgradeInput,
+): Promise<MemoryStore> {
+  if (input instanceof Map) {
+    return input;
+  }
+  if (input instanceof zarr.FetchStore) {
+    throw new Error(
+      "In-place upgrade requires a writable store, but a read-only FetchStore " +
+        "was given. Pass `output` to write the upgraded store to a new location.",
+    );
+  }
+  if (typeof input === "string") {
+    if (input.startsWith("http://") || input.startsWith("https://")) {
+      throw new Error(
+        "In-place upgrade requires a writable store, but a read-only HTTP(S) " +
+          "URL was given. Pass `output` to write the upgraded store to a new " +
+          "location.",
+      );
+    }
+    if (typeof window !== "undefined") {
+      throw new Error(
+        "Local file paths are not supported in browser environments. Use a " +
+          "MemoryStore for an in-place upgrade, or pass `output`.",
+      );
+    }
+    const { FileSystemStore } = await import("@zarrita/storage");
+    // Normalize the path for cross-platform compatibility (mirrors the reader).
+    const normalizedPath = input.replace(/^\/([A-Za-z]:)/, "$1");
+    return new FileSystemStore(normalizedPath) as unknown as MemoryStore;
+  }
+  // A generic Readable store (e.g. a TiffStore) with no write capability.
+  throw new Error(
+    "In-place upgrade requires a writable store (a local path or MemoryStore). " +
+      "Pass `output` to write the upgraded store to a new location.",
+  );
+}
+
+/**
+ * Upgrade an OME-Zarr store to a different specification version.
+ *
+ * Mirrors the Python `upgrade_ome_zarr`, offering two modes:
+ *
+ * **In-place metadata-only rewrite.** When `output` is omitted (or resolves to
+ * the same store as `input`) and the source and target share the same
+ * underlying Zarr format — 0.5 <-> 0.6, both Zarr v3 — only the root group's
+ * `zarr.json` is rewritten. Every array chunk on disk is left byte-for-byte
+ * untouched. This is the fix for issue #219, where a naive "read, erase,
+ * re-write" upgrade destroyed the array data it was meant to preserve. An
+ * in-place upgrade that would cross the Zarr v2 <-> v3 boundary
+ * (OME-Zarr 0.4 <-> 0.5/0.6) throws with guidance to pass `output` instead.
+ *
+ * **Write-to-new-store conversion.** When `output` is a store distinct from
+ * `input`, the source is read lazily and re-written to `output` at the
+ * requested version through the standard, tested write pipeline. Every
+ * supported transition (0.4 <-> 0.5 <-> 0.6) works in this mode, and the source
+ * store is never mutated.
+ *
+ * In-place upgrade of a local **path** store is Node/Deno-only (the browser
+ * build ships no filesystem store); `MemoryStore` inputs work everywhere,
+ * consistent with the other I/O functions.
+ *
+ * @param input Source store or path to read.
+ * @param options Upgrade options; `version` defaults to `"0.6"`.
+ * @returns A promise that resolves once the upgraded metadata has been written
+ *   to `output` (or, for an in-place upgrade, back to `input`).
+ *
+ * @example
+ * ```ts
+ * // Upgrade a 0.5 store to 0.6 in place, keeping all array chunks.
+ * await upgradeOmeZarr("image.ome.zarr", { version: "0.6" });
+ *
+ * // Write an upgraded copy to a new store.
+ * await upgradeOmeZarr("image_v04.ome.zarr", {
+ *   output: "image_v06.ome.zarr",
+ *   version: "0.6",
+ * });
+ * ```
+ *
+ * @see https://github.com/fideus-labs/ngff-zarr/issues/219
+ */
+export function upgradeOmeZarr(
+  input: UpgradeInput,
+  options: UpgradeOmeZarrOptions = {},
+): Promise<void> {
+  return upgradeOmeZarrImpl(input, options, {
+    fromOmeZarr,
+    toOmeZarr,
+    resolveWritableStore,
+  });
+}

--- a/ts/src/io/upgrade_ome_zarr_common.ts
+++ b/ts/src/io/upgrade_ome_zarr_common.ts
@@ -1,0 +1,207 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * Environment-agnostic core of `upgradeOmeZarr`, shared by the Node
+ * (`upgrade_ome_zarr.ts`) and browser (`upgrade_ome_zarr-browser.ts`) wrappers.
+ *
+ * The version-detection, no-op / same-format / cross-format decision, and the
+ * in-place root-metadata rewrite are identical across environments; only the
+ * concrete `fromOmeZarr` / `toOmeZarr` implementations and the writable-store
+ * resolution differ (the browser build ships no filesystem store). Those three
+ * pieces are injected via {@link UpgradeOmeZarrDeps} so this module stays free
+ * of any Node-specific imports and safe to bundle for the browser.
+ */
+
+import * as zarr from "zarrita";
+
+import type { NgffMultiscales } from "../types/multiscales.ts";
+import type { MemoryStore } from "./rfc9_zip.ts";
+import { detectVersion } from "../utils/parse_metadata.ts";
+import { isV06Version } from "../types/supported_versions.ts";
+import { buildRootAttributes } from "./to_ngff_zarr_ozx_common.ts";
+
+/** Stores/paths `upgradeOmeZarr` can read from. */
+export type UpgradeInput =
+  | string
+  | MemoryStore
+  | zarr.FetchStore
+  | zarr.Readable;
+
+export interface UpgradeOmeZarrOptions {
+  /**
+   * Destination store or path. Omit (or pass the same store as `input`) for an
+   * in-place upgrade; pass a distinct store to write an upgraded copy there.
+   * A `FetchStore` is read-only and cannot be a write destination, so it is not
+   * accepted here (it remains valid as an `input`).
+   */
+  output?: string | MemoryStore;
+  /** Target OME-Zarr specification version. Defaults to `"0.6"`. */
+  version?: "0.4" | "0.5" | "0.6";
+  /** Validate the source metadata against the NGFF schema while reading. */
+  validate?: boolean;
+  /**
+   * Write-to-new-store only: overwrite pre-existing data at `output`
+   * (default `true`). Ignored for in-place upgrades, which never overwrite
+   * array data.
+   */
+  overwrite?: boolean;
+}
+
+/** The environment-specific pieces injected into {@link upgradeOmeZarrImpl}. */
+export interface UpgradeOmeZarrDeps {
+  fromOmeZarr: (
+    store: UpgradeInput,
+    options?: { validate?: boolean; version?: "0.4" | "0.5" | "0.6" },
+  ) => Promise<NgffMultiscales>;
+  toOmeZarr: (
+    store: string | MemoryStore | zarr.FetchStore,
+    multiscales: NgffMultiscales,
+    options?: { overwrite?: boolean; version?: "0.4" | "0.5" | "0.6" },
+  ) => Promise<void>;
+  /**
+   * Resolve `input` to a writable store for an in-place rewrite. Must reject a
+   * read-only input (e.g. FetchStore / HTTP URL) — and, in the browser, a local
+   * path — with an actionable message directing the user to pass `output`.
+   */
+  resolveWritableStore: (input: UpgradeInput) => Promise<MemoryStore>;
+}
+
+/** OME-Zarr < 0.5 lives in Zarr v2; 0.5 and later live in Zarr v3. */
+function zarrFormatForVersion(version: string): 2 | 3 {
+  const [major, minor] = version.split(".").map((part) => Number(part));
+  return major === 0 && minor < 5 ? 2 : 3;
+}
+
+/**
+ * Collapse the v0.6 family (including the on-disk draft `0.6.dev4`) to `"0.6"`
+ * so a store tagged `0.6.dev4` compares equal to a requested version of `"0.6"`.
+ */
+function normalizeVersion(version: string): string {
+  return isV06Version(version) ? "0.6" : version;
+}
+
+/** Whether `s` looks like a URL with a scheme (e.g. `http://`, `s3://`). */
+function isUrl(s: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(s);
+}
+
+/**
+ * Lexically normalize a local path so different spellings of the same location
+ * compare equal: collapse duplicate slashes, drop `.` segments, resolve `..`,
+ * and strip a trailing slash. This mirrors (a subset of) the Python side's
+ * `Path(...).resolve()` in `_stores_are_same`, so `foo`, `./foo/`, and
+ * `bar/../foo` all match and are routed to the safe in-place path rather than
+ * the overwriting write-to-new-store path (issue #219). It is purely lexical --
+ * it never touches the filesystem -- so it does not resolve symlinks or make a
+ * relative path absolute against the cwd; genuinely equivalent forms that
+ * differ in those respects still fall back to the never-mutating copy path.
+ */
+function normalizeLocalPath(p: string): string {
+  const isAbsolute = p.startsWith("/");
+  const stack: string[] = [];
+  for (const seg of p.split("/")) {
+    if (seg === "" || seg === ".") continue;
+    if (seg === "..") {
+      if (stack.length && stack[stack.length - 1] !== "..") {
+        stack.pop();
+      } else if (!isAbsolute) {
+        stack.push("..");
+      }
+      // A leading `..` on an absolute path is dropped, matching path resolution.
+    } else {
+      stack.push(seg);
+    }
+  }
+  return (isAbsolute ? "/" : "") + stack.join("/");
+}
+
+/** Whether `output` designates the same store as `input` (an in-place request). */
+function isSameStore(
+  input: UpgradeInput,
+  output: UpgradeOmeZarrOptions["output"],
+): boolean {
+  if (output === undefined) {
+    return true;
+  }
+  if ((input as unknown) === (output as unknown)) {
+    return true;
+  }
+  if (typeof input === "string" && typeof output === "string") {
+    // URLs: compare up to a trailing slash (no `.`/`..` resolution -- those are
+    // meaningful in a URL path). Local paths: compare lexically-normalized forms
+    // so `foo`, `./foo/`, and `bar/../foo` all match, mirroring the Python
+    // `_stores_are_same` `.resolve()` comparison. Any remaining ambiguity still
+    // routes to the never-mutating write-to-new-store path.
+    if (isUrl(input) || isUrl(output)) {
+      return input.replace(/\/+$/, "") === output.replace(/\/+$/, "");
+    }
+    return normalizeLocalPath(input) === normalizeLocalPath(output);
+  }
+  return false;
+}
+
+/**
+ * Core `upgradeOmeZarr` algorithm. See the wrappers' public docs for the full
+ * two-mode behavior; this function assumes `deps` supplies the environment's
+ * I/O and writable-store resolution.
+ */
+export async function upgradeOmeZarrImpl(
+  input: UpgradeInput,
+  options: UpgradeOmeZarrOptions,
+  deps: UpgradeOmeZarrDeps,
+): Promise<void> {
+  const version = options.version ?? "0.6";
+  const validate = options.validate ?? false;
+  const overwrite = options.overwrite ?? true;
+
+  if (!isSameStore(input, options.output)) {
+    // Write-to-new-store: read the source lazily and re-write it to `output`
+    // through the standard, tested pipeline. `toOmeZarr` re-derives the
+    // target-version metadata, so every supported transition (0.4<->0.5<->0.6)
+    // works and the source store is never mutated.
+    const multiscales = await deps.fromOmeZarr(input, { validate });
+    await deps.toOmeZarr(options.output!, multiscales, { version, overwrite });
+    return;
+  }
+
+  // In-place: resolve a writable store (rejects read-only inputs) and detect
+  // the on-disk source version from the root-group attributes.
+  const store = await deps.resolveWritableStore(input);
+  const location = zarr.root(store);
+  const rootGroup = await zarr.open(location, { kind: "group" });
+  const sourceVersion = detectVersion(
+    rootGroup.attrs as Record<string, unknown>,
+  );
+  const sourceZarrFormat = zarrFormatForVersion(sourceVersion);
+  const targetZarrFormat = zarrFormatForVersion(version);
+
+  // No-op: the store already records the requested spec version. Leave it
+  // byte-for-byte unchanged (no read of arrays, no write).
+  if (normalizeVersion(sourceVersion) === normalizeVersion(version)) {
+    return;
+  }
+
+  if (sourceZarrFormat !== targetZarrFormat) {
+    // Cross-format in-place (Zarr v2<->v3, i.e. OME-Zarr 0.4<->0.5/0.6). A safe
+    // rewrite would have to re-encode every array's chunk keys; to stay aligned
+    // with the Python package's public behavior we direct the user to
+    // write-to-new-store, which handles the transition through the tested
+    // pipeline without ever touching the source.
+    throw new Error(
+      "In-place upgrade across the Zarr v2/v3 boundary (OME-Zarr " +
+        `${normalizeVersion(sourceVersion)} -> ${version}) is not supported ` +
+        "because it cannot preserve array chunk files. Pass `output` (a path " +
+        "or MemoryStore) to write a new upgraded store safely.",
+    );
+  }
+
+  // Same underlying Zarr format (0.5<->0.6): rewrite ONLY the root-group
+  // metadata. `fromOmeZarr` reads the metadata and opens the arrays lazily (no
+  // chunk data is read), and `zarr.create` overwrites the root `zarr.json`
+  // alone — every array `zarr.json` and chunk file is left byte-for-byte
+  // untouched. This is the fix for issue #219.
+  const multiscales = await deps.fromOmeZarr(store, { validate });
+  const attributes = buildRootAttributes(multiscales.metadata, version);
+  await zarr.create(location, { attributes });
+}

--- a/ts/src/mod.ts
+++ b/ts/src/mod.ts
@@ -18,6 +18,15 @@ export {
   readOzxVersion,
 } from "./io/rfc9_zip.ts";
 export * from "./io/to_ngff_zarr.ts";
+// upgradeOmeZarr: spec-version upgrade (in-place metadata rewrite or
+// write-to-new-store). In-place upgrade of a local *path* store is Node/Deno-
+// only (needs a filesystem store); MemoryStore/FetchStore inputs work
+// everywhere, consistent with the other I/O functions.
+export {
+  type UpgradeInput,
+  upgradeOmeZarr,
+  type UpgradeOmeZarrOptions,
+} from "./io/upgrade_ome_zarr.ts";
 export * from "./process/to_multiscales-node.ts";
 export * from "./schemas/methods.ts";
 export * from "./schemas/multiscales.ts";

--- a/ts/test/upgrade_ome_zarr_test.ts
+++ b/ts/test/upgrade_ome_zarr_test.ts
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+//
+// Tests for upgradeOmeZarr, mirroring the Python upgrade_ome_zarr matrix:
+// in-place same-format rewrites (chunks byte-identical, issue #219),
+// write-to-new-store for every representative transition (source untouched),
+// the cross-format in-place guidance error, and the same-version no-op.
+import { assertEquals, assertExists, assertRejects } from "@std/assert";
+import * as zarr from "zarrita";
+import {
+  fromOmeZarr,
+  type MemoryStore,
+  toOmeZarr,
+  upgradeOmeZarr,
+} from "../src/mod.ts";
+import {
+  createAxis,
+  createDataset,
+  createMetadata,
+  createNgffMultiscales,
+} from "../src/utils/factory.ts";
+import { NgffImage } from "../src/types/ngff_image.ts";
+
+const SHAPE = [1, 2, 8, 8]; // c, z, y, x
+const CHUNKS = [1, 1, 8, 8];
+const STRIDE = [2 * 8 * 8, 8 * 8, 8, 1];
+
+/** Deterministic uint16 payload so "array data intact" can be asserted exactly. */
+function fixtureData(): Uint16Array {
+  const n = SHAPE.reduce((a, b) => a * b, 1);
+  const data = new Uint16Array(n);
+  for (let i = 0; i < n; i++) data[i] = (i * 7 + 3) % 60000;
+  return data;
+}
+
+/** Write a fresh synthetic single-scale image to a MemoryStore at `version`. */
+async function makeSourceStore(
+  version: "0.4" | "0.5" | "0.6",
+): Promise<MemoryStore> {
+  const seed: MemoryStore = new Map();
+  const seedArray = await zarr.create(zarr.root(seed).resolve("seed"), {
+    shape: SHAPE,
+    chunk_shape: CHUNKS,
+    data_type: "uint16" as zarr.DataType,
+    fill_value: 0,
+  });
+  await zarr.set(seedArray, null, {
+    data: fixtureData(),
+    shape: SHAPE,
+    stride: STRIDE,
+  });
+
+  const image = new NgffImage({
+    data: seedArray,
+    dims: ["c", "z", "y", "x"],
+    scale: { c: 1, z: 1, y: 1, x: 1 },
+    translation: { c: 0, z: 0, y: 0, x: 0 },
+    name: "upgrade-fixture",
+    axesUnits: undefined,
+    computedCallbacks: undefined,
+  });
+  const axes = [
+    createAxis("c", "channel"),
+    createAxis("z", "space", "micrometer"),
+    createAxis("y", "space", "micrometer"),
+    createAxis("x", "space", "micrometer"),
+  ];
+  const datasets = [createDataset("0", [1, 1, 1, 1], [0, 0, 0, 0])];
+  const metadata = createMetadata(axes, datasets, "upgrade-fixture", version);
+  const multiscales = createNgffMultiscales([image], metadata);
+
+  const store: MemoryStore = new Map();
+  await toOmeZarr(store, multiscales, { version });
+  return store;
+}
+
+const METADATA_SIDECARS = [
+  "zarr.json",
+  ".zarray",
+  ".zattrs",
+  ".zgroup",
+  ".zmetadata",
+];
+
+/** Keys holding array chunk *data* (everything but the metadata sidecars). */
+function chunkKeys(store: MemoryStore): string[] {
+  return [...store.keys()]
+    .filter((key) => !METADATA_SIDECARS.some((name) => key.endsWith(name)))
+    .sort();
+}
+
+/** Snapshot every key -> bytes so store immutability can be asserted. */
+function snapshot(store: MemoryStore): Map<string, string> {
+  const snap = new Map<string, string>();
+  for (const [key, value] of store) snap.set(key, [...value].join(","));
+  return snap;
+}
+
+function assertSnapshotsEqual(
+  before: Map<string, string>,
+  after: Map<string, string>,
+): void {
+  assertEquals([...after.keys()].sort(), [...before.keys()].sort());
+  for (const [key, value] of before) {
+    assertEquals(after.get(key), value, `store key changed: ${key}`);
+  }
+}
+
+function assertChunksUnchanged(
+  store: MemoryStore,
+  before: Map<string, string>,
+  chunksBefore: string[],
+): void {
+  assertEquals(chunkKeys(store), chunksBefore);
+  for (const key of chunksBefore) {
+    assertEquals(
+      [...store.get(key)!].join(","),
+      before.get(key),
+      `array chunk changed: ${key}`,
+    );
+  }
+}
+
+/** Read the root-group `ome` namespace attributes from a store. */
+async function readOme(store: MemoryStore): Promise<Record<string, unknown>> {
+  const group = await zarr.open(zarr.root(store), { kind: "group" });
+  return (group.attrs as Record<string, Record<string, unknown>>).ome;
+}
+
+/** Re-read (validated) and return the full first-scale payload as uint16. */
+async function readImageData(
+  store: MemoryStore,
+  version: "0.4" | "0.5" | "0.6",
+): Promise<Uint16Array> {
+  const multiscales = await fromOmeZarr(store, { validate: true, version });
+  assertEquals(multiscales.images.length, 1);
+  const { data } = await zarr.get(multiscales.images[0].data, null);
+  return data as Uint16Array;
+}
+
+function assertDataIntact(actual: Uint16Array): void {
+  const expected = fixtureData();
+  assertEquals(actual.length, expected.length);
+  for (let i = 0; i < expected.length; i++) {
+    assertEquals(actual[i], expected[i], `pixel ${i} differs`);
+  }
+}
+
+// The on-disk `ome.version` string a given API version is written as.
+const DISK_VERSION: Record<"0.4" | "0.5" | "0.6", string> = {
+  "0.4": "0.4",
+  "0.5": "0.5",
+  "0.6": "0.6.dev4",
+};
+
+Deno.test("in-place same-format upgrade 0.5 -> 0.6 preserves chunks", async () => {
+  const store = await makeSourceStore("0.5");
+  assertEquals((await readOme(store)).version, "0.5");
+  const chunksBefore = chunkKeys(store);
+  assertEquals(chunksBefore.length > 0, true, "expected chunk data before");
+  const before = snapshot(store);
+
+  await upgradeOmeZarr(store, { version: "0.6" });
+
+  const ome = await readOme(store);
+  assertEquals(ome.version, "0.6.dev4");
+  const ms0 = (ome.multiscales as Record<string, unknown>[])[0];
+  assertExists(ms0.coordinateSystems);
+
+  assertChunksUnchanged(store, before, chunksBefore);
+  assertDataIntact(await readImageData(store, "0.6"));
+});
+
+Deno.test("in-place same-format downgrade 0.6 -> 0.5 preserves chunks", async () => {
+  const store = await makeSourceStore("0.6");
+  assertEquals((await readOme(store)).version, "0.6.dev4");
+  const chunksBefore = chunkKeys(store);
+  const before = snapshot(store);
+
+  await upgradeOmeZarr(store, { version: "0.5" });
+
+  const ome = await readOme(store);
+  assertEquals(ome.version, "0.5");
+  const ms0 = (ome.multiscales as Record<string, unknown>[])[0];
+  assertExists(ms0.axes);
+  assertEquals("coordinateSystems" in ms0, false);
+
+  assertChunksUnchanged(store, before, chunksBefore);
+  assertDataIntact(await readImageData(store, "0.5"));
+});
+
+for (
+  const [source, target] of [
+    ["0.4", "0.5"],
+    ["0.4", "0.6"],
+    ["0.5", "0.6"],
+  ] as const
+) {
+  Deno.test(
+    `write-to-new-store ${source} -> ${target} leaves the source unchanged`,
+    async () => {
+      const store = await makeSourceStore(source);
+      const before = snapshot(store);
+      const target_store: MemoryStore = new Map();
+
+      await upgradeOmeZarr(store, { output: target_store, version: target });
+
+      // The source store is left completely unchanged.
+      assertSnapshotsEqual(before, snapshot(store));
+
+      // The new store reads back validated at the requested version.
+      assertEquals((await readOme(target_store)).version, DISK_VERSION[target]);
+      assertDataIntact(await readImageData(target_store, target));
+    },
+  );
+}
+
+Deno.test("in-place cross-format upgrade 0.4 -> 0.5 throws guidance", async () => {
+  const store = await makeSourceStore("0.4");
+  const before = snapshot(store);
+
+  await assertRejects(
+    () => upgradeOmeZarr(store, { version: "0.5" }),
+    Error,
+    "output",
+  );
+
+  // The rejected cross-format upgrade left the store untouched.
+  assertSnapshotsEqual(before, snapshot(store));
+});
+
+Deno.test("in-place no-op (same version) leaves the store unchanged", async () => {
+  const store = await makeSourceStore("0.5");
+  const before = snapshot(store);
+
+  await upgradeOmeZarr(store, { version: "0.5" });
+
+  assertSnapshotsEqual(before, snapshot(store));
+});
+
+Deno.test("in-place no-op with default target version on a 0.6 store", async () => {
+  const store = await makeSourceStore("0.6");
+  const before = snapshot(store);
+
+  // version defaults to "0.6"; the 0.6 store is already at the target.
+  await upgradeOmeZarr(store);
+
+  assertSnapshotsEqual(before, snapshot(store));
+});


### PR DESCRIPTION
## Summary

Adds a first-class **OME-Zarr specification-version upgrade** capability to both the Python (`ngff-zarr`) and TypeScript (`@fideus-labs/ngff-zarr`) packages, plus a `ngff-zarr upgrade` CLI subcommand and documentation. Upgrading a store to a newer OME-Zarr version (0.4 → 0.5 → 0.6) no longer requires an erase-then-reload round trip that risked data loss.

Fixes #219.

## Why

Previously the only way to move an existing OME-Zarr store to a newer spec version was to read it and write it back out, which erased the original before the rewrite completed — a data-loss hazard reported in #219. There was also no public API or CLI verb for a version upgrade at all. This PR provides a safe, explicit upgrade path with a **non-destructive default** and an in-place mode that leaves array chunk binaries byte-for-byte untouched.

## What changed

### Python — `upgrade_ome_zarr()` / `upgrade_ngff_zarr()`
New module `py/ngff_zarr/upgrade_ome_zarr.py`, exported from `ngff_zarr`:

```python
upgrade_ome_zarr(input, output=None, *, version="0.6",
                 validate=False, storage_options=None, overwrite=True) -> None
```

Two modes:
- **In-place, metadata-only** (omit `output`): rewrites only root/array/group metadata; every array chunk is left byte-for-byte unchanged. For same-Zarr-format transitions (e.g. 0.5 ↔ 0.6) this is a pure metadata edit. Across the Zarr v2 ↔ v3 boundary (0.4 → 0.5/0.6) it writes Zarr v3 metadata with a `v2` `chunk_key_encoding` matching the source separator, so existing chunk binaries still resolve.
- **Write-to-new-store** (pass `output`): reuses the tested read/write pipeline for any supported transition; the source store is never mutated.

Input handling is hardened: source-version detection from root attributes, target-version validation, a same-version no-op short-circuit (bit-for-bit unchanged), and rejection of HCS-plate / bioformats2raw containers with per-image guidance. The in-place v3 → v2 downgrade is rejected with an actionable `ValueError` pointing to the write-to-new-store mode. `_write_root_ome_attrs()` was extracted from `_create_zarr_root()` in `to_ngff_zarr.py` so the writer and the upgrade path emit byte-identical root metadata.

### Python CLI — `ngff-zarr upgrade`
`cli.py`'s `main()` is refactored into a thin argv dispatcher: a leading `upgrade` token routes to a new `_upgrade_main()`; every other invocation runs the existing conversion parser (renamed `_convert_main`) unchanged, so the `ngff-zarr` entry point and all current flags behave identically. `upgrade` supports both modes (omit/pass `--output`), prints the detected source version / mode / target version via Rich, accepts `--to 0.4|0.5|0.6` (default 0.6), passes through `--validate` and `--overwrite/--no-overwrite`, and renders the documented errors as concise messages with a non-zero exit code (no traceback).

### TypeScript — `upgradeOmeZarr()`
Mirrors the Python behavior for parity. A shared, env-agnostic core (`upgrade_ome_zarr_common.ts`) is wrapped by thin Node (`upgrade_ome_zarr.ts`) and browser (`upgrade_ome_zarr-browser.ts`) entry points, exported from `mod.ts` and `browser-mod.ts`. In-place same-format upgrades rewrite only the root group's `zarr.json`; write-to-new-store reuses `fromOmeZarr` → `toOmeZarr` without mutating the source; cross-format in-place throws with guidance to pass `output`. A shared `buildRootAttributes()` helper was extracted so the Node/browser writers and the in-place rewrite share one source of truth for root metadata (accounting for the reductions in `to_ngff_zarr.ts` / `to_ngff_zarr-browser.ts`). In-place upgrade of a local *path* store is Node/Deno-only; `MemoryStore`/`FetchStore` inputs work everywhere.

### Docs & examples
- `docs/python.md`, `docs/cli.md`, `docs/typescript.md`: sections covering both modes, the array-chunks-untouched guarantee, and the cross-format constraints.
- `py/examples/upgrade_ome_zarr_example.py`: runnable, network-free example upgrading 0.4 → 0.6 (write-to-new-store) and 0.5 → 0.6 (in-place), asserting the in-place chunks stay byte-for-byte identical and the data reads back.

## Testing
- `py/test/test_upgrade_ome_zarr.py`: parametrized suite over the full (source, target) × (in_place, new_store) matrix, chunk byte-identity, OMERO/name/type/orientation round-trips, and edge cases (unsupported version, aliasing, HCS).
- `py/test/test_cli_upgrade.py`: network-free CLI tests for both modes, the rejected downgrade, invalid `--to`, `--help`, and subcommand dispatch.
- `ts/test/upgrade_ome_zarr_test.ts`: 8 Deno tests mirroring the Python matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ngff-zarr upgrade` CLI subcommand plus new upgrade APIs in Python (`upgrade_ome_zarr`) and TypeScript (`upgradeOmeZarr`), including browser support.
  * Supports safe in-place root-metadata upgrades and write-to-new-store upgrades for cross-format OME-Zarr version transitions.
* **Bug Fixes**
  * Prevents unsupported in-place cross-format upgrades and improves guidance for invalid targets/unsuitable inputs.
  * Preserves array/chunk payloads byte-for-byte during in-place metadata-only upgrades.
* **Tests**
  * Added end-to-end CLI and API test coverage for version transitions, no-op behavior, and on-disk immutability.
* **Documentation**
  * Expanded CLI/Python/TypeScript docs and added a runnable Python upgrade example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->