### PR TITLE
docs(py): sync py/README with root README (v0.6, RFC-4/5, HCS, .ozx, MCP)

### DIFF
--- a/py/README.md
+++ b/py/README.md
@@ -4,7 +4,7 @@
 
 [![PyPI - Version](https://img.shields.io/pypi/v/ngff-zarr.svg)](https://pypi.org/project/ngff-zarr)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ngff-zarr.svg)](https://pypi.org/project/ngff-zarr)
-[![Test](https://github.com/thewtex/ngff-zarr/actions/workflows/pixi-test.yml/badge.svg)](https://github.com/thewtex/ngff-zarr/actions/workflows/pixi-test.yml)
+[![Python CI Testing](https://github.com/fideus-labs/ngff-zarr/actions/workflows/python.yml/badge.svg)](https://github.com/fideus-labs/ngff-zarr/actions/workflows/python.yml)
 [![DOI](https://zenodo.org/badge/541840158.svg)](https://zenodo.org/badge/latestdoi/541840158)
 [![Documentation Status](https://readthedocs.org/projects/ngff-zarr/badge/?version=latest)](https://ngff-zarr.readthedocs.io/en/latest/?badge=latest)
 
@@ -23,15 +23,20 @@ implementation.
 - Conversion of most bioimaging file formats
 - Multiple downscaling methods
 - Supports Python>=3.10
-- Reads OME-Zarr v0.1 to v0.5 into simple Python data classes with Dask arrays
+- Reads OME-Zarr v0.1 to v0.6 into simple Python data classes with Dask arrays
 - Optional OME-Zarr data model validation during reading
-- Writes OME-Zarr v0.4 to v0.5
+- Writes OME-Zarr v0.4 to v0.6
+- v0.6 adds RFC-5 coordinate systems and transformations
 - [Sharded Zarr] stores
-- Optional writing via [tensorstore]
+- Optional writing via zarr-python 2, zarr-python 3, [tensorstore] or zarrita (TypeScript)
+- [Anatomical orientation metadata][rfc4] (RFC-4)
+- **OME-Zarr Zip (.ozx) file support** for single-file OME-Zarr datasets (RFC-9)
+- **High Content Screening (HCS) support** for plate and well data
+- **Model Context Protocol (MCP) server** for AI agent integration
 
 ## Documentation
 
-More information on command line usage, the Python API, library features, and
+More information about command line usage, the Python API, library features, and
 how to contribute can be found in
 [our documentation](https://ngff-zarr.readthedocs.io/).
 
@@ -44,6 +49,7 @@ how to contribute can be found in
 - [pydantic-ome-ngff](https://janeliascicomp.github.io/pydantic-ome-ngff/)
 - [aicsimageio](https://allencellmodeling.github.io/aicsimageio/)
 - [bfio](https://bfio.readthedocs.io/)
+- [zod-ome-ngff](https://github.com/hms-dbmi/zod-ome-ngff)
 
 ## License
 
@@ -52,3 +58,4 @@ how to contribute can be found in
 
 [Sharded Zarr]: https://zarr.dev/zeps/accepted/ZEP0002.html
 [tensorstore]: https://google.github.io/tensorstore/
+[rfc4]: https://ngff-zarr.readthedocs.io/en/latest/rfc4.html


### PR DESCRIPTION
## What

Brings the PyPI-published Python README (`py/README.md`) back in line with the current repo-root `README.md`, which had drifted ahead of it.

**Badge**
- Replace the stale `thewtex/ngff-zarr` + `pixi-test.yml` CI badge with the current `fideus-labs/ngff-zarr` **Python CI Testing** badge (`python.yml`).

**Features**
- OME-Zarr read support updated to **v0.1–v0.6** (was v0.5) and write support to **v0.4–v0.6** (was v0.5).
- Note that **v0.6 adds RFC-5 coordinate systems and transformations**.
- Expand writer backends from just `tensorstore` to **zarr-python 2, zarr-python 3, tensorstore, and zarrita**.
- Add feature bullets that already shipped but were missing here: **RFC-4 anatomical orientation metadata**, **OME-Zarr Zip (`.ozx`) support (RFC-9)**, **High Content Screening (HCS)**, and the **Model Context Protocol (MCP) server**.

**See also**
- Add `zod-ome-ngff`.

**Wording**
- Minor phrasing tweak in the documentation sentence to match the root README.

## Why

`py/README.md` is the README rendered on the [PyPI project page](https://pypi.org/project/ngff-zarr), so it is the first thing Python users see. It had fallen behind the root README (OME-Zarr v0.6 / RFC-5 support, plus HCS, `.ozx`, RFC-4, and the MCP server) and advertised outdated version support and a broken CI badge pointing at the old `thewtex` org. This sync keeps the published package page accurate.

## Implementation notes

- Kept `py/README.md` as the **Python-package README**, not a copy of the multi-package root README. The root README's "Repository Structure", TypeScript/MCP package sections, and npm/TS-CI/MCP-CI badges were intentionally **not** imported — those belong to the repo-level page, not the PyPI page.
- The RFC-4 link uses an **absolute readthedocs URL** (`https://ngff-zarr.readthedocs.io/en/latest/rfc4.html`) rather than the root README's relative `./docs/rfc4.md`, because relative links break when rendered on PyPI.
- Documentation-only change: no tests apply. Verified with CodeRabbit (0 findings) and prek hooks (pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project status and CI badge information.
  * Expanded documentation of supported OME-Zarr read/write versions and capabilities.
  * Added references to coordinate systems, anatomical orientation metadata, ZIP archives, HCS plates and wells, and MCP server integration.
  * Documented additional optional writing backends and added a related project reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->