### PR TITLE
docs: add RFC-5 header emoji and move TIFF/LIF guides into the FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -127,6 +127,17 @@ In addition to specification of credentials explicitly,
 The same patterns work for other cloud providers (GCS, Azure) by using their
 respective fsspec implementations (e.g., `gcsfs`, `adlfs`).
 
+## File Formats
+
+### Where can I find documentation for specific file formats like TIFF or LIF?
+
+ngff-zarr converts most bioimaging formats to OME-Zarr. Detailed, format-specific
+guides are available for:
+
+- [TIFF and OME-TIFF Support](./tiff.md) — automatic metadata extraction and
+  multi-series conversion
+- [Leica Image Format (LIF) Support](./lif.md) — Leica microscopy data
+
 ## Troubleshooting
 
 ### I'm getting "Invalid argument", "Invalid page offset", or `OSError` errors when converting TIFF/SVS files

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,8 +50,6 @@ cli.md
 mcp.md
 rfc5.md
 hcs.md
-tiff.md
-lif.md
 spec_features.md
 itk.md
 methods.md

--- a/docs/lif.md
+++ b/docs/lif.md
@@ -1,3 +1,6 @@
+---
+orphan: true
+---
 <!-- SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC -->
 <!-- SPDX-License-Identifier: MIT -->
 # Leica Image Format (LIF) Support

--- a/docs/rfc5.md
+++ b/docs/rfc5.md
@@ -1,6 +1,6 @@
 <!-- SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC -->
 <!-- SPDX-License-Identifier: MIT -->
-# RFC-5: Coordinate Systems and Transformations
+# 🧭 RFC-5: Coordinate Systems and Transformations
 
 [RFC-5] extends OME-NGFF with named **coordinate systems** and a richer set of
 **coordinate transformations** — identity, scale, translation, rotation,

--- a/docs/tiff.md
+++ b/docs/tiff.md
@@ -1,3 +1,6 @@
+---
+orphan: true
+---
 <!-- SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC -->
 <!-- SPDX-License-Identifier: MIT -->
 # TIFF and OME-TIFF Support


### PR DESCRIPTION
## Overview

Two small documentation improvements that make the docs navigation cleaner and
more consistent:

1. Add a 🧭 emoji to the RFC-5 page header.
2. Move the TIFF/OME-TIFF and Leica LIF format guides out of the left sidebar
   navigation and link them from the FAQ instead.

## Changes

### 1. RFC-5 header emoji (`docs/rfc5.md`)

- Prefixed the RFC-5 page `H1` with 🧭 → `# 🧭 RFC-5: Coordinate Systems and Transformations`.
- **Why:** Nearly every top-level docs page already leads its header with an
  emoji (⚡ Quick start, 🐍 Python Interface, 🦕 TypeScript, 🤖 MCP Server, …).
  RFC-5 was missing one. The compass fits the page's subject of coordinate
  systems and spatial transformations.

### 2. Move TIFF & LIF guides into the FAQ (`docs/index.md`, `docs/tiff.md`, `docs/lif.md`, `docs/faq.md`)

- Removed `tiff.md` and `lif.md` from the main `{toctree}` in `index.md` — the
  toctree that renders the left-hand content side panel.
- Added a new **"File Formats"** section to `faq.md` (between *Network Storage
  and Authentication* and *Troubleshooting*) that links both guides.
- **Why:** These are narrow, format-specific reference pages. Keeping them as
  top-level sidebar entries added noise to the primary navigation; surfacing
  them from the FAQ keeps the guides one click away while letting the sidebar
  highlight the core workflow.

## Implementation details

- **Orphan pages, not deleted pages.** Removing a page from every `{toctree}`
  makes Sphinx emit a `document isn't included in any toctree` warning. Both
  `tiff.md` and `lif.md` were marked with `orphan: true` YAML frontmatter (the
  canonical Sphinx mechanism for a page intentionally kept out of the nav tree),
  placed above the existing SPDX header comments so MyST parses it as
  frontmatter. The pages still build and remain fully linkable.
- **Existing cross-links preserved.** Links to these pages from `cli.md`,
  `python.md`, and `tiff.md` continue to resolve — toctree membership does not
  affect MyST/relative link resolution.

## Verification

Installed the `docs` pixi environment and ran a full `sphinx-build`:

- ✅ Build succeeds.
- ✅ **Zero new warnings** — a stashed-baseline build (original files) produces
  the exact same 4 pre-existing warnings; `tiff.md`/`lif.md` no longer produce
  orphan warnings.
- ✅ Rendered `index.html` sidebar no longer lists TIFF or LIF.
- ✅ `tiff.html` and `lif.html` are still generated.
- ✅ Built `faq.html` contains the `href="tiff.html"` and `href="lif.html"` links.

## Scope

Documentation only — no library, CLI, or API code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Troubleshooting section covering supported bioimaging file formats, including TIFF/OME-TIFF and Leica Image Format (LIF).
  - Updated documentation navigation and page metadata for file-format references.
  - Improved the LIF documentation page’s introductory formatting.
  - Added a compass emoji to the RFC-5 heading for clearer visual identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->