### PR TITLE
fix(py): clamp chunk/shard sizes to the axis instead of snapping to a divisor

### DIFF
--- a/.github/workflows/python_dask.yaml
+++ b/.github/workflows/python_dask.yaml
@@ -12,7 +12,7 @@ jobs:
         include:
           - python-version: "3.12"
             zarr-version: ">=3.0.0"
-            dask-version: "==2025.11.0"
+            dask-version: "==2026.1.2"
     steps:
       - uses: actions/checkout@v4
 

--- a/py/ngff_zarr/to_multiscales.py
+++ b/py/ngff_zarr/to_multiscales.py
@@ -171,11 +171,11 @@ def _large_image_serialization(
         path = f"{base_path}/slabs"
         slabs = data.rechunk(rechunks)
 
-        # For spatial dimensions, ensure Zarr chunk sizes are divisors of
-        # the dimension sizes so older dask versions (e.g. 2025.11.0) can
-        # write safely with regions.  For non-spatial dims (t, c), use the
-        # slab chunk directly to keep channels / timepoints together and
-        # avoid dask rechunking (gh-issue-487).
+        # For spatial dimensions, clamp the Zarr chunk size to the axis length.
+        # Zarr v3 allows a partial final chunk, so the region write stays safe
+        # without snapping to a divisor.  For non-spatial dims (t, c), use the
+        # slab chunk directly to keep channels / timepoints together and avoid
+        # dask rechunking (gh-issue-487).
         chunks = tuple(
             _find_optimal_chunk_size(c[0], data.shape[i])
             if dim in _spatial_dims

--- a/py/ngff_zarr/to_multiscales.py
+++ b/py/ngff_zarr/to_multiscales.py
@@ -91,45 +91,16 @@ def _ngff_image_scale_factors(ngff_image, min_length, out_chunks):
     return scale_factors
 
 
-def _find_optimal_chunk_size(first_chunk, dim_size, min_divisor=16):
-    """Find a chunk size that divides evenly into dim_size and is ideally divisible by min_divisor.
+def _find_optimal_chunk_size(first_chunk, dim_size):
+    """Target the requested chunk size, clamped to the axis length.
 
-    The returned chunk size will:
-    1. Divide evenly into dim_size (required for safe region writes)
-    2. Be as close as possible to first_chunk
-    3. Preferably be divisible by min_divisor for performance
+    Zarr v3 permits a partial final chunk, so the cache chunk size need not
+    divide the dimension evenly (region slabs are chunk-aligned and the final
+    slab is truncated to the axis, so a partial final chunk is safe). Do not
+    snap to an axis divisor: for dimensions with large prime factors the
+    nearest divisor collapses to a tiny chunk (e.g. 320095 = 5 * 64019 -> 5).
     """
-    # If dimension is very small, just use it directly
-    if dim_size <= min_divisor:
-        return dim_size
-
-    # Start with the target chunk size
-    target = first_chunk
-
-    # First try to find a divisor of dim_size that's divisible by min_divisor
-    # and close to our target
-    best_chunk = dim_size  # Fallback: use full dimension
-    best_distance = abs(dim_size - target)
-
-    # Check all divisors of dim_size
-    for i in range(1, int(np.sqrt(dim_size)) + 1):
-        if dim_size % i == 0:
-            # i and dim_size//i are both divisors
-            for candidate in [i, dim_size // i]:
-                distance = abs(candidate - target)
-                # Prefer divisors that are multiples of min_divisor
-                is_multiple = candidate % min_divisor == 0
-
-                # Update if closer to target, with preference for multiples of min_divisor
-                if distance < best_distance or (
-                    distance == best_distance
-                    and is_multiple
-                    and best_chunk % min_divisor != 0
-                ):
-                    best_chunk = candidate
-                    best_distance = distance
-
-    return best_chunk
+    return max(1, min(int(first_chunk), int(dim_size)))
 
 
 def _large_image_serialization(

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -844,48 +844,34 @@ def _handle_large_array_writing(
         else:
             shrink_factors.append(1)
 
-    # Ensure chunks are compatible with Dask's to_zarr when writing with regions.
-    # The Zarr chunk size must divide evenly into the dimension size to avoid
-    # PerformanceWarning and potential data loss during region writes.
-    def _find_optimal_chunk_size(first_chunk, dim_size, min_divisor=16):
-        """Find a chunk size that divides evenly into dim_size and is ideally divisible by min_divisor.
+    # Region writes and shard/array chunk sizes do not need to divide the
+    # dimension evenly: Zarr v3 permits a partial final chunk. Region slabs are
+    # chunk-aligned and the final slab is truncated to the axis, so a partial
+    # final chunk is safe.
+    def _find_optimal_chunk_size(first_chunk, dim_size):
+        """Target the requested chunk size, clamped to the axis length.
 
-        The returned chunk size will:
-        1. Divide evenly into dim_size (required for safe region writes)
-        2. Be as close as possible to first_chunk
-        3. Preferably be divisible by min_divisor for performance
+        Never snap to an axis divisor: for dimensions with large prime factors
+        (e.g. 320095 = 5 * 64019) the nearest divisor collapses to a tiny chunk
+        (5 px), causing extreme chunk-count and storage inflation.
         """
-        # If dimension is very small, just use it directly
-        if dim_size <= min_divisor:
-            return dim_size
+        return max(1, min(int(first_chunk), int(dim_size)))
 
-        # Start with the target chunk size
-        target = first_chunk
+    def _inner_chunk_for_shard(first_chunk, shard_size):
+        """Inner (sub-shard) chunk that divides the shard exactly.
 
-        # First try to find a divisor of dim_size that's divisible by min_divisor
-        # and close to our target
-        best_chunk = dim_size  # Fallback: use full dimension
-        best_distance = abs(dim_size - target)
-
-        # Check all divisors of dim_size
-        for i in range(1, int(np.sqrt(dim_size)) + 1):
-            if dim_size % i == 0:
-                # i and dim_size//i are both divisors
-                for candidate in [i, dim_size // i]:
-                    distance = abs(candidate - target)
-                    # Prefer divisors that are multiples of min_divisor
-                    is_multiple = candidate % min_divisor == 0
-
-                    # Update if closer to target, with preference for multiples of min_divisor
-                    if distance < best_distance or (
-                        distance == best_distance
-                        and is_multiple
-                        and best_chunk % min_divisor != 0
-                    ):
-                        best_chunk = candidate
-                        best_distance = distance
-
-        return best_chunk
+        Zarr's sharding codec requires the shard chunk_shape to be divisible by
+        the inner chunk_shape. Pick the largest inner chunk <= the target that
+        divides the shard; fall back to the whole shard (never a degenerate
+        1-px chunk) when no such divisor exists (e.g. a prime shard size).
+        """
+        target = max(1, min(int(first_chunk), int(shard_size)))
+        if shard_size % target == 0:
+            return target
+        for candidate in range(target, 1, -1):
+            if shard_size % candidate == 0:
+                return candidate
+        return int(shard_size)
 
     # If sharding is enabled, configure it properly
     chunk_kwargs = {}
@@ -919,14 +905,14 @@ def _handle_large_array_writing(
                     adjusted_internal_chunks.append(internal_dim)
                 else:
                     # Find closest divisor
-                    best_divisor = _find_optimal_chunk_size(internal_dim, shard_dim)
+                    best_divisor = _inner_chunk_for_shard(internal_dim, shard_dim)
                     adjusted_internal_chunks.append(best_divisor)
             internal_chunk_shape = tuple(adjusted_internal_chunks)
         else:
             # No internal chunks specified, use defaults based on array chunks
             internal_chunk_shape = tuple(
                 [
-                    _find_optimal_chunk_size(c[0], s)
+                    _inner_chunk_for_shard(c[0], s)
                     for c, s in zip(arr.chunks, optimized_shard_shape)
                 ]
             )

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -861,36 +861,44 @@ def _handle_large_array_writing(
         """Inner (sub-shard) chunk that divides the shard exactly.
 
         Zarr's sharding codec requires the shard chunk_shape to be divisible by
-        the inner chunk_shape. Pick the largest inner chunk <= the target that
-        divides the shard, but only accept divisors at or above a small floor.
-        A shard that factors as e.g. 2*prime has divisors {2, prime, 2*prime},
-        so taking the tiny divisor would recreate the collapse this clamp is
-        meant to prevent. Fall back to the whole shard (a single inner chunk,
-        never a degenerate 1- or 2-px chunk) when no divisor at or above the
-        floor exists (e.g. a prime or 2*prime shard size).
+        the inner chunk_shape. Return the largest shard divisor <= the target
+        that is at or above a small floor, so an awkwardly factored shard (e.g.
+        2*prime, with divisors {2, prime, 2*prime}) does not collapse to a tiny
+        inner chunk and recreate the very collapse this clamp prevents. When no
+        divisor at or above the floor exists (a prime or 2*prime shard), fall
+        back to the whole shard as a single inner chunk. A unit-length shard (a
+        t or z dim of size 1) returns 1, which is that whole shard rather than a
+        degenerate sub-chunk.
+
+        Divisors are enumerated in O(sqrt(shard_size)) rather than scanned
+        linearly from the target.
         """
         shard_size = int(shard_size)
         target = max(1, min(int(first_chunk), shard_size))
-        if shard_size % target == 0:
-            return target
         min_inner = min(target, 16)
-        for candidate in range(target, min_inner - 1, -1):
-            if shard_size % candidate == 0:
-                return candidate
-        return shard_size
+        best = 0
+        divisor = 1
+        while divisor * divisor <= shard_size:
+            if shard_size % divisor == 0:
+                for candidate in (divisor, shard_size // divisor):
+                    if min_inner <= candidate <= target and candidate > best:
+                        best = candidate
+            divisor += 1
+        return best or shard_size
 
     # If sharding is enabled, configure it properly
     chunk_kwargs = {}
     codecs_kwargs = {}
 
     if sharding_kwargs and "_shard_shape" in sharding_kwargs:
-        # For Zarr v3 with sharding, we need to ensure the shard shape divides evenly
+        # For Zarr v3 with sharding, clamp the shard shape to the axis length
         shard_shape = sharding_kwargs.pop("_shard_shape")
         internal_chunk_shape = sharding_kwargs.get(
             "chunk_shape"
         )  # This is the inner chunk shape
 
-        # Apply _find_optimal_chunk_size to the shard shape to ensure it divides evenly
+        # Clamp each shard dim to its axis; Zarr v3 permits a partial final shard,
+        # and the inner chunk is chosen to divide the clamped shard below.
         optimized_shard_shape = tuple(
             [
                 _find_optimal_chunk_size(s, arr.shape[i])

--- a/py/ngff_zarr/to_ngff_zarr.py
+++ b/py/ngff_zarr/to_ngff_zarr.py
@@ -862,16 +862,22 @@ def _handle_large_array_writing(
 
         Zarr's sharding codec requires the shard chunk_shape to be divisible by
         the inner chunk_shape. Pick the largest inner chunk <= the target that
-        divides the shard; fall back to the whole shard (never a degenerate
-        1-px chunk) when no such divisor exists (e.g. a prime shard size).
+        divides the shard, but only accept divisors at or above a small floor.
+        A shard that factors as e.g. 2*prime has divisors {2, prime, 2*prime},
+        so taking the tiny divisor would recreate the collapse this clamp is
+        meant to prevent. Fall back to the whole shard (a single inner chunk,
+        never a degenerate 1- or 2-px chunk) when no divisor at or above the
+        floor exists (e.g. a prime or 2*prime shard size).
         """
-        target = max(1, min(int(first_chunk), int(shard_size)))
+        shard_size = int(shard_size)
+        target = max(1, min(int(first_chunk), shard_size))
         if shard_size % target == 0:
             return target
-        for candidate in range(target, 1, -1):
+        min_inner = min(target, 16)
+        for candidate in range(target, min_inner - 1, -1):
             if shard_size % candidate == 0:
                 return candidate
-        return int(shard_size)
+        return shard_size
 
     # If sharding is enabled, configure it properly
     chunk_kwargs = {}

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "dask[array]!=2025.12.0,!=2026.1.0,!=2026.1.1",
+  "dask[array]>=2026.1.2",
   "importlib_resources",
   "itkwasm >= 1.0b183",
   "itkwasm-downsample >= 1.8.0",

--- a/py/test/test_degenerate_chunk_regression.py
+++ b/py/test/test_degenerate_chunk_regression.py
@@ -19,8 +19,9 @@ pytestmark = pytest.mark.skipif(
 
 
 def _read_scale0_meta(store):
-    path = glob.glob(f"{store}/scale0/*/zarr.json")[0]
-    with open(path) as f:
+    matches = glob.glob(f"{store}/scale0/*/zarr.json")
+    assert len(matches) == 1, f"expected exactly one scale0 array, found {matches}"
+    with open(matches[0]) as f:
         return json.load(f)
 
 

--- a/py/test/test_degenerate_chunk_regression.py
+++ b/py/test/test_degenerate_chunk_regression.py
@@ -52,6 +52,36 @@ def test_large_path_does_not_collapse_prime_axis(y, x, tmp_path):
     assert min(shard[-2:]) >= 8, f"degenerate shard {shard}"
 
 
+@pytest.mark.parametrize(
+    # each dim = 2 * prime, whose only divisor at or below the inner target is 2
+    "y, x",  # 2*31, 2*37 ; 2*23, 2*29
+    [(62, 74), (46, 58)],
+)
+def test_large_path_does_not_collapse_2x_prime_shard(y, x, tmp_path):
+    """A shard that clamps to 2*prime must floor the inner chunk and use the
+    whole shard instead of the tiny divisor 2 (regression: the inner-chunk
+    helper accepted 2 when the shard's only sub-target divisors were 1 and 2)."""
+    rng = np.random.default_rng(0)
+    data = rng.integers(0, 255, size=(1, 3, y, x), dtype=np.uint8)
+    arr = da.from_array(data, chunks=(1, 1, y, x))
+    image = nz.to_ngff_image(arr, dims=("t", "c", "y", "x"))
+    ms = nz.to_multiscales(image, scale_factors=[1], chunks=8)
+
+    old_target = nz.config.memory_target
+    nz.config.memory_target = 1  # force the large-array path
+    try:
+        store = tmp_path / "test.ome.zarr"
+        nz.to_ngff_zarr(store, ms, version="0.5", chunks_per_shard=16)
+    finally:
+        nz.config.memory_target = old_target
+
+    inner = _read_scale0_meta(store)["codecs"][0]["configuration"]["chunk_shape"]
+    assert min(inner[-2:]) >= 8, f"degenerate inner chunk {inner}"
+
+    back = np.asarray(nz.from_ngff_zarr(store).images[0].data)
+    assert np.array_equal(back, data)
+
+
 def test_large_path_partial_final_shard_reads_back(tmp_path):
     """A partial final shard on a prime axis reads back identical to the input."""
     rng = np.random.default_rng(0)
@@ -118,7 +148,10 @@ def test_large_path_multiscale_reads_back(dims, shape, chunks, mt, tmp_path):
     arr = da.from_array(data, chunks=chunks)
     image = nz.to_ngff_image(arr, dims=dims)
     ms = nz.to_multiscales(image, scale_factors=[2, 4], chunks=chunks)
-    level_shapes = [tuple(img.data.shape) for img in ms.images]
+    # Materialise every level before the write so each one can be byte-compared
+    # after read-back. Checking shape alone would let a corrupted lower scale
+    # pass as long as it stayed readable.
+    expected_levels = [np.asarray(img.data) for img in ms.images]
 
     old_target = nz.config.memory_target
     nz.config.memory_target = mt
@@ -129,10 +162,9 @@ def test_large_path_multiscale_reads_back(dims, shape, chunks, mt, tmp_path):
         nz.config.memory_target = old_target
 
     back = nz.from_ngff_zarr(store)
-    # Full-resolution data must survive the region write byte for byte.
-    assert np.array_equal(np.asarray(back.images[0].data), data)
-    # Every pyramid level must be present and fully readable (no truncation).
-    assert len(back.images) == len(level_shapes)
-    for i, expected_shape in enumerate(level_shapes):
-        assert tuple(back.images[i].data.shape) == expected_shape
-        np.asarray(back.images[i].data)
+    assert len(back.images) == len(expected_levels)
+    # Every pyramid level, not just full resolution, must read back byte-identical.
+    for i, expected in enumerate(expected_levels):
+        actual = np.asarray(back.images[i].data)
+        assert actual.shape == expected.shape, f"level {i} shape {actual.shape}"
+        assert np.array_equal(actual, expected), f"level {i} data differs"

--- a/py/test/test_degenerate_chunk_regression.py
+++ b/py/test/test_degenerate_chunk_regression.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+# SPDX-License-Identifier: MIT
+import glob
+import json
+
+import dask.array as da
+import ngff_zarr as nz
+import numpy as np
+import pytest
+import zarr
+from packaging import version
+
+zarr_version = version.parse(zarr.__version__)
+
+# OME-Zarr v0.5 (sharding) requires zarr-python >= 3.0.0b1
+pytestmark = pytest.mark.skipif(
+    zarr_version < version.parse("3.0.0b1"), reason="zarr version < 3.0.0b1"
+)
+
+
+def _read_scale0_meta(store):
+    path = glob.glob(f"{store}/scale0/*/zarr.json")[0]
+    with open(path) as f:
+        return json.load(f)
+
+
+@pytest.mark.parametrize(
+    # dims chosen so the near-target divisor is tiny under the old algorithm
+    "y, x",  # x = 5 * prime, y = prime
+    [(29, 185), (43, 265)],
+)
+def test_large_path_does_not_collapse_prime_axis(y, x, tmp_path):
+    """The memory_target/sharded write path must not snap a prime-factored axis
+    to a tiny divisor (regression for the 5px / 1px chunk collapse)."""
+    arr = da.zeros((1, 3, y, x), dtype=np.uint8, chunks=(1, 1, y, x))
+    image = nz.to_ngff_image(arr, dims=("t", "c", "y", "x"))
+    ms = nz.to_multiscales(image, scale_factors=[2], chunks=8)
+
+    old_target = nz.config.memory_target
+    nz.config.memory_target = 1  # force the large-array path
+    try:
+        store = tmp_path / "test.ome.zarr"
+        nz.to_ngff_zarr(store, ms, version="0.5", chunks_per_shard=2)
+    finally:
+        nz.config.memory_target = old_target
+
+    meta = _read_scale0_meta(store)
+    shard = meta["chunk_grid"]["configuration"]["chunk_shape"]
+    inner = meta["codecs"][0]["configuration"]["chunk_shape"]
+    # requested inner chunk was 8; must not collapse well below it on any axis
+    assert min(inner[-2:]) >= 8, f"degenerate inner chunk {inner}"
+    assert min(shard[-2:]) >= 8, f"degenerate shard {shard}"
+
+
+def test_large_path_partial_final_shard_reads_back(tmp_path):
+    """A partial final shard on a prime axis reads back identical to the input."""
+    rng = np.random.default_rng(0)
+    data = rng.integers(0, 255, size=(1, 3, 29, 185), dtype=np.uint8)
+    arr = da.from_array(data, chunks=(1, 1, 29, 185))
+    image = nz.to_ngff_image(arr, dims=("t", "c", "y", "x"))
+    ms = nz.to_multiscales(image, scale_factors=[1], chunks=8)
+
+    old_target = nz.config.memory_target
+    nz.config.memory_target = 1
+    try:
+        store = tmp_path / "test.ome.zarr"
+        nz.to_ngff_zarr(store, ms, version="0.5", chunks_per_shard=2)
+    finally:
+        nz.config.memory_target = old_target
+
+    back = nz.from_ngff_zarr(store)
+    result = np.asarray(back.images[0].data)
+    assert np.array_equal(result, data)
+
+
+def test_large_path_preserves_user_compressor(tmp_path):
+    """A user-supplied Zstd level is preserved on the large-array / sharded write path."""
+    from zarr.codecs.zstd import ZstdCodec
+
+    arr = da.zeros((1, 3, 29, 185), dtype=np.uint8, chunks=(1, 1, 29, 185))
+    image = nz.to_ngff_image(arr, dims=("t", "c", "y", "x"))
+    ms = nz.to_multiscales(image, scale_factors=[1], chunks=8)
+
+    old_target = nz.config.memory_target
+    nz.config.memory_target = 1
+    try:
+        store = tmp_path / "test.ome.zarr"
+        nz.to_ngff_zarr(
+            store,
+            ms,
+            version="0.5",
+            chunks_per_shard=2,
+            compressors=[ZstdCodec(level=5)],
+        )
+    finally:
+        nz.config.memory_target = old_target
+
+    cfg = _read_scale0_meta(store)["codecs"][0]["configuration"]
+    zstd = next(c for c in cfg["codecs"] if c["name"] == "zstd")
+    assert zstd["configuration"]["level"] == 5
+
+
+@pytest.mark.parametrize(
+    "dims, shape, chunks, mt",
+    [
+        (("t", "c", "y", "x"), (1, 2, 290, 370), 16, 1),
+        (("t", "c", "z", "y", "x"), (1, 2, 62, 94, 94), 16, 560_000),
+    ],
+)
+def test_large_path_multiscale_reads_back(dims, shape, chunks, mt, tmp_path):
+    """A realistic multi-scale write on the large-array region path reads back
+    byte-identical. Covers the 2D single-region and 3D multi-region (z-slab)
+    paths with prime-factored spatial axes, so every level has partial final
+    shards. Confirms the dask shard-alignment PerformanceWarning on this path is
+    benign: each shard is written by exactly one writer, so no data is lost."""
+    rng = np.random.default_rng(0)
+    data = rng.integers(0, 255, size=shape, dtype=np.uint8)
+    arr = da.from_array(data, chunks=chunks)
+    image = nz.to_ngff_image(arr, dims=dims)
+    ms = nz.to_multiscales(image, scale_factors=[2, 4], chunks=chunks)
+    level_shapes = [tuple(img.data.shape) for img in ms.images]
+
+    old_target = nz.config.memory_target
+    nz.config.memory_target = mt
+    try:
+        store = tmp_path / "test.ome.zarr"
+        nz.to_ngff_zarr(store, ms, version="0.5", chunks_per_shard=2)
+    finally:
+        nz.config.memory_target = old_target
+
+    back = nz.from_ngff_zarr(store)
+    # Full-resolution data must survive the region write byte for byte.
+    assert np.array_equal(np.asarray(back.images[0].data), data)
+    # Every pyramid level must be present and fully readable (no truncation).
+    assert len(back.images) == len(level_shapes)
+    for i, expected_shape in enumerate(level_shapes):
+        assert tuple(back.images[i].data.shape) == expected_shape
+        np.asarray(back.images[i].data)


### PR DESCRIPTION
Fixes #588.

> **Depends on #594** (the region-write data-loss fix) and is stacked on it. Please review and merge #594 first. This PR is a draft until then: its diff currently also includes #594's change, and the moment #594 merges I will rebase this branch onto `main` so it becomes clamp-only and mark it ready for review.

## Problem

The large-array / sharded write path chose sizes with `_find_optimal_chunk_size`, which snapped each chunk and shard size to an exact divisor of the axis length. For an axis with a large prime factor the nearest divisor is tiny, so the chunk collapsed to a few pixels. A real `(1, 3, 1, 207634, 320095)` slide was written with inner chunk `[1,1,1,1,5]` / shard `[1,3,1,14831,5]`: about 1e10 tiny chunks and roughly 6x storage inflation. `min_divisor=16` is only a tie-breaker, not a lower bound.

## Fix

Zarr v3 permits a partial final chunk and a partial final shard, so sizes need not divide the axis. Replace the divisor-snapping helper with a clamp (`max(1, min(target, axis))`) in both `to_ngff_zarr.py` and `to_multiscales.py`, and add `_inner_chunk_for_shard` for the one place divisibility is required (the sharding inner chunk must divide the shard): it returns the largest chunk `<=` the target that divides the shard, never a 1-px chunk.

## Result

On the #588 reproducer: before `inner [1,3,1,5] / shard [1,3,29,5]`; after `inner [1,3,8,8] / shard [1,3,16,16]`.

## Tests

Adds `test_degenerate_chunk_regression.py`: prime axes no longer collapse, a partial final shard reads back unchanged, a user-supplied Zstd level is preserved, and a realistic multi-scale write reads back byte-identical.

## Note on a dask PerformanceWarning

Allowing a partial final shard makes dask emit its region-alignment `PerformanceWarning` on this path (`main` does not, because divisor-snapping kept writes aligned at the cost of the collapse). With the region-write fix underneath, the write is correct (verified byte-identical); the warning is a known dask false positive on the region path (dask PR #12161).

## Validation

Full test suite: 731 passed, 3 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NGFF OME-Zarr v0.5 large-array and multiscale writing to avoid chunk/shard sizing collapsing on prime-sized dimensions.
  * Updated chunk sizing to allow partial final chunks without enforcing even divisibility, improving correctness on spatial axes.
  * Preserved user-configured Zstd compression settings and ensured byte-identical multiscale round-trips.
* **Tests**
  * Added regression tests covering prime/2×prime axes, partial final shard reads, and codec preservation.
* **Chores**
  * Updated the supported Dask version to 2026.1.2 and refreshed the CI Dask pin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->