### PR TITLE
fix(py): step region writes by the band width so the whole array is written

### DIFF
--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -1251,12 +1251,12 @@ def _compute_plane_regions(
                     min((slab_index + 1) * z_chunks, arr.shape[z_index]),
                 )
                 region[y_index] = slice(
-                    plane_index * y_chunks,
-                    min((plane_index + 1) * y_chunks, arr.shape[y_index]),
+                    plane_index * plane_slices,
+                    min((plane_index + 1) * plane_slices, arr.shape[y_index]),
                 )
                 region[x_index] = slice(
-                    strip_index * x_chunks,
-                    min((strip_index + 1) * x_chunks, arr.shape[x_index]),
+                    strip_index * strip_slices,
+                    min((strip_index + 1) * strip_slices, arr.shape[x_index]),
                 )
                 plane_regions.append(tuple(region))
     else:
@@ -1268,8 +1268,8 @@ def _compute_plane_regions(
                 min((slab_index + 1) * z_chunks, arr.shape[z_index]),
             )
             region[y_index] = slice(
-                plane_index * y_chunks,
-                min((plane_index + 1) * y_chunks, arr.shape[y_index]),
+                plane_index * plane_slices,
+                min((plane_index + 1) * plane_slices, arr.shape[y_index]),
             )
             plane_regions.append(tuple(region))
 

--- a/py/test/test_region_write_coverage.py
+++ b/py/test/test_region_write_coverage.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+import tempfile
+
+import dask.array as da
+import ngff_zarr as nz
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize(
+    "dims, shape, chunks, mt",
+    [
+        (("t", "c", "z", "y", "x"), (1, 1, 40, 128, 256), 16, 800_000),
+        (("t", "c", "z", "y", "x"), (1, 1, 40, 160, 320), 16, 2_000_000),
+    ],
+)
+def test_large_array_region_write_covers_whole_array(dims, shape, chunks, mt):
+    """The large-array (memory_target) write path must write the whole array.
+
+    Regression for silent data loss: _compute_plane_regions counted planes and
+    strips by the memory-band width but stepped each region by the chunk width,
+    leaving the array tail unwritten (it read back as the fill value). Data is
+    in 1..255 so any zero read back is unambiguously lost.
+    """
+    data = np.random.default_rng(0).integers(1, 256, size=shape, dtype=np.uint8)
+    image = nz.to_ngff_image(da.from_array(data, chunks=chunks), dims=dims)
+    ms = nz.to_multiscales(image, scale_factors=[1], chunks=chunks)
+
+    old = nz.config.memory_target
+    nz.config.memory_target = mt
+    try:
+        store = tempfile.mkdtemp(suffix=".ome.zarr")
+        nz.to_ngff_zarr(store, ms, version="0.5", chunks_per_shard=2)
+    finally:
+        nz.config.memory_target = old
+
+    result = np.asarray(nz.from_ngff_zarr(store).images[0].data)
+    assert np.array_equal(result, data)

--- a/py/test/test_region_write_coverage.py
+++ b/py/test/test_region_write_coverage.py
@@ -1,11 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
 # SPDX-License-Identifier: MIT
-import tempfile
-
 import dask.array as da
 import ngff_zarr as nz
 import numpy as np
 import pytest
+import zarr
+from packaging import version
+
+zarr_version = version.parse(zarr.__version__)
+
+# OME-Zarr v0.5 (sharding) requires zarr-python >= 3.0.0b1
+pytestmark = pytest.mark.skipif(
+    zarr_version < version.parse("3.0.0b1"), reason="zarr version < 3.0.0b1"
+)
 
 
 @pytest.mark.parametrize(
@@ -15,7 +22,7 @@ import pytest
         (("t", "c", "z", "y", "x"), (1, 1, 40, 160, 320), 16, 2_000_000),
     ],
 )
-def test_large_array_region_write_covers_whole_array(dims, shape, chunks, mt):
+def test_large_array_region_write_covers_whole_array(dims, shape, chunks, mt, tmp_path):
     """The large-array (memory_target) write path must write the whole array.
 
     Regression for silent data loss: _compute_plane_regions counted planes and
@@ -30,7 +37,7 @@ def test_large_array_region_write_covers_whole_array(dims, shape, chunks, mt):
     old = nz.config.memory_target
     nz.config.memory_target = mt
     try:
-        store = tempfile.mkdtemp(suffix=".ome.zarr")
+        store = tmp_path / "test.ome.zarr"
         nz.to_ngff_zarr(store, ms, version="0.5", chunks_per_shard=2)
     finally:
         nz.config.memory_target = old


### PR DESCRIPTION
Fixes #592.

## Problem

On the large-array write path (`memory_usage(image) > config.memory_target`), `_compute_plane_regions` computes the number of planes and strips from the memory-band widths (`plane_slices`, `strip_slices`) but advances each write region by the chunk width (`y_chunks`, `x_chunks`). When a band is more than one chunk wide, the loop runs `ceil(axis / band)` iterations of `chunk` pixels each and stops short of the axis, leaving the tail unwritten. It reads back as the fill value (zeros), silently, with no error.

Minimal case: `x = 256`, chunk 32, band 128 gives `num_x_splits = 2` stepped by 32, covering only `x in [0, 64)`; `x in [64, 256)` is lost. See #592 for a runnable reproducer (about 75% of a 3D image dropped).

## Fix

Advance each region by the band width the loop count already assumes (`plane_slices` / `strip_slices` instead of `y_chunks` / `x_chunks`), at the three region-slice sites. The bands are already sized to `config.memory_target`, so the regions now tile the whole array within the intended memory budget.

## Backward compatibility

Output is unchanged for every case that already produced correct data; only previously-broken cases change (wrong to correct). Verified directly (same input, unpatched vs patched, compared to the source):

| Case | unpatched == source | patched == source | patched == unpatched |
|---|---|---|---|
| 2D (single region) | yes | yes | yes (no change) |
| 3D, direct path | yes | yes | yes (no change) |
| 3D region, previously correct | yes | yes | yes (no change) |
| 3D region, previously broken | no (data loss) | yes | no (fixed) |

The change is in version-agnostic tiling logic: no metadata, on-disk format, or spec field is touched, so OME-Zarr 0.4 and 0.5 behave identically. The `use_tensorstore=True` writer iterates the same regions and is repaired by the same change (confirmed).

## Tests

Adds `test_region_write_coverage.py`, which writes real data through the region path with a configuration that reproduces the loss on `main` and asserts byte-identical read-back. It fails on `main` and passes with this change.

## Validation

Full test suite on this branch: 727 passed, 3 skipped, no regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved region tiling for large array writes so coverage is complete, including the last rows/regions.
  * Ensured y-dimension partitioning matches the intended plane-based granularity for consistent write/read alignment.
* **Tests**
  * Added a regression test that exercises large-array region write round-trips across multiple shapes and memory target settings, with a guard for older Zarr versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->